### PR TITLE
workflow: use checkout action version 3

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -17,7 +17,10 @@ jobs:
         python-version: ["3.10", "3.9"]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
     - name: Install required packages
       run: |
         sudo apt-get install -y \
@@ -69,7 +72,7 @@ jobs:
           - mypy
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
     - name: Install required packages
       run: |
         sudo apt-get install -y \

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = bandit,black,isort,flake8,mypy,python3.10
+envlist = bandit,black,isort,flake8,mypy,python3.9,python3.10
 
 [gh-actions]
 python =


### PR DESCRIPTION
Older versions run with unsupported nodejs

Signed-off-by: Martin Basti <mbasti@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a Docs updated (if applicable)
