### PR TITLE
Move checksum-related things to their own module

### DIFF
--- a/cachi2/core/checksum.py
+++ b/cachi2/core/checksum.py
@@ -1,0 +1,49 @@
+import collections
+import hashlib
+import os
+
+from cachi2.core.errors import PackageRejected
+
+ChecksumInfo = collections.namedtuple("ChecksumInfo", "algorithm hexdigest")
+
+
+def verify_checksum(file_path: str, checksum_info: ChecksumInfo, chunk_size: int = 10240):
+    """
+    Verify the checksum of the file at the given path matches the expected checksum info.
+
+    :param str file_path: the path to the file to be verified
+    :param ChecksumInfo checksum_info: the expected checksum information
+    :param int chunk_size: the amount of bytes to read at a time
+    :raise PackageRejected: if the checksum is not as expected or cannot be computed
+    """
+    filename = os.path.basename(file_path)
+
+    try:
+        hasher = hashlib.new(checksum_info.algorithm)
+    except ValueError:
+        known_algorithms = sorted(hashlib.algorithms_guaranteed)
+        msg = (
+            f"Cannot perform checksum on the file {filename}, "
+            f"unknown algorithm: {checksum_info.algorithm}. Known: {', '.join(known_algorithms)}"
+        )
+        raise PackageRejected(msg, solution="Please use one of the known hash algorithms.")
+
+    with open(file_path, "rb") as f:
+        while chunk := f.read(chunk_size):
+            hasher.update(chunk)
+
+    computed_hexdigest = hasher.hexdigest()
+
+    if computed_hexdigest != checksum_info.hexdigest:
+        msg = (
+            f"The file {filename} has an unexpected checksum value, "
+            f"expected {checksum_info.hexdigest} but computed {computed_hexdigest}"
+        )
+        raise PackageRejected(
+            msg,
+            solution=(
+                "Please verify that the specified hash is correct.\n"
+                "Caution is advised; if the hash was previously correct, it means the content "
+                "has changed!"
+            ),
+        )

--- a/cachi2/core/checksum.py
+++ b/cachi2/core/checksum.py
@@ -1,10 +1,15 @@
-import collections
 import hashlib
 import os
+from typing import NamedTuple
 
 from cachi2.core.errors import PackageRejected
 
-ChecksumInfo = collections.namedtuple("ChecksumInfo", "algorithm hexdigest")
+
+class ChecksumInfo(NamedTuple):
+    """A cryptographic algorithm and a hex-encoded checksum calculated by that algorithm."""
+
+    algorithm: str
+    hexdigest: str
 
 
 def verify_checksum(file_path: str, checksum_info: ChecksumInfo, chunk_size: int = 10240):

--- a/cachi2/core/package_managers/general.py
+++ b/cachi2/core/package_managers/general.py
@@ -1,64 +1,12 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
-import collections
-import hashlib
-import os
 import urllib
 
 import requests
 
-from cachi2.core.errors import FetchError, PackageRejected
+from cachi2.core.errors import FetchError
 from cachi2.core.http_requests import SAFE_REQUEST_METHODS, get_requests_session
 
-__all__ = [
-    "verify_checksum",
-    "ChecksumInfo",
-]
-
-ChecksumInfo = collections.namedtuple("ChecksumInfo", "algorithm hexdigest")
-
 pkg_requests_session = get_requests_session(retry_options={"allowed_methods": SAFE_REQUEST_METHODS})
