### PR TITLE
Fix --force-gomod-tidy help message

### DIFF
--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -123,7 +123,7 @@ def fetch_deps(
     force_gomod_tidy: bool = Option(
         False,
         "--force-gomod-tidy",
-        help="Run 'go mod tidy' before processing gomod packages.",
+        help="Run 'go mod tidy' after downloading go dependencies.",
     ),
     gomod_vendor: bool = Option(
         False,


### PR DESCRIPTION
Cachi2 runs `go mod tidy` after downloading, not before.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [x] Docs updated (if applicable)
