### PR TITLE
Implement new error classes

### DIFF
--- a/cachi2/core/errors.py
+++ b/cachi2/core/errors.py
@@ -2,15 +2,6 @@ class Cachi2Error(Exception):
     """Root of the error hierarchy. Don't raise this directly, use more specific error types."""
 
 
-class CachitoCalledProcessError(Cachi2Error):
-    """Command executed with subprocess.run() returned non-zero value."""
-
-    def __init__(self, err_msg: str, retcode: int):
-        """Initialize the error with a message and the return code of the failing command."""
-        super().__init__(err_msg)
-        self.retcode = retcode
-
-
 class PackageRejected(Cachi2Error):
     """Cachi2 refused to process the package the user requested.
 

--- a/cachi2/core/errors.py
+++ b/cachi2/core/errors.py
@@ -1,15 +1,5 @@
-from enum import Enum
-
-
 class Cachi2Error(Exception):
     """Root of the error hierarchy. Don't raise this directly, use more specific error types."""
-
-
-class RequestErrorOrigin(str, Enum):
-    """An Enum that represents the request error origin."""
-
-    client = "client"
-    server = "server"
 
 
 class CachitoCalledProcessError(Cachi2Error):
@@ -29,25 +19,6 @@ class PackageRejected(Cachi2Error):
     """
 
 
-# Request error classifiers
-class ClientError(Cachi2Error):
-    """Client Error."""
-
-    origin = RequestErrorOrigin.client
-
-
-class ServerError(Cachi2Error):
-    """Server Error."""
-
-    origin = RequestErrorOrigin.server
-
-
-class SubprocessCallError(ServerError):
-    """Error calling subprocess."""
-
-    pass
-
-
 class FetchError(Cachi2Error):
     """Cachi2 failed to fetch a dependency or other data needed to process a package."""
 
@@ -58,7 +29,7 @@ class GoModError(Cachi2Error):
     pass
 
 
-class UnsupportedFeature(ClientError):
+class UnsupportedFeature(Cachi2Error):
     """Unsupported feature."""
 
     pass

--- a/cachi2/core/errors.py
+++ b/cachi2/core/errors.py
@@ -15,12 +15,15 @@ class FetchError(Cachi2Error):
 
 
 class GoModError(Cachi2Error):
-    """Go mod related error. A module can't be downloaded by go mod download command."""
+    """The 'go' command used while processing a Go module returned an error.
 
-    pass
+    Maybe the module is invalid, maybe the go tool was unable to fetch a dependency, maybe the
+    error is intermittent. We don't really know, but we do at least log the stderr.
+    """
 
 
 class UnsupportedFeature(Cachi2Error):
-    """Unsupported feature."""
+    """Cachi2 doesn't support a feature the user requested.
 
-    pass
+    The requested feature might be valid, but Cachi2 doesn't implement it.
+    """

--- a/cachi2/core/errors.py
+++ b/cachi2/core/errors.py
@@ -48,17 +48,8 @@ class SubprocessCallError(ServerError):
     pass
 
 
-class NetworkError(ServerError):
-    """Network connection error."""
-
-    pass
-
-
-# Third-party service errors
-class RepositoryAccessError(ServerError):
-    """Repository is not accessible and can't be cloned."""
-
-    pass
+class FetchError(Cachi2Error):
+    """Cachi2 failed to fetch a dependency or other data needed to process a package."""
 
 
 class GoModError(Cachi2Error):

--- a/cachi2/core/errors.py
+++ b/cachi2/core/errors.py
@@ -21,8 +21,12 @@ class CachitoCalledProcessError(Cachi2Error):
         self.retcode = retcode
 
 
-class ValidationError(ValueError, Cachi2Error):
-    """An error was encountered during validation."""
+class PackageRejected(Cachi2Error):
+    """Cachi2 refused to process the package the user requested.
+
+    a) The package appears invalid (e.g. missing go.mod for a Go module).
+    b) The package does not meet Cachi2's extra requirements (e.g. missing checksums).
+    """
 
 
 # Request error classifiers