-
-
-def verify_checksum(file_path: str, checksum_info: ChecksumInfo, chunk_size: int = 10240):
-    """
-    Verify the checksum of the file at the given path matches the expected checksum info.
-
-    :param str file_path: the path to the file to be verified
-    :param ChecksumInfo checksum_info: the expected checksum information
-    :param int chunk_size: the amount of bytes to read at a time
-    :raise PackageRejected: if the checksum is not as expected or cannot be computed
-    """
-    filename = os.path.basename(file_path)
-
-    try:
-        hasher = hashlib.new(checksum_info.algorithm)
-    except ValueError:
-        known_algorithms = sorted(hashlib.algorithms_guaranteed)
-        msg = (
-            f"Cannot perform checksum on the file {filename}, "
-            f"unknown algorithm: {checksum_info.algorithm}. Known: {', '.join(known_algorithms)}"
-        )
-        raise PackageRejected(msg, solution="Please use one of the known hash algorithms.")
-
-    with open(file_path, "rb") as f:
-        while chunk := f.read(chunk_size):
-            hasher.update(chunk)
-
-    computed_hexdigest = hasher.hexdigest()
-
-    if computed_hexdigest != checksum_info.hexdigest:
-        msg = (
-            f"The file {filename} has an unexpected checksum value, "
-            f"expected {checksum_info.hexdigest} but computed {computed_hexdigest}"
-        )
-        raise PackageRejected(
-            msg,
-            solution=(
-                "Please verify that the specified hash is correct.\n"
-                "Caution is advised; if the hash was previously correct, it means the content "
-                "has changed!"
-            ),
-        )
 
 
 def download_binary_file(url, download_path, auth=None, insecure=False, chunk_size=8192):

--- a/cachi2/core/package_managers/pip.py
+++ b/cachi2/core/package_managers/pip.py
@@ -17,13 +17,12 @@ import pkg_resources
 import requests
 from packaging.utils import canonicalize_name, canonicalize_version
 
+from cachi2.core.checksum import ChecksumInfo, verify_checksum
 from cachi2.core.errors import FetchError, PackageRejected, UnexpectedFormat, UnsupportedFeature
 from cachi2.core.package_managers.general import (
-    ChecksumInfo,
     download_binary_file,
     extract_git_info,
     pkg_requests_session,
-    verify_checksum,
 )
 from cachi2.core.scm import clone_as_tarball
 

--- a/tests/unit/package_managers/test_general.py
+++ b/tests/unit/package_managers/test_general.py
@@ -4,50 +4,11 @@ from unittest import mock
 import pytest
 import requests
 
-from cachi2.core.errors import FetchError, PackageRejected
+from cachi2.core.errors import FetchError
 from cachi2.core.package_managers import general
-from cachi2.core.package_managers.general import (
-    ChecksumInfo,
-    download_binary_file,
-    pkg_requests_session,
-    verify_checksum,
-)
+from cachi2.core.package_managers.general import download_binary_file, pkg_requests_session
 
 GIT_REF = "9a557920b2a6d4110f838506120904a6fda421a2"
-
-
-def test_verify_checksum(tmpdir):
-    file = tmpdir.join("spells.txt")
-    file.write("Beetlejuice! Beetlejuice! Beetlejuice!")
-
-    expected = {
-        "sha512": (
-            "da518fe8b800b3325fe35ca680085fe37626414d0916937a01a25ef8f5d7aa769b7233073235fce85ee"
-            "c717e02bb9d72062656cf2d79223792a784910c267b54"
-        ),
-        "sha256": "ed1f8cd69bfacf0528744b6a7084f36e8841b6128de0217503e215612a0ee835",
-        "md5": "308764bc995153f7d853827a675e6731",
-    }
-    for algorithm, checksum in expected.items():
-        verify_checksum(str(file), ChecksumInfo(algorithm, checksum))
-
-
-def test_verify_checksum_invalid_hexdigest(tmpdir):
-    file = tmpdir.join("spells.txt")
-    file.write("Beetlejuice! Beetlejuice! Beetlejuice!")
-
-    expected_error = "The file spells.txt has an unexpected checksum value"
-    with pytest.raises(PackageRejected, match=expected_error):
-        verify_checksum(str(file), ChecksumInfo("sha512", "spam"))
-
-
-def test_verify_checksum_unsupported_algorithm(tmpdir):
-    file = tmpdir.join("spells.txt")
-    file.write("Beetlejuice! Beetlejuice! Beetlejuice!")
-
-    expected_error = "Cannot perform checksum on the file spells.txt,.*bacon.*"
-    with pytest.raises(PackageRejected, match=expected_error):
-        verify_checksum(str(file), ChecksumInfo("bacon", "spam"))
 
 
 @pytest.mark.parametrize("auth", [None, ("user", "password")])

