### PR TITLE
Enable mypy for tests

### DIFF
--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -58,7 +58,8 @@ class TestPackageInput:
         ],
     )
     def test_valid_packages(self, input_data: dict[str, Any], expect_data: dict[str, Any]):
-        package = pydantic.parse_obj_as(PackageInput, input_data)
+        # doesn't pass type check: https://github.com/pydantic/pydantic/issues/1847
+        package = pydantic.parse_obj_as(PackageInput, input_data)  # type: ignore
         assert package.dict() == expect_data
 
     @pytest.mark.parametrize(
@@ -104,7 +105,8 @@ class TestPackageInput:
     )
     def test_invalid_packages(self, input_data: dict[str, Any], expect_error: str):
         with pytest.raises(pydantic.ValidationError, match=expect_error):
-            pydantic.parse_obj_as(PackageInput, input_data)
+            # doesn't pass type check: https://github.com/pydantic/pydantic/issues/1847
+            pydantic.parse_obj_as(PackageInput, input_data)  # type: ignore
 
 
 class TestRequest:

--- a/tests/unit/package_managers/test_pip.py
+++ b/tests/unit/package_managers/test_pip.py
@@ -3,7 +3,7 @@ import logging
 import re
 from pathlib import Path
 from textwrap import dedent
-from typing import Union
+from typing import Any, Union
 from unittest import mock
 from urllib.parse import urlparse
 
@@ -1207,7 +1207,7 @@ class TestSetupPY:
 class TestPipRequirementsFile:
     """PipRequirementsFile tests."""
 
-    PIP_REQUIREMENT_ATTRS = {
+    PIP_REQUIREMENT_ATTRS: dict[str, Any] = {
         "download_line": None,
         "environment_marker": None,
         "extras": [],

--- a/tox.ini
+++ b/tox.ini
@@ -78,7 +78,7 @@ commands =
 [testenv:mypy]
 commands =
     pip install mypy  # cannot be in deps due requirement of hashes
-    mypy -p cachi2 --install-types --non-interactive
+    mypy --install-types --non-interactive cachi2 tests
 
 [testenv:integration]
 basepython = python3


### PR DESCRIPTION
Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- N/A Docs updated (if applicable)
- N/A Docs links in the code are still valid (if docs were updated)
- N/A [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
