### PR TITLE
Added ppc64le support

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -144,20 +144,3 @@ jobs:
           CACHI2_IMAGE: localhost/cachi2:${{ github.sha }}
         run: |
            tox -e integration
-
-     # Authenticate to container image registry to push the image
-      - name: Podman Login
-        uses: redhat-actions/podman-login@v1
-        if: github.ref == 'refs/heads/main'
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_USER }}
-          password: ${{ secrets.QUAY_PWD }}
-
-      - name: Push image to Quay.io registry
-        if: github.ref == 'refs/heads/main'
-        run: |
-          podman push cachi2:${{ github.sha }} \
-            quay.io/containerbuildsystem/cachi2:${{ github.sha }}
-          podman push cachi2:${{ github.sha }} \
-            quay.io/containerbuildsystem/cachi2:latest

--- a/.github/workflows/multi-arch-build.yaml
+++ b/.github/workflows/multi-arch-build.yaml
@@ -1,0 +1,50 @@
+name: Mult-Arch-Build
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-image:
+    name: Build Cachi2 image
+    runs-on: ubuntu-latest
+    steps:
+      - name: add checkout action...
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          
+      - name: Install required packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox tox-gh-actions
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Build Cachi2 image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: cachi2
+          tags: ${{ github.sha }}
+          platforms: linux/amd64,linux/ppc64le
+          containerfiles: |
+            ./Containerfile
+      - name: Check image created and Cachi2 version
+        run: |
+          buildah images | grep 'cachi2'
+          podman run -t cachi2:${{ github.sha }} --version
+     # Authenticate to container image registry to push the image
+      - name: Podman Login
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PWD }}
+
+      - name: Push image to Quay.io registry
+        run: |
+          podman manifest push cachi2:${{ github.sha }} \
+            quay.io/containerbuildsystem/cachi2:${{ github.sha }}
+          podman manifest push cachi2:${{ github.sha }} \
+            quay.io/containerbuildsystem/cachi2:latest


### PR DESCRIPTION
This PR will add ppc64le support to the Cachi2 image.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a Docs updated (if applicable)
- n/a Docs links in the code are still valid (if docs were updated)
- n/a [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
