### PR TITLE
Make error messages friendlier

### DIFF
--- a/cachi2/core/errors.py
+++ b/cachi2/core/errors.py
@@ -70,8 +70,24 @@ class GoModError(Cachi2Error):
     error is intermittent. We don't really know, but we do at least log the stderr.
     """
 
+    notice = textwrap.dedent(
+        """
+        The cause of the failure could be:
+        - something is broken in Cachi2
+        - something is wrong with your Go module
+        - communication with an external service failed (please try again)
+        The output of the failing go command should provide more details, please check the logs.
+        """
+    ).strip()
 
-def _friendly_error_msg(reason: str, solution: Optional[str], docs_link: Optional[str]) -> str:
+    def friendly_msg(self) -> str:
+        """Return the user-friendly representation of this error."""
+        return _friendly_error_msg(str(self), self.notice)
+
+
+def _friendly_error_msg(
+    reason: str, solution: Optional[str], docs_link: Optional[str] = None
+) -> str:
     msg = reason
     if solution:
         msg += f"\n{textwrap.indent(solution, prefix='  ')}"

--- a/cachi2/core/errors.py
+++ b/cachi2/core/errors.py
@@ -33,6 +33,32 @@ class PackageRejected(Cachi2Error):
         return _friendly_error_msg(str(self), self.solution, self.docs)
 
 
+class UnsupportedFeature(Cachi2Error):
+    """Cachi2 doesn't support a feature the user requested.
+
+    The requested feature might be valid, but Cachi2 doesn't implement it.
+    """
+
+    default_solution = "If you need Cachi2 to support this feature, please contact the maintainers."
+
+    def __init__(
+        self, reason: str, *, solution: Optional[str] = default_solution, docs: Optional[str] = None
+    ) -> None:
+        """Initialize an Unsupported Feature error.
+
+        :param reason: explain why the feature is not supported
+        :param solution: politely suggest a potential solution (or workaround) to the user
+        :param docs: include a link to relevant documentation (if there is any)
+        """
+        super().__init__(reason)
+        self.solution = solution
+        self.docs = docs
+
+    def friendly_msg(self) -> str:
+        """Return the user-friendly representation of this error."""
+        return _friendly_error_msg(str(self), self.solution, self.docs)
+
+
 class FetchError(Cachi2Error):
     """Cachi2 failed to fetch a dependency or other data needed to process a package."""
 
@@ -42,13 +68,6 @@ class GoModError(Cachi2Error):
 
     Maybe the module is invalid, maybe the go tool was unable to fetch a dependency, maybe the
     error is intermittent. We don't really know, but we do at least log the stderr.
-    """
-
-
-class UnsupportedFeature(Cachi2Error):
-    """Cachi2 doesn't support a feature the user requested.
-
-    The requested feature might be valid, but Cachi2 doesn't implement it.
     """
 
 

--- a/cachi2/core/errors.py
+++ b/cachi2/core/errors.py
@@ -62,6 +62,15 @@ class UnsupportedFeature(Cachi2Error):
 class FetchError(Cachi2Error):
     """Cachi2 failed to fetch a dependency or other data needed to process a package."""
 
+    please_retry = (
+        "The error might be intermittent, please try again.\n"
+        "If the issue seems to be on the Cachi2 side, please contact the maintainers."
+    )
+
+    def friendly_msg(self) -> str:
+        """Return the user-friendly representation of this error."""
+        return _friendly_error_msg(str(self), self.please_retry)
+
 
 class GoModError(Cachi2Error):
     """The 'go' command used while processing a Go module returned an error.

--- a/cachi2/core/errors.py
+++ b/cachi2/core/errors.py
@@ -1,5 +1,13 @@
+import textwrap
+from typing import Optional
+
+
 class Cachi2Error(Exception):
     """Root of the error hierarchy. Don't raise this directly, use more specific error types."""
+
+    def friendly_msg(self) -> str:
+        """Return the user-friendly representation of this error."""
+        return str(self)
 
 
 class PackageRejected(Cachi2Error):
