### PR TITLE
Test fetch gomod source

### DIFF
--- a/tests/unit/package_managers/conftest.py
+++ b/tests/unit/package_managers/conftest.py
@@ -198,3 +198,13 @@ def fake_repo():
         r.index.add(["main.py"])
         r.index.commit("add main source")
         yield repo_dir, repo_dir.lstrip("/")
+
+
+@pytest.fixture()
+def env_variables():
+    return [
+        {"name": "GOCACHE", "value": "deps/gomod", "kind": "path"},
+        {"name": "GOMODCACHE", "value": "deps/gomod/pkg/mod", "kind": "path"},
+        {"name": "GOPATH", "value": "deps/gomod", "kind": "path"},
+        {"name": "GOSUMDB", "value": "off", "kind": "literal"},
+    ]


### PR DESCRIPTION
Without the API as we have in Cachito, these tests needed to be pretty much rewritten from scratch. They were broken down into two tests: one that covers the ported "dependency replacements feature" from Cachito, and one that covers the main "fetch gomod source".

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- n/a Docs updated (if applicable)
- n/a Docs links in the code are still valid (if docs were updated)
- n/a [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
