### PR TITLE
Improve the isort experience

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -64,6 +64,7 @@ jobs:
         tox_env:
           - bandit
           - black
+          - isort
           - flake8
           - mypy
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,3 +41,7 @@ ignore_missing_imports = true
 
 [tool.black]
 line-length = 100
+
+[tool.isort]
+profile = "black"
+line_length = 100

--- a/tests/unit/models/test_output.py
+++ b/tests/unit/models/test_output.py
@@ -4,12 +4,7 @@ from typing import Any
 import pydantic
 import pytest
 
-from cachi2.core.models.output import (
-    Dependency,
-    EnvironmentVariable,
-    Package,
-    RequestOutput,
-)
+from cachi2.core.models.output import Dependency, EnvironmentVariable, Package, RequestOutput
 
 
 class TestDependency:

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -43,10 +43,7 @@ from cachi2.core.package_managers.gomod import (
     _vet_local_deps,
 )
 from cachi2.core.packages_data import _package_sort_key
-from tests.unit.package_managers.helper_utils import (
-    assert_directories_equal,
-    write_file_tree,
-)
+from tests.unit.package_managers.helper_utils import assert_directories_equal, write_file_tree
 
 
 def setup_module():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = bandit,black,flake8,mypy,python3.10
+envlist = bandit,black,isort,flake8,mypy,python3.10
 
 [gh-actions]
 python =
@@ -42,12 +42,18 @@ commands =
     # Use shorter line length for scripts
     black --check --diff bin --line-length=88
 
+[testenv:isort]
+skip_install = true
+deps =
+    isort[colors]
+commands =
+    isort --check --diff --color cachi2 tests
+
 [testenv:flake8]
 skip_install = true
 deps =
     flake8==3.9.2
     flake8-docstrings==1.6.0
-    flake8-isort==4.2.0
 commands =
     flake8
 

--- a/tox.ini
+++ b/tox.ini
@@ -62,12 +62,6 @@ per-file-ignores =
     # Ignore missing docstrings in the tests and migrations
     tests/*:D101,D102,D103
 
-[isort]
-line_length = 88
-# Vertical hanging indent
-multi_line_output = 3
-include_trailing_comma = true
-
 [testenv:bandit]
 skip_install = true
 deps =


### PR DESCRIPTION
* set line_length=100 to match black
* run it outside of flake8 to improve the atrocious error messages

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
