### PR TITLE
Download PyPI dep archives directly to deps/pip/

### DIFF
--- a/cachi2/core/package_managers/pip.py
+++ b/cachi2/core/package_managers/pip.py
@@ -1543,9 +1543,7 @@ def _download_pypi_package(requirement, pip_deps_dir, pypi_url, pypi_auth=None):
             ),
         )
 
-    package_dir = pip_deps_dir / sdist["name"]
-    package_dir.mkdir(exist_ok=True)
-    download_path = package_dir / sdist["filename"]
+    download_path = pip_deps_dir / sdist["filename"]
 
     # URLs may be absolute or relative, see https://peps.python.org/pep-0503/
     sdist_url = urllib.parse.urljoin(package_url, sdist["url"])

--- a/tests/unit/package_managers/test_pip.py
+++ b/tests/unit/package_managers/test_pip.py
@@ -2385,7 +2385,7 @@ class TestDownload:
             assert download_info == {
                 "package": "aiowsgi",
                 "version": "0.7",
-                "path": tmp_path / "aiowsgi" / "aiowsgi-0.7.tar.gz",
+                "path": tmp_path / "aiowsgi-0.7.tar.gz",
             }
 
             absolute_file_url = "https://pypi-proxy.org/packages/aiowsgi-0.7.tar.gz"
@@ -2913,7 +2913,7 @@ class TestDownload:
 
         pip_deps = tmp_path / "deps" / "pip"
 
-        pypi_download = pip_deps / "foo" / "foo-1.0.tar.gz"
+        pypi_download = pip_deps / "foo-1.0.tar.gz"
         vcs_download = pip_deps.joinpath(
             "github.com",
             "spam",
@@ -2995,7 +2995,7 @@ class TestDownload:
         # <check basic logging output>
         assert f"Downloading {pypi_req.download_line}" in caplog.text
         assert (
-            f"Successfully downloaded {pypi_req.download_line} to deps/pip/foo/foo-1.0.tar.gz"
+            f"Successfully downloaded {pypi_req.download_line} to deps/pip/foo-1.0.tar.gz"
         ) in caplog.text
 
         assert f"Downloading {vcs_req.download_line}" in caplog.text


### PR DESCRIPTION
CLOUDBLD-11107

Do not nest them under `deps/pip/{package_name}/`.

We need to have all the PyPI deps in the same directory so that the piprepo library can build a local index for them.

---

*Side note on filename conflicts.*

Filename conflicts should be impossible. Python sdists follow a naming convention (and since [PEP 625](https://peps.python.org/pep-0625/), there is even a standard) that allows the name and version of the project to be determined from the filename.

Cachi2's code already relies on this convention to find the sdist archive for a given name==version.

The only time a filename conflict should be possible (guaranteed, in fact) is in cases like

- FooBar==1.0.0
- foobar==1

These two dependencies are exactly the same per normalization rules, their filenames must be identical (and in Cachi2, they are).

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- N/A New code has type annotations
- N/A Docs updated (if applicable)
- N/A Docs links in the code are still valid (if docs were updated)
- [x] [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
