### PR TITLE
Support specifiying "pip" packages in the CLI

### DIFF
--- a/cachi2/core/__init__.py
+++ b/cachi2/core/__init__.py
@@ -1,4 +1,0 @@
-# The following imports are functions that serve as the interface
-# to use Cachi2. No module should need to access files from
-# cachi2.core directly.
-from cachi2.core.package_managers.gomod import fetch_gomod_source  # noqa: F401

--- a/cachi2/core/models/input.py
+++ b/cachi2/core/models/input.py
@@ -104,19 +104,19 @@ class Request(pydantic.BaseModel):
     dep_replacements: tuple[dict, ...] = ()  # TODO: do we want dep replacements at all?
 
     @pydantic.validator("source_dir", "output_dir")
-    def resolve_path(cls, path: Path) -> Path:
+    def _resolve_path(cls, path: Path) -> Path:
         """Check that path is absolute and fully resolve it."""
         if not path.is_absolute():
             raise ValueError(f"path must be absolute: {path}")
         return path.resolve()
 
     @pydantic.validator("packages")
-    def unique_packages(cls, packages: list[PackageInput]) -> list[PackageInput]:
+    def _unique_packages(cls, packages: list[PackageInput]) -> list[PackageInput]:
         """De-duplicate the packages to be processed."""
         return unique(packages, by=lambda pkg: (pkg.type, pkg.path))
 
     @pydantic.validator("packages", each_item=True)
-    def check_package_paths(cls, package: PackageInput, values: dict) -> PackageInput:
+    def _check_package_paths(cls, package: PackageInput, values: dict) -> PackageInput:
         """Check that package paths are existing subdirectories."""
         source_dir = values.get("source_dir")
         # Don't run validation if source_dir failed to validate

--- a/cachi2/core/models/input.py
+++ b/cachi2/core/models/input.py
@@ -46,7 +46,7 @@ def _present_user_input_error(validation_error: pydantic.ValidationError) -> str
 
 
 # Supported package managers
-PackageManagerType = Literal["gomod"]
+PackageManagerType = Literal["gomod", "pip"]
 
 Flag = Literal["cgo-disable", "force-gomod-tidy", "gomod-vendor", "gomod-vendor-check"]
 
@@ -104,6 +104,19 @@ class Request(pydantic.BaseModel):
                     f"package path does not exist (or is not a directory): {package.path}"
                 )
         return package
+
+    @property
+    def gomod_packages(self) -> list[PackageInput]:
+        """Get the gomod packages specified for this request."""
+        return self._packages_by_type("gomod")
+
+    @property
+    def pip_packages(self) -> list[PackageInput]:
+        """Get the pip packages specified for this request."""
+        return self._packages_by_type("pip")
+
+    def _packages_by_type(self, pkgtype: PackageManagerType) -> list[PackageInput]:
+        return [package for package in self.packages if package.type == pkgtype]
 
     # This is kept here temporarily, should be refactored
     go_mod_cache_download_part: ClassVar[Path] = Path("pkg", "mod", "cache", "download")

--- a/cachi2/core/models/output.py
+++ b/cachi2/core/models/output.py
@@ -3,7 +3,7 @@ from typing import Literal, Optional
 
 import pydantic
 
-from cachi2.core.models.validators import unique_sorted
+from cachi2.core.models.validators import check_sane_relpath, unique_sorted
 
 # Supported package types (a superset of the supported package *manager* types)
 PackageType = Literal["gomod", "go-package", "pip"]
@@ -35,11 +35,8 @@ class Package(pydantic.BaseModel):
     dependencies: list[Dependency]
 
     @pydantic.validator("path")
-    def check_path(cls, path: Path) -> Path:
-        """Check that the package path is relative."""
-        if path.is_absolute():
-            raise ValueError(f"package path must be relative: {path}")
-        return path
+    def _path_is_relative(cls, path: Path) -> Path:
+        return check_sane_relpath(path)
 
     @pydantic.validator("dependencies")
     def unique_deps(cls, dependencies: list[Dependency]) -> list[Dependency]:

--- a/cachi2/core/models/output.py
+++ b/cachi2/core/models/output.py
@@ -6,7 +6,7 @@ import pydantic
 from cachi2.core.models.validators import unique_sorted
 
 # Supported package types (a superset of the supported package *manager* types)
-PackageType = Literal["gomod", "go-package"]
+PackageType = Literal["gomod", "go-package", "pip"]
 
 
 class Dependency(pydantic.BaseModel):

--- a/cachi2/core/models/output.py
+++ b/cachi2/core/models/output.py
@@ -17,7 +17,7 @@ class Dependency(pydantic.BaseModel):
     version: Optional[str]  # go-package stdlib dependencies are allowed not to have versions
 
     @pydantic.validator("version")
