### PR TITLE
use allowlist_externals key in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ python =
 deps =
     -rrequirements.txt
     -rrequirements-test.txt
-whitelist_externals =
+allowlist_externals =
     make
     mkdir
     rm


### PR DESCRIPTION
whitelist_externals was removed in tox 4

https://tox--2601.org.readthedocs.build/en/2601/faq.html#tox-4-removed-tox-ini-keys

Signed-off-by: Taylor Madore <tmadore@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] ~New code has type annotations~
- [ ] ~Docs updated (if applicable)~
- [ ] ~Docs links in the code are still valid (if docs were updated)~
- [ ] ~[Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)~
