### PR TITLE
Adds item to the PR checklist aiming to track OSBS2 integration issues

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -4,3 +4,4 @@
 - [ ] Code coverage from testing does not decrease and new code is covered
 - [ ] New code has type annotations
 - [ ] Docs updated (if applicable)
+- [ ] [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)


### PR DESCRIPTION
Cachi2 development is being driven by features that are needed by HACBS.

Since the OSBS2 integration is still intended, a Github issue was filed with the intention of keeping track of all changes that are introduced to Cachi2 that will need to be handled in the future integration effort.

We need to check each PR to see if that issue needs to be updated.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] New code has type annotations
- [n/a] Docs updated (if applicable)