-    def check_version_vs_type(cls, version: Optional[str], values: dict) -> Optional[str]:
+    def _check_version_vs_type(cls, version: Optional[str], values: dict) -> Optional[str]:
         """Check that the dependency has a version or is 'go-package'."""
         ptype = values.get("type")
         if ptype is not None and (version is None and ptype != "go-package"):
@@ -39,7 +39,7 @@ class Package(pydantic.BaseModel):
         return check_sane_relpath(path)
 
     @pydantic.validator("dependencies")
-    def unique_deps(cls, dependencies: list[Dependency]) -> list[Dependency]:
+    def _unique_deps(cls, dependencies: list[Dependency]) -> list[Dependency]:
         """Sort and de-duplicate dependencies."""
         return unique_sorted(dependencies, by=lambda dep: (dep.type, dep.name, dep.version))
 
@@ -71,7 +71,7 @@ class RequestOutput(pydantic.BaseModel):
     environment_variables: list[EnvironmentVariable]
 
     @pydantic.validator("packages")
-    def unique_packages(cls, packages: list[Package]) -> list[Package]:
+    def _unique_packages(cls, packages: list[Package]) -> list[Package]:
         """Sort packages and check that there are no duplicates."""
         return unique_sorted(
             packages,
@@ -80,7 +80,7 @@ class RequestOutput(pydantic.BaseModel):
         )
 
     @pydantic.validator("environment_variables")
-    def unique_env_vars(cls, env_vars: list[EnvironmentVariable]) -> list[EnvironmentVariable]:
+    def _unique_env_vars(cls, env_vars: list[EnvironmentVariable]) -> list[EnvironmentVariable]:
         """Sort and de-duplicate environment variables by name."""
         return unique_sorted(env_vars, by=lambda env_var: env_var.name)
 

--- a/cachi2/core/models/validators.py
+++ b/cachi2/core/models/validators.py
@@ -1,3 +1,5 @@
+import os
+from pathlib import Path
 from typing import Any, Callable, Iterable, TypeVar
 
 T = TypeVar("T")
@@ -30,3 +32,12 @@ def unique_sorted(items: Iterable[T], by: Callable[[T], Any], dedupe: bool = Tru
     unique_items = unique(items, by, dedupe)
     unique_items.sort(key=by)
     return unique_items
+
+
+def check_sane_relpath(path: Path) -> Path:
+    """Check that the path is relative and looks sane."""
+    if path.is_absolute():
+        raise ValueError(f"path must be relative: {path}")
+    if os.path.pardir in path.parts:
+        raise ValueError(f"path contains {os.path.pardir}: {path}")
+    return path

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -60,7 +60,7 @@ def fetch_gomod_source(request: Request) -> RequestOutput:
     log.info(f"Go version: {version_output.strip()}")
 
     config = get_worker_config()
-    subpaths = [str(package.path) for package in request.packages]
+    subpaths = [str(package.path) for package in request.gomod_packages]
 
     if not subpaths:
         return RequestOutput.empty()

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -1,0 +1,35 @@
+from collections.abc import Iterable
+from itertools import chain
+from typing import Callable
+
+from cachi2.core.errors import UnsupportedFeature
+from cachi2.core.models.input import PackageManagerType, Request
+from cachi2.core.models.output import RequestOutput
+from cachi2.core.package_managers import gomod
+
+Handler = Callable[[Request], RequestOutput]
+
+_package_managers: dict[PackageManagerType, Handler] = {
+    "gomod": gomod.fetch_gomod_source,
+}
+
+
+def resolve_packages(request: Request) -> RequestOutput:
+    """Run all requested package managers, return their combined output."""
+    requested_types = set(pkg.type for pkg in request.packages)
+    unsupported_types = requested_types - _package_managers.keys()
+    if unsupported_types:
+        raise UnsupportedFeature(
+            f"Package manager(s) not yet supported: {', '.join(sorted(unsupported_types))}",
+            # unknown package managers shouldn't get past input validation
+            solution="But the good news is that we're already working on it!",
+        )
+    pkg_managers = [_package_managers[type_] for type_ in sorted(requested_types)]
+    return _merge_outputs(pkg_manager(request) for pkg_manager in pkg_managers)
+
+
+def _merge_outputs(outputs: Iterable[RequestOutput]) -> RequestOutput:
+    """Merge RequestOutput instances."""
+    packages = list(chain.from_iterable(o.packages for o in outputs))
+    env_vars = list(chain.from_iterable(o.environment_variables for o in outputs))
+    return RequestOutput(packages=packages, environment_variables=env_vars)

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -14,6 +14,9 @@ _package_managers: dict[PackageManagerType, Handler] = {
 }
 
 
+supported_package_managers = list(_package_managers)
+
+
 def resolve_packages(request: Request) -> RequestOutput:
     """Run all requested package managers, return their combined output."""
     requested_types = set(pkg.type for pkg in request.packages)

--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -14,7 +14,7 @@ from cachi2.core.errors import Cachi2Error
 from cachi2.core.extras.envfile import EnvFormat, generate_envfile
 from cachi2.core.models.input import Request, parse_user_input
 from cachi2.core.models.output import RequestOutput
-from cachi2.core.resolver import resolve_packages
+from cachi2.core.resolver import resolve_packages, supported_package_managers
 from cachi2.interface.logging import LogLevel, setup_logging
 
 app = typer.Typer()
@@ -52,9 +52,12 @@ def handle_errors(cmd: Callable[..., None]) -> Callable[..., None]:
 
 def version_callback(value: bool) -> None:
     """If --version was used, print the cachi2 version and exit."""
-    if value:
-        print("cachi2", importlib.metadata.version("cachi2"))
-        raise typer.Exit()
+    if not value:
+        return
+
+    print("cachi2", importlib.metadata.version("cachi2"))
+    print("Supported package managers:", ", ".join(supported_package_managers))
+    raise typer.Exit()
 
 
 @app.callback()

--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -14,7 +14,7 @@ from cachi2.core.errors import Cachi2Error
 from cachi2.core.extras.envfile import EnvFormat, generate_envfile
 from cachi2.core.models.input import Request, parse_user_input
 from cachi2.core.models.output import RequestOutput
-from cachi2.core.package_managers import gomod
+from cachi2.core.resolver import resolve_packages
 from cachi2.interface.logging import LogLevel, setup_logging
 
 app = typer.Typer()
@@ -211,7 +211,7 @@ def fetch_deps(
         },
     )
 