@@ -8,6 +16,21 @@ class PackageRejected(Cachi2Error):
     a) The package appears invalid (e.g. missing go.mod for a Go module).
     b) The package does not meet Cachi2's extra requirements (e.g. missing checksums).
     """
+
+    def __init__(self, reason: str, *, solution: Optional[str], docs: Optional[str] = None) -> None:
+        """Initialize a Package Rejected error.
+
+        :param reason: explain why we rejected the package
+        :param solution: politely suggest a potential solution to the user
+        :param docs: include a link to relevant documentation (if there is any)
+        """
+        super().__init__(reason)
+        self.solution = solution
+        self.docs = docs
+
+    def friendly_msg(self) -> str:
+        """Return the user-friendly representation of this error."""
+        return _friendly_error_msg(str(self), self.solution, self.docs)
 
 
 class FetchError(Cachi2Error):
@@ -27,3 +50,12 @@ class UnsupportedFeature(Cachi2Error):
 
     The requested feature might be valid, but Cachi2 doesn't implement it.
     """
+
+
+def _friendly_error_msg(reason: str, solution: Optional[str], docs_link: Optional[str]) -> str:
+    msg = reason
+    if solution:
+        msg += f"\n{textwrap.indent(solution, prefix='  ')}"
+    if docs_link:
+        msg += f"\n  Docs: {docs_link}"
+    return msg

--- a/cachi2/core/extras/envfile.py
+++ b/cachi2/core/extras/envfile.py
@@ -24,7 +24,20 @@ class EnvFormat(str, Enum):
             reason = (
                 f"file has no suffix: {filepath}" if not suffix else f"unsupported suffix: {suffix}"
             )
-            raise UnsupportedFeature(f"Cannot determine envfile format, {reason}") from e
+            raise UnsupportedFeature(
+                f"Cannot determine envfile format, {reason}",
+                solution=(
+                    f"Please use one of the supported suffixes: {cls._suffixes_repr()}\n"
+                    "You can also define the format explicitly instead of letting Cachi2 choose."
+                ),
+            ) from e
+
+    @classmethod
+    def _suffixes_repr(cls) -> str:
+        return ", ".join(
+            f"{suffix}[=={fmt}]" if suffix != fmt else suffix
+            for suffix, fmt in cls.__members__.items()
+        )
 
 
 def generate_envfile(output: RequestOutput, fmt: EnvFormat, relative_to_path: Path) -> str:

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -147,7 +147,7 @@ def _resolve_gomod(path: Path, request: Request, git_dir_path=None):
     Resolve and fetch gomod dependencies for given app source archive.
 
     :param str path: the full path to the application source code
-    :param dict request: the Cachito request this is for
+    :param dict request: the Cachi2 request this is for
     :param list dep_replacements: dependency replacements with the keys "name" and "version"; this
         results in a series of `go mod edit -replace` commands
     :param RequestBundleDir git_dir_path: the full path to the application's git repository
@@ -245,7 +245,7 @@ def _resolve_gomod(path: Path, request: Request, git_dir_path=None):
                 old_name, old_version = parts[:2]
                 # Only keep track of user provided replaces. There could be existing "replace"
                 # directives in the go.mod file, but they are an implementation detail specific to
