### PR TITLE
Add the Containerfile

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,5 +1,4 @@
 .env/
-.git/
 .idea/
 .pytest_cache/
 .tox/

--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -84,3 +84,17 @@ jobs:
         pip install tox
     - name: Test '${{ matrix.tox_env }}' with tox
       run: tox -e ${{ matrix.tox_env }}
+
+  hadolint:
+    name: Hadolint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: hadolint/hadolint-action@v1.5.0
+      with:
+        dockerfile: Containerfile
+        # Ignore list:
+        # * DL3041 - Specify version with dnf install -y <package>-<version>
+        ignore: DL3041
+        failure-threshold: warning
+

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,21 @@
+FROM registry.fedoraproject.org/fedora-minimal:36
+LABEL maintainer="Red Hat"
+
+WORKDIR /src
+RUN microdnf -y install \
+    --setopt install_weak_deps=0 \
+    --nodocs \
+    golang \
+    git-core \
+    python3 \
+    python3-pip \
+    && microdnf clean all
+
+COPY . .
+
+RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes && \
+    pip3 install --no-cache-dir -e . && \
+    # the git folder is only needed to determine the package version
+    rm -rf .git
+
+ENTRYPOINT ["cachi2"]


### PR DESCRIPTION
Only a minimal configuration was set to the Containerfile, we will need to add more dependencies as other package managers are onboarded.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] New code has type annotations
- [ ] Docs updated (if applicable)