-    request_output = gomod.fetch_gomod_source(request)
+    request_output = resolve_packages(request)
 
     request.output_dir.mkdir(parents=True, exist_ok=True)
     request.output_dir.joinpath("output.json").write_text(request_output.json())

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -94,6 +94,12 @@ class TestRequest:
             "dep_replacements": (),
         }
 
+    def test_packages_properties(self, tmp_path: Path):
+        packages = [{"type": "gomod"}, {"type": "pip"}]
+        request = Request(source_dir=tmp_path, output_dir=tmp_path, packages=packages)
+        assert request.gomod_packages == [PackageInput(type="gomod")]
+        assert request.pip_packages == [PackageInput(type="pip")]
+
     @pytest.mark.parametrize("which_path", ["source_dir", "output_dir"])
     def test_path_not_absolute(self, which_path: str):
         input_data = {

--- a/tests/unit/models/test_output.py
+++ b/tests/unit/models/test_output.py
@@ -111,3 +111,15 @@ class TestRequestOutput:
             EnvironmentVariable(name="A", value="x", kind="literal"),
             EnvironmentVariable(name="B", value="y", kind="literal"),
         ]
+
+
+def mock_output(pkg_names: list[str], env_names: list[str]) -> RequestOutput:
+    return RequestOutput(
+        packages=[
+            Package(type="pip", name=name, version="1.0.0", path=".", dependencies=[])
+            for name in pkg_names
+        ],
+        environment_variables=[
+            EnvironmentVariable(name=name, value="foo", kind="literal") for name in env_names
+        ],
+    )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -228,47 +228,51 @@ class TestFetchDeps:
                 ["--package=idk"],
                 [
                     "1 validation error for user input",
-                    "packages -> 0 -> type",
-                    re.compile(r"unexpected value; permitted: .*\(given=idk;"),
+                    "packages -> 0",
+                    "No match for discriminator 'type' and value 'idk' (allowed values:",
                 ],
             ),
             (
                 ["--package=", '--package={"type": "idk"}'],
                 [
                     "2 validation errors for user input",
-                    "packages -> 0 -> type",
-                    re.compile(r"unexpected value; permitted: .*\(given=;"),
-                    "packages -> 1 -> type",
-                    re.compile(r"unexpected value; permitted: .*\(given=idk;"),
+                    "packages -> 0",
+                    "No match for discriminator 'type' and value 'idk' (allowed values:",
+                    "packages -> 1",
+                    "No match for discriminator 'type' and value 'idk' (allowed values:",
                 ],
             ),
             (
                 ["--package={}"],
-                ["1 validation error for user input", "packages -> 0 -> type", "field required"],
+                [
+                    "1 validation error for user input",
+                    "packages -> 0",
+                    "Discriminator 'type' is missing",
+                ],
             ),
             (
                 ['--package=[{"type": "gomod"}, {}]', "--package={}"],
                 [
                     "2 validation errors for user input",
-                    "packages -> 1 -> type",
-                    "packages -> 2 -> type",
-                    "field required",
+                    "packages -> 1",
+                    "packages -> 2",
+                    "Discriminator 'type' is missing",
                 ],
             ),
             (
                 ['--package={"type": "gomod", "path": "/absolute"}'],
                 [
                     "1 validation error for user input",
-                    "packages -> 0 -> path",
-                    "package path must be relative: /absolute",
+                    "packages -> 0 -> GomodPackageInput -> path",
+                    "path must be relative: /absolute",
                 ],
             ),
             (
                 ['--package={"type": "gomod", "path": "weird/../subpath"}'],
                 [
                     "1 validation error for user input",
-                    "packages -> 0 -> path",
-                    "package path contains ..: weird/../subpath",
+                    "packages -> 0 -> GomodPackageInput -> path",
+                    "path contains ..: weird/../subpath",
                 ],
             ),
             (
@@ -291,7 +295,7 @@ class TestFetchDeps:
                 ['--package={"type": "gomod", "what": "dunno"}'],
                 [
                     "1 validation error for user input",
-                    "packages -> 0 -> what",
+                    "packages -> 0 -> GomodPackageInput -> what",
                     "extra fields not permitted",
                 ],
             ),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -35,12 +35,12 @@ def mock_fetch_deps(
 ) -> Iterator[mock.MagicMock]:
     output = output or RequestOutput.empty()
 