-                # Go and they don't need to be recorded in Cachito.
+                # Go and they don't need to be recorded in Cachi2.
                 if old_name in replaced_dep_names:
                     used_replaced_dep_names.add(old_name)
                     replaces = {
@@ -288,7 +288,7 @@ def _resolve_gomod(path: Path, request: Request, git_dir_path=None):
         module = {"name": module_name, "type": "gomod", "version": module_version}
 
         if "gomod-vendor" in flags:
-            # Create an empty gomod cache in the bundle directory so that any Cachito
+            # Create an empty gomod cache in the bundle directory so that any Cachi2
             # user does not have to guard against this directory not existing
             request.gomod_download_dir.mkdir(exist_ok=True, parents=True)
         else:
@@ -390,8 +390,8 @@ def _run_download_cmd(cmd: Iterable[str], params: Dict[str, Any]) -> str:
     Such commands may fail due to network errors (go is bad at retrying), so the entire operation
     will be retried a configurable number of times.
 
-    Cachito will reuse the same cache directory between retries, so Go will not have to download
-    the same dependency twice. The backoff is exponential, Cachito will wait 1s -> 2s -> 4s -> ...
+    Cachi2 will reuse the same cache directory between retries, so Go will not have to download
+    the same dependency twice. The backoff is exponential, Cachi2 will wait 1s -> 2s -> 4s -> ...
     before retrying.
     """
     n_tries = get_worker_config().cachito_gomod_download_max_tries
@@ -411,7 +411,7 @@ def _run_download_cmd(cmd: Iterable[str], params: Dict[str, Any]) -> str:
         return run_go(cmd, params)
     except GoModError:
         err_msg = (
-            f"Processing gomod dependencies failed. Cachito tried the {' '.join(cmd)} command "
+            f"Processing gomod dependencies failed. Cachi2 tried the {' '.join(cmd)} command "
             f"{n_tries} times."
         )
         raise GoModError(err_msg) from None
@@ -419,13 +419,13 @@ def _run_download_cmd(cmd: Iterable[str], params: Dict[str, Any]) -> str:
 
 def _should_vendor_deps(flags: Iterable[str], app_dir: Path, strict: bool) -> Tuple[bool, bool]:
     """
-    Determine if Cachito should vendor dependencies and if it is allowed to make changes.
+    Determine if Cachi2 should vendor dependencies and if it is allowed to make changes.
 
     This is based on the presence of flags:
     - gomod-vendor-check => should vendor, can only make changes if vendor dir does not exist
     - gomod-vendor => should vendor, can make changes
 
-    :param flags: flags from the Cachito request
+    :param flags: flags from the Cachi2 request
     :param app_dir: absolute path to the app directory
     :param strict: fail the request if the vendor dir is present but the flags are not used?
     :return: (should vendor: bool, allowed to make changes in the vendor directory: bool)
@@ -940,13 +940,13 @@ def _vendor_deps(run_params: dict, can_make_changes: bool, git_dir: str):
     """
     Vendor golang dependencies.
 
-    If Cachito is not allowed to make changes, it will verify that the vendor directory already
+    If Cachi2 is not allowed to make changes, it will verify that the vendor directory already
     contained the correct content.
 
     :param run_params: common params for the subprocess calls to `go`
-    :param can_make_changes: is Cachito allowed to make changes?
+    :param can_make_changes: is Cachi2 allowed to make changes?
     :param git_dir: path to the repository root
-    :raise PackageRejected: if vendor directory changed and Cachito is not allowed to make changes
+    :raise PackageRejected: if vendor directory changed and Cachi2 is not allowed to make changes
     """
     log.info("Vendoring the gomod dependencies")
     _run_download_cmd(("go", "mod", "vendor"), run_params)

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -486,7 +486,7 @@ def _get_golang_version(module_name, git_path, commit_sha=None, update_tags=Fals
             repo.remote().fetch(force=True, tags=True)
         except Exception as ex:
             raise FetchError(
-                "Failed to fetch the tags on the Git repository (%s) for %s ",
+                "Failed to fetch the tags on the Git repository (%s) for %s",
                 type(ex).__name__,
                 module_name,
             )

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -762,10 +762,7 @@ def _vet_local_deps(dependencies: List[dict], module_name: str, allowed_patterns
                 version,
             )
             if ".." in Path(version).parts:
-                raise UnsupportedFeature(
-                    f"Path to gomod dependency contains '..': {version}. "
-                    "Cachito does not support this case."
-                )
+                raise UnsupportedFeature(f"Path to gomod dependency contains '..': {version}.")
             _fail_unless_allowed(module_name, name, allowed_patterns)
         elif version.startswith("/") or PureWindowsPath(version).root:
             # This will disallow paths starting with '/', '\' or '<drive letter>:\'
@@ -974,9 +971,14 @@ def _fail_unless_allowed(module_name: str, package_name: str, allowed_patterns: 
     is_submodule = _contains_package(versionless_module_name, package_name)
     if not is_submodule and not any(fnmatch.fnmatch(package_name, pat) for pat in allowed_patterns):
         raise UnsupportedFeature(
-            f"The module {module_name} is not allowed to replace {package_name} with a local "
-            f"dependency. Please contact the maintainers of this Cachito instance about adding "
-            "an exception."
+            reason=(
+                f"The module {module_name} is not allowed to replace {package_name} with a local "
+                "dependency."
+            ),
+            solution=(
+                "Please allow the replacement in Cachi2's configuration, or contact someone who "
+                "has access to the configuration."
+            ),
         )
 
 

--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -41,8 +41,10 @@ def friendly_errors(cmd: Callable[..., None]) -> Callable[..., None]:
     def cmd_with_friendlier_errors(*args, **kwargs) -> None:
         try:
             cmd(*args, **kwargs)
+        except Cachi2Error as e:
+            die(f"{type(e).__name__}: {e.friendly_msg()}")
         # TODO: wrap pydantic ValidationErrors in our own errors?
-        except (Cachi2Error, pydantic.ValidationError) as e:
+        except pydantic.ValidationError as e:
             die(f"{type(e).__name__}: {e}")
 
     return cmd_with_friendlier_errors

--- a/tests/unit/extras/test_envfile.py
+++ b/tests/unit/extras/test_envfile.py
@@ -30,8 +30,17 @@ def test_format_based_on_suffix(filename: str, expect_format: EnvFormat):
 )
 def test_cannot_determine_format(filename: str, expect_reason: str):
     expect_error = f"Cannot determine envfile format, {expect_reason}"
-    with pytest.raises(UnsupportedFeature, match=expect_error):
+    with pytest.raises(UnsupportedFeature, match=expect_error) as exc_info:
         EnvFormat.based_on_suffix(Path(filename))
+
+    expect_friendly_msg = dedent(
+        f"""
+        Cannot determine envfile format, {expect_reason}
+          Please use one of the supported suffixes: json, env, sh[==env]
+          You can also define the format explicitly instead of letting Cachi2 choose.
+        """
+    ).strip()
+    assert exc_info.value.friendly_msg() == expect_friendly_msg
 
 
 def test_generate_env_as_json():

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1473,7 +1473,7 @@ def test_run_download_cmd_failure(mock_sleep, mock_run, mock_worker_config, capl
     mock_run.side_effect = [failure] * 5
 
     expect_msg = (
-        "Processing gomod dependencies failed. Cachito tried the go mod download command 5 times."
+        "Processing gomod dependencies failed. Cachi2 tried the go mod download command 5 times."
     )
 
     with pytest.raises(GoModError, match=expect_msg):

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -882,9 +882,7 @@ def test_vet_local_deps_abspath(platform_specific_path):
 def test_vet_local_deps_parent_dir(path):
     dependencies = [{"name": "foo", "version": path}]
 
-    expect_error = re.escape(
-        f"Path to gomod dependency contains '..': {path}. Cachito does not support this case."
-    )
+    expect_error = re.escape(f"Path to gomod dependency contains '..': {path}.")
     with pytest.raises(UnsupportedFeature, match=expect_error):
         _vet_local_deps(dependencies, "some-module", [])
 

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -576,7 +576,7 @@ def test_resolve_gomod_unused_dep(mock_run, mock_temp_dir, tmpdir, gomod_request
     ]
 
     expected_error = "The following gomod dependency replacements don't apply: pizza"
-    with pytest.raises(GoModError, match=expected_error):
+    with pytest.raises(PackageRejected, match=expected_error):
         _resolve_gomod(
             Path("./source/path/archive.tar.gz"),
             gomod_request,
@@ -601,6 +601,10 @@ def test_go_list_cmd_failure(
         proc_mock("go mod download", returncode=go_mod_rc, stdout=None),
         proc_mock("go list -m all", returncode=go_list_rc, stdout=_generate_mock_cmd_output()),
     ]
+
+    expect_error = "Processing gomod dependencies failed"
+    if go_mod_rc == 0:
+        expect_error += ": `go list -m all` failed with rc=1"
 
     with pytest.raises(
         GoModError,
@@ -1469,8 +1473,7 @@ def test_run_download_cmd_failure(mock_sleep, mock_run, mock_worker_config, capl
     mock_run.side_effect = [failure] * 5
 
     expect_msg = (
-        "Processing gomod dependencies failed. Cachito tried the go mod download command 5 times. "
-        "This may indicate a problem with your repository or Cachito itself."
+        "Processing gomod dependencies failed. Cachito tried the go mod download command 5 times."
     )
 
     with pytest.raises(GoModError, match=expect_msg):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -479,3 +479,4 @@ class TestGenerateEnv:
         result = runner.invoke(app, ["generate-env", ".", "-o", "env.yaml"])
         assert result.exit_code != 0
         assert "Cannot determine envfile format, unsupported suffix: yaml" in result.output
+        assert "  Please use one of the supported suffixes: " in result.output

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,0 +1,20 @@
+from textwrap import dedent
+
+from cachi2.core import errors
+
+
+def test_package_rejected_friendly_msg():
+    err = errors.PackageRejected(
+        "The package does not look valid",
+        solution="Please fix your package\nOr read this second line",
+        docs="https://example.org",
+    )
+    expect_msg = dedent(
+        """
+        The package does not look valid
+          Please fix your package
+          Or read this second line
+          Docs: https://example.org
+        """
+    ).strip()
+    assert err.friendly_msg() == expect_msg

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -47,3 +47,15 @@ def test_gomod_error_friendly_msg():
         """
     ).strip()
     assert err.friendly_msg() == expect_msg
+
+
+def test_fetch_error_friendly_msg():
+    err = errors.FetchError("Failed to fetch something")
+    expect_msg = dedent(
+        """
+        Failed to fetch something
+          The error might be intermittent, please try again.
+          If the issue seems to be on the Cachi2 side, please contact the maintainers.
+        """
+    ).strip()
+    assert err.friendly_msg() == expect_msg

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -32,3 +32,18 @@ def test_unsupported_feature_default_friendly_msg():
 
     no_default = errors.UnsupportedFeature("This feature is not supported", solution=None)
     assert no_default.friendly_msg() == "This feature is not supported"
+
+
+def test_gomod_error_friendly_msg():
+    err = errors.GoModError("Some go command failed")
+    expect_msg = dedent(
+        """
+        Some go command failed
+          The cause of the failure could be:
+          - something is broken in Cachi2
+          - something is wrong with your Go module
+          - communication with an external service failed (please try again)
+          The output of the failing go command should provide more details, please check the logs.
+        """
+    ).strip()
+    assert err.friendly_msg() == expect_msg

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -18,3 +18,17 @@ def test_package_rejected_friendly_msg():
         """
     ).strip()
     assert err.friendly_msg() == expect_msg
+
+
+def test_unsupported_feature_default_friendly_msg():
+    err = errors.UnsupportedFeature("This feature is not supported")
+    expect_msg = dedent(
+        """
+        This feature is not supported
+          If you need Cachi2 to support this feature, please contact the maintainers.
+        """
+    ).strip()
+    assert err.friendly_msg() == expect_msg
+
+    no_default = errors.UnsupportedFeature("This feature is not supported", solution=None)
+    assert no_default.friendly_msg() == "This feature is not supported"


### PR DESCRIPTION
CLOUDBLD-12401

Still missing:
* turn pydantic validation into InvalidInput error
* different retcode for user errors
* log errors before printing them

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [x] Docs updated (if applicable)
- [x] [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