--- a/tests/unit/package_managers/test_pip.py
+++ b/tests/unit/package_managers/test_pip.py
@@ -11,6 +11,7 @@ import bs4
 import pytest
 import requests
 
+from cachi2.core.checksum import ChecksumInfo
 from cachi2.core.errors import FetchError, PackageRejected, UnexpectedFormat, UnsupportedFeature
 from cachi2.core.package_managers import general, pip
 from tests.unit.package_managers.helper_utils import write_file_tree
@@ -2958,16 +2959,14 @@ class TestDownload:
         # </check calls that must always be made>
 
         # <check calls to checksum verification method>
-        verify_url_checksum_call = mock.call(
-            str(url_download), general.ChecksumInfo("sha256", "654321")
-        )
+        verify_url_checksum_call = mock.call(str(url_download), ChecksumInfo("sha256", "654321"))
         if use_hashes:
             msg = "At least one dependency uses the --hash option, will require hashes"
             assert msg in caplog.text
 
             verify_checksum_calls = [
-                mock.call(str(pypi_download), general.ChecksumInfo("sha256", "abcdef")),
-                mock.call(str(vcs_download), general.ChecksumInfo("sha256", "123456")),
+                mock.call(str(pypi_download), ChecksumInfo("sha256", "abcdef")),
+                mock.call(str(vcs_download), ChecksumInfo("sha256", "123456")),
                 verify_url_checksum_call,
             ]
         else:
@@ -3050,7 +3049,7 @@ class TestDownload:
             num_calls = num_fails = len(hashes)
 
         calls = [
-            mock.call(str(path), general.ChecksumInfo(*hash_spec.split(":", 1)))
+            mock.call(str(path), ChecksumInfo(*hash_spec.split(":", 1)))
             for hash_spec in hashes[:num_calls]
         ]
         mock_verify_checksum.assert_has_calls(calls)

--- a/tests/unit/test_checksum.py
+++ b/tests/unit/test_checksum.py
@@ -1,0 +1,38 @@
+import pytest
+
+from cachi2.core.checksum import ChecksumInfo, verify_checksum
+from cachi2.core.errors import PackageRejected
+
+
+def test_verify_checksum(tmpdir):
+    file = tmpdir.join("spells.txt")
+    file.write("Beetlejuice! Beetlejuice! Beetlejuice!")
+
+    expected = {
+        "sha512": (
+            "da518fe8b800b3325fe35ca680085fe37626414d0916937a01a25ef8f5d7aa769b7233073235fce85ee"
+            "c717e02bb9d72062656cf2d79223792a784910c267b54"
+        ),
+        "sha256": "ed1f8cd69bfacf0528744b6a7084f36e8841b6128de0217503e215612a0ee835",
+        "md5": "308764bc995153f7d853827a675e6731",
+    }
+    for algorithm, checksum in expected.items():
+        verify_checksum(str(file), ChecksumInfo(algorithm, checksum))
+
+
+def test_verify_checksum_invalid_hexdigest(tmpdir):
+    file = tmpdir.join("spells.txt")
+    file.write("Beetlejuice! Beetlejuice! Beetlejuice!")
+
+    expected_error = "The file spells.txt has an unexpected checksum value"
+    with pytest.raises(PackageRejected, match=expected_error):
+        verify_checksum(str(file), ChecksumInfo("sha512", "spam"))
+
+
+def test_verify_checksum_unsupported_algorithm(tmpdir):
+    file = tmpdir.join("spells.txt")
+    file.write("Beetlejuice! Beetlejuice! Beetlejuice!")
+
+    expected_error = "Cannot perform checksum on the file spells.txt,.*bacon.*"
+    with pytest.raises(PackageRejected, match=expected_error):
+        verify_checksum(str(file), ChecksumInfo("bacon", "spam"))


### PR DESCRIPTION
Clean up the pkg_managers.general module a bit

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- N/A Docs updated (if applicable)
- N/A Docs links in the code are still valid (if docs were updated)
- N/A [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