-    with mock.patch("cachi2.core.package_managers.gomod.fetch_gomod_source") as mock_gomod:
-        mock_gomod.return_value = output
-        yield mock_gomod
+    with mock.patch("cachi2.interface.cli.resolve_packages") as mock_resolve_packages:
+        mock_resolve_packages.return_value = output
+        yield mock_resolve_packages
 
     if expect_request is not None:
-        mock_gomod.assert_called_once_with(expect_request)
+        mock_resolve_packages.assert_called_once_with(expect_request)
 
 
 def invoke_expecting_sucess(app, args: list[str]) -> typer.testing.Result:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -72,7 +72,9 @@ class TestTopLevelOpts:
     def test_version_option(self):
         expect_version = importlib.metadata.version("cachi2")
         result = invoke_expecting_sucess(app, ["--version"])
-        assert result.output == f"cachi2 {expect_version}\n"
+        lines = result.output.splitlines()
+        assert lines[0] == f"cachi2 {expect_version}"
+        assert lines[1].startswith("Supported package managers: gomod")
 
 
 class TestLogLevelOpt:

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from typing import Callable
+from unittest import mock
+
+from cachi2.core import resolver
+from cachi2.core.models.input import Request
+from cachi2.core.models.output import Package, RequestOutput
+
+GOMOD_PACKAGE = Package(
+    type="gomod", path=".", name="github.com/foo/bar", version="v1.0.0", dependencies=[]
+)
+PIP_PACKAGE = Package(type="pip", path=".", name="spam", version="1.0.0", dependencies=[])
+
+
+def mock_output(*packages: Package) -> RequestOutput:
+    return RequestOutput(packages=packages, environment_variables=[])
+
+
+def test_resolve_packages(tmp_path: Path):
+    request = Request(
+        source_dir=tmp_path,
+        output_dir=tmp_path,
+        packages=[{"type": "pip"}, {"type": "gomod"}],
+    )
+
+    calls_by_pkgtype = []
+
+    def mock_fetch(pkgtype: str, output: RequestOutput) -> Callable[[Request], RequestOutput]:
+        def fetch(req: Request) -> RequestOutput:
+            assert req == request
+            calls_by_pkgtype.append(pkgtype)
+            return output
+
+        return fetch
+
+    with mock.patch.dict(
+        resolver._package_managers,
+        {
+            "gomod": mock_fetch("gomod", mock_output(GOMOD_PACKAGE)),
+            "pip": mock_fetch("pip", mock_output(PIP_PACKAGE)),
+        },
+    ):
+        assert resolver.resolve_packages(request) == mock_output(GOMOD_PACKAGE, PIP_PACKAGE)
+
+    assert calls_by_pkgtype == ["gomod", "pip"]


### PR DESCRIPTION
CLOUDBLD-11105

Add everything needed to support pip except for the `fetch_pip_source` function which would actually do the work

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [ ] ~Docs updated (if applicable)~
- [ ] ~Docs links in the code are still valid (if docs were updated)~
- [ ] ~[Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)~
