### PR TITLE
Set GOPROXY in the Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,6 +13,8 @@ RUN microdnf -y install \
 
 COPY . .
 
+ENV GOPROXY="https://proxy.golang.org,direct"
+
 RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes && \
     pip3 install --no-cache-dir -e . && \
     # the git folder is only needed to determine the package version


### PR DESCRIPTION
This env variable was defaulting to only "direct", which would make the go command to skip the proxy altogether, resulting in very long download times.

Signed-off-by: Bruno Pimentel <bpimente@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a Docs updated (if applicable)
- n/a Docs links in the code are still valid (if docs were updated)
- n/a [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