@@ -36,20 +40,6 @@ class ServerError(Cachi2Error):
     """Server Error."""
 
     origin = RequestErrorOrigin.server
-
-
-# Web errors
-class InvalidRequestData(ClientError):
-    """Invalid request data."""
-
-    pass
-
-
-# Low-level errors
-class FileAccessError(ServerError):
-    """File not found."""
-
-    pass
 
 
 class SubprocessCallError(ServerError):
@@ -79,11 +69,5 @@ class GoModError(Cachi2Error):
 
 class UnsupportedFeature(ClientError):
     """Unsupported feature."""
-
-    pass
-
-
-class InvalidFileFormat(ClientError):
-    """Invalid file format."""
 
     pass

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -60,7 +60,7 @@ def fetch_gomod_source(request: Request) -> RequestOutput:
 
         # missing gomod files is supported if there is only one path referenced
         if config.cachito_gomod_ignore_missing_gomod_file and len(subpaths) == 1:
-            log.warning("go.mod file missing for request at %s", invalid_files_print)
+            log.warning("go.mod file missing at %s", invalid_files_print)
             return RequestOutput.empty()
 
         raise PackageRejected(
@@ -84,7 +84,7 @@ def fetch_gomod_source(request: Request) -> RequestOutput:
     packages = []
 
     for i, subpath in enumerate(subpaths):
-        log.info("Fetching the gomod dependencies for request in subpath %s", subpath)
+        log.info("Fetching the gomod dependencies at subpath %s", subpath)
 
         log.info(f'Fetching the gomod dependencies at the "{subpath}" directory')
 
@@ -92,7 +92,7 @@ def fetch_gomod_source(request: Request) -> RequestOutput:
         try:
             gomod = _resolve_gomod(gomod_source_path, request)
         except GoModError:
-            log.exception("Failed to fetch gomod dependencies for request %d")
+            log.exception("Failed to fetch gomod dependencies")
             raise
 
         module_info = gomod["module"]

--- a/cachi2/core/packages_data.py
+++ b/cachi2/core/packages_data.py
@@ -6,8 +6,6 @@ import os
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Union
 
-from cachi2.core.errors import InvalidRequestData
-
 log = logging.getLogger(__name__)
 
 # TODO: delete the whole module (RequestOutput does the same thing)
@@ -110,12 +108,12 @@ class PackagesData:
             ``fetch_*_source`` for the detailed information about a package's path.
         :param deps: a list of dependencies the package has.
         :type deps: list[dict[str, any]]
-        :raises InvalidRequestData: if there is a package with same name, type and version
+        :raises ValueError: if there is a package with same name, type and version
             has been added already.
         """
         key = (pkg_info["name"], pkg_info["type"], pkg_info["version"])
         if key in self._index:
-            raise InvalidRequestData(f"Duplicate package: {pkg_info!r}")
+            raise ValueError(f"Duplicate package: {pkg_info!r}")
         self._index.add(key)
         package = {
             "name": pkg_info["name"],

--- a/cachi2/core/utils.py
+++ b/cachi2/core/utils.py
@@ -5,18 +5,16 @@ import subprocess  # nosec
 from typing import Iterator
 
 from cachi2.core.config import get_worker_config
-from cachi2.core.errors import CachitoCalledProcessError
 
 log = logging.getLogger(__name__)
 
 
-def run_cmd(cmd, params, exc_msg=None):
+def run_cmd(cmd, params):
     """
     Run the given command with provided parameters.
 
     :param iter cmd: iterable representing command to be executed
     :param dict params: keyword parameters for command execution
-    :param str exc_msg: an optional exception message when the command fails
     :returns: the command output
     :rtype: str
     :raises SubprocessCallError: if the command fails
@@ -30,11 +28,11 @@ def run_cmd(cmd, params, exc_msg=None):
 
     response = subprocess.run(cmd, **params)  # nosec
 
-    if response.returncode != 0:
+    try:
+        response.check_returncode()
+    except subprocess.CalledProcessError:
         log.error('The command "%s" failed with: %s', " ".join(cmd), response.stderr)
-        raise CachitoCalledProcessError(
-            exc_msg or "An unexpected error occurred", response.returncode
-        )
+        raise
 
     return response.stdout
 

--- a/cachi2/core/utils.py
+++ b/cachi2/core/utils.py
@@ -5,7 +5,7 @@ import subprocess  # nosec
 from typing import Iterator
 
 from cachi2.core.config import get_worker_config
-from cachi2.core.errors import CachitoCalledProcessError, SubprocessCallError
+from cachi2.core.errors import CachitoCalledProcessError
 
 log = logging.getLogger(__name__)
 
@@ -28,10 +28,7 @@ def run_cmd(cmd, params, exc_msg=None):
     conf = get_worker_config()
     params.setdefault("timeout", conf.cachito_subprocess_timeout)
 
-    try:
-        response = subprocess.run(cmd, **params)  # nosec
-    except subprocess.TimeoutExpired as e:
-        raise SubprocessCallError(str(e))
+    response = subprocess.run(cmd, **params)  # nosec
 
     if response.returncode != 0:
         log.error('The command "%s" failed with: %s', " ".join(cmd), response.stderr)

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -14,11 +14,9 @@ import pytest
 
 from cachi2.core.errors import (
     CachitoCalledProcessError,
-    FileAccessError,
     GoModError,
-    InvalidFileFormat,
+    PackageRejected,
     UnsupportedFeature,
-    ValidationError,
 )
 from cachi2.core.models.input import Request
 from cachi2.core.package_managers import gomod
@@ -483,7 +481,7 @@ def test_resolve_gomod_strict_mode_raise_error(
         'The "gomod-vendor" or "gomod-vendor-check" flag must be set when your repository has '
         "vendored dependencies."
     )
-    with strict_vendor and pytest.raises(ValidationError, match=expected_error) or nullcontext():
+    with strict_vendor and pytest.raises(PackageRejected, match=expected_error) or nullcontext():
         _resolve_gomod(archive_path, gomod_request)
 
 
@@ -1180,7 +1178,7 @@ def test_should_vendor_deps_strict(flags, vendor_exists, expect_error, tmp_path)
 
     if expect_error:
         msg = 'The "gomod-vendor" or "gomod-vendor-check" flag must be set'
-        with pytest.raises(ValidationError, match=msg):
+        with pytest.raises(PackageRejected, match=msg):
             _should_vendor_deps(flags, tmp_path, True)
     else:
         _should_vendor_deps(flags, tmp_path, True)
@@ -1199,7 +1197,7 @@ def test_vendor_deps(mock_vendor_changed, mock_run_cmd, can_make_changes, vendor
 
     if expect_error:
         msg = "The content of the vendor directory is not consistent with go.mod."
-        with pytest.raises(ValidationError, match=msg):
+        with pytest.raises(PackageRejected, match=msg):
             _vendor_deps(run_params, can_make_changes, git_dir)
     else:
         _vendor_deps(run_params, can_make_changes, git_dir)
@@ -1345,7 +1343,7 @@ def test_module_lines_from_modules_txt_invalid_format(file_content, expect_error
     vendor.mkdir()
     vendor.joinpath("modules.txt").write_text(file_content)
 
-    with pytest.raises((InvalidFileFormat, FileAccessError), match=expect_error_msg):
+    with pytest.raises(PackageRejected, match=expect_error_msg):
         _module_lines_from_modules_txt(tmp_path)
 
 


### PR DESCRIPTION
Replace existing error classes with the new ones designed in CLOUDBLD-11302

Other parts of error handling changes to follow in separate PRs

Invalid Input is not included yet because nothing would raise it currently

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [x] Docs updated (if applicable)
- [x] [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
