### PR TITLE
Document error message guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ Run all the checks that your pull request will be subjected to:
 make test
 ```
 
+### Error message guidelines
+
+We try to keep error messages friendly and actionable.
+
+* If there is a known solution, the error message should politely suggest the solution.
+  * Include a link to the documentation when suitable.
+* If there is no known solution, suggest where to look for help.
+* If retrying is a possible solution, suggest retrying and where to look for help if the issue persists.
+
+The error classes aim to encourage these guidelines. See the [errors.py](cachi2/core/errors.py) module.
+
 ### Running unit tests
 
 Run all unit tests (but no other checks):

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -4,4 +4,5 @@
 - [ ] Code coverage from testing does not decrease and new code is covered
 - [ ] New code has type annotations
 - [ ] Docs updated (if applicable)
+- [ ] Docs links in the code are still valid (if docs were updated)
 - [ ] [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)


### PR DESCRIPTION
Short section in the README + a checklist item to keep links updated

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [x] Docs updated (if applicable)
- [ ] [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
