### PR TITLE
Remove the ignore_missing_gomod configuration option

### DIFF
--- a/cachi2/core/config.py
+++ b/cachi2/core/config.py
@@ -14,7 +14,6 @@ class Config:
     cachito_default_environment_variables = {
         "gomod": {"GOSUMDB": {"value": "off", "kind": "literal"}},
     }
-    cachito_gomod_ignore_missing_gomod_file = False
     cachito_gomod_download_max_tries = 5
     cachito_gomod_file_deps_allowlist: Dict[str, Dict[str, str]] = {}
     cachito_gomod_strict_vendor = False

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -64,11 +64,6 @@ def fetch_gomod_source(request: Request) -> RequestOutput:
     if invalid_gomod_files:
         invalid_files_print = "; ".join(str(file.parent) for file in invalid_gomod_files)
 
-        # missing gomod files is supported if there is only one path referenced
-        if config.cachito_gomod_ignore_missing_gomod_file and len(subpaths) == 1:
-            log.warning("go.mod file missing at %s", invalid_files_print)
-            return RequestOutput.empty()
-
         raise PackageRejected(
             f"The go.mod file must be present for the Go module(s) at: {invalid_files_print}",
             solution="Please double-check that you have specified correct paths to your Go modules",


### PR DESCRIPTION
This option is a tech debt that was inherited from Cachito. The presence of a go.mod file is basic requirement for processing a Go module, which made us decide to remove this option altogether in Cachi2.

This PR also adds a unit test to cover the check that guarantees that the file is always present in the processed paths.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a Docs updated (if applicable)
- [ ] [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
