### PR TITLE
Fix the way the GOPROXY variable is set in Cachi2 

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,8 +13,6 @@ RUN microdnf -y install \
 
 COPY . .
 
-ENV GOPROXY="https://proxy.golang.org,direct"
-
 RUN pip3 install -r requirements.txt --no-deps --no-cache-dir --require-hashes && \
     pip3 install --no-cache-dir -e . && \
     # the git folder is only needed to determine the package version

--- a/cachi2/core/config.py
+++ b/cachi2/core/config.py
@@ -10,7 +10,7 @@ class Config:
     All values currently need to be changed in this file.
     """
 
-    cachito_athens_url = None
+    cachito_goproxy_url = "https://proxy.golang.org,direct"
     cachito_default_environment_variables = {
         "gomod": {"GOSUMDB": {"value": "off", "kind": "literal"}},
     }

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -173,9 +173,8 @@ def _resolve_gomod(path: Path, request: Request, git_dir_path=None):
             "GOMODCACHE": "{}/pkg/mod".format(temp_dir),
         }
 
-        if worker_config.cachito_athens_url:
-            athens_url = worker_config.cachito_athens_url
-            env["GOPROXY"] = f"{athens_url}|{athens_url}"
+        if worker_config.cachito_goproxy_url:
+            env["GOPROXY"] = worker_config.cachito_goproxy_url
 
         if "cgo-disable" in request.flags:
             env["CGO_ENABLED"] = "0"


### PR DESCRIPTION
It was previously being set on the image environment, which makes the Python subprocess that is used to call "go mod download" to not pick it up.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a Docs updated (if applicable)
- n/a Docs links in the code are still valid (if docs were updated)
- n/a [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
