### PR TITLE
Error updates vol. 3

### DIFF
--- a/cachi2/core/errors.py
+++ b/cachi2/core/errors.py
@@ -1,9 +1,11 @@
 import textwrap
-from typing import Optional
+from typing import ClassVar, Optional
 
 
 class Cachi2Error(Exception):
     """Root of the error hierarchy. Don't raise this directly, use more specific error types."""
+
+    is_invalid_usage: ClassVar[bool] = False
 
     def friendly_msg(self) -> str:
         """Return the user-friendly representation of this error."""
@@ -13,6 +15,8 @@ class Cachi2Error(Exception):
 class InvalidInput(Cachi2Error):
     """User input was invalid."""
 
+    is_invalid_usage: ClassVar[bool] = True
+
 
 class PackageRejected(Cachi2Error):
     """Cachi2 refused to process the package the user requested.
@@ -20,6 +24,8 @@ class PackageRejected(Cachi2Error):
     a) The package appears invalid (e.g. missing go.mod for a Go module).
     b) The package does not meet Cachi2's extra requirements (e.g. missing checksums).
     """
+
+    is_invalid_usage: ClassVar[bool] = True
 
     def __init__(self, reason: str, *, solution: Optional[str], docs: Optional[str] = None) -> None:
         """Initialize a Package Rejected error.
@@ -43,6 +49,7 @@ class UnsupportedFeature(Cachi2Error):
     The requested feature might be valid, but Cachi2 doesn't implement it.
     """
 
+    is_invalid_usage: ClassVar[bool] = True
     default_solution = "If you need Cachi2 to support this feature, please contact the maintainers."
 
     def __init__(

--- a/cachi2/core/errors.py
+++ b/cachi2/core/errors.py
@@ -10,6 +10,10 @@ class Cachi2Error(Exception):
         return str(self)
 
 
+class InvalidInput(Cachi2Error):
+    """User input was invalid."""
+
+
 class PackageRejected(Cachi2Error):
     """Cachi2 refused to process the package the user requested.
 

--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -33,7 +33,7 @@ def handle_errors(cmd: Callable[..., None]) -> Callable[..., None]:
     """
 
     def log_error(error: Exception) -> None:
-        log.error("%s: %s", type(error).__name__, error)
+        log.error("%s: %s", type(error).__name__, str(error).replace("\n", r"\n"))
 
     @functools.wraps(cmd)
     def cmd_with_error_handling(*args, **kwargs) -> None:

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -5,7 +5,18 @@ from typing import Any
 import pydantic
 import pytest as pytest
 
-from cachi2.core.models.input import PackageInput, Request
+from cachi2.core.errors import InvalidInput
+from cachi2.core.models.input import PackageInput, Request, parse_user_input
+
+
+def test_parse_user_input():
+    expect_error = re.compile(
+        r"1 validation error for user input\n"
+        r"type\n"
+        r"  unexpected value; permitted: .* \(given=go-package; permitted=[^;]*\)"
+    )
+    with pytest.raises(InvalidInput, match=expect_error):
+        parse_user_input(PackageInput.parse_obj, {"type": "go-package"})
 
 
 class TestPackageInput:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -212,15 +212,15 @@ class TestFetchDeps:
         [
             (
                 ["--package={notjson}"],
-                ["--package: looks like JSON but is not valid JSON"],
+                ["'--package': Looks like JSON but is not valid JSON: '{notjson}'"],
             ),
             (
                 ["--package=[notjson]"],
-                ["--package: looks like JSON but is not valid JSON"],
+                ["'--package': Looks like JSON but is not valid JSON: '[notjson]'"],
             ),
             (
                 ["--package=gomod", "--package={notjson}"],
-                ["--package: looks like JSON but is not valid JSON"],
+                ["'--package': Looks like JSON but is not valid JSON: '{notjson}'"],
             ),
             (
                 ["--package=idk"],

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -219,29 +219,29 @@ class TestFetchDeps:
             (
                 ["--package=idk"],
                 [
-                    "1 validation error for Request",
+                    "1 validation error for user input",
                     "packages -> 0 -> type",
-                    re.compile(r"unexpected value; permitted: .* given=idk;"),
+                    re.compile(r"unexpected value; permitted: .*\(given=idk;"),
                 ],
             ),
             (
                 ["--package=", '--package={"type": "idk"}'],
                 [
-                    "2 validation errors for Request",
+                    "2 validation errors for user input",
                     "packages -> 0 -> type",
-                    re.compile(r"unexpected value; permitted: .* given=;"),
+                    re.compile(r"unexpected value; permitted: .*\(given=;"),
                     "packages -> 1 -> type",
-                    re.compile(r"unexpected value; permitted: .* given=idk;"),
+                    re.compile(r"unexpected value; permitted: .*\(given=idk;"),
                 ],
             ),
             (
                 ["--package={}"],
-                ["1 validation error for Request", "packages -> 0 -> type", "field required"],
+                ["1 validation error for user input", "packages -> 0 -> type", "field required"],
             ),
             (
                 ['--package=[{"type": "gomod"}, {}]', "--package={}"],
                 [
-                    "2 validation errors for Request",
+                    "2 validation errors for user input",
                     "packages -> 1 -> type",
                     "packages -> 2 -> type",
                     "field required",
@@ -250,7 +250,7 @@ class TestFetchDeps:
             (
                 ['--package={"type": "gomod", "path": "/absolute"}'],
                 [
-                    "1 validation error for Request",
+                    "1 validation error for user input",
                     "packages -> 0 -> path",
                     "package path must be relative: /absolute",
                 ],
@@ -258,7 +258,7 @@ class TestFetchDeps:
             (
                 ['--package={"type": "gomod", "path": "weird/../subpath"}'],
                 [
-                    "1 validation error for Request",
+                    "1 validation error for user input",
                     "packages -> 0 -> path",
                     "package path contains ..: weird/../subpath",
                 ],
@@ -266,7 +266,7 @@ class TestFetchDeps:
             (
                 ['--package={"type": "gomod", "path": "suspicious-symlink"}'],
                 [
-                    "1 validation error for Request",
+                    "1 validation error for user input",
                     "packages -> 0",
                     "package path (a symlink?) leads outside source directory: suspicious-symlink",
                 ],
@@ -274,7 +274,7 @@ class TestFetchDeps:
             (
                 ['--package={"type": "gomod", "path": "no-such-dir"}'],
                 [
-                    "1 validation error for Request",
+                    "1 validation error for user input",
                     "packages -> 0",
                     "package path does not exist (or is not a directory): no-such-dir",
                 ],
@@ -282,7 +282,7 @@ class TestFetchDeps:
             (
                 ['--package={"type": "gomod", "what": "dunno"}'],
                 [
-                    "1 validation error for Request",
+                    "1 validation error for user input",
                     "packages -> 0 -> what",
                     "extra fields not permitted",
                 ],
@@ -339,9 +339,9 @@ class TestFetchDeps:
             (
                 ["--flags=no-such-flag"],
                 re.compile(
-                    r"1 validation error for Request\n"
+                    r"1 validation error for user input\n"
                     r"flags -> 0\n"
-                    r"  unexpected value; permitted: .* given=no-such-flag",
+                    r"  unexpected value; permitted: .*\(given=no-such-flag",
                 ),
             ),
         ],


### PR DESCRIPTION
Main changes:

* re-raise input validation errors as InvalidInput
* return rc=2 for invalid usage
* log errors before printing them (https://github.com/containerbuildsystem/cachi2/pull/20#issuecomment-1308881540)

WIP: how to log multiline errors

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
