### PR TITLE
Fix how we merge package manager outputs

### DIFF
--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -1,5 +1,4 @@
 from collections.abc import Iterable
-from itertools import chain
 from typing import Callable
 
 from cachi2.core.errors import UnsupportedFeature
@@ -33,6 +32,9 @@ def resolve_packages(request: Request) -> RequestOutput:
 
 def _merge_outputs(outputs: Iterable[RequestOutput]) -> RequestOutput:
     """Merge RequestOutput instances."""
-    packages = list(chain.from_iterable(o.packages for o in outputs))
-    env_vars = list(chain.from_iterable(o.environment_variables for o in outputs))
+    packages = []
+    env_vars = []
+    for output in outputs:
+        packages.extend(output.packages)
+        env_vars.extend(output.environment_variables)
     return RequestOutput(packages=packages, environment_variables=env_vars)

--- a/tests/integration/test_data/gomod_with_deps/output.json
+++ b/tests/integration/test_data/gomod_with_deps/output.json
@@ -257,5 +257,26 @@
       ]
     }
   ],
-  "environment_variables": []
+  "environment_variables": [
+    {
+      "name": "GOCACHE",
+      "value": "deps/gomod",
+      "kind": "path"
+    },
+    {
+      "name": "GOMODCACHE",
+      "value": "deps/gomod/pkg/mod",
+      "kind": "path"
+    },
+    {
+      "name": "GOPATH",
+      "value": "deps/gomod",
+      "kind": "path"
+    },
+    {
+      "name": "GOSUMDB",
+      "value": "off",
+      "kind": "literal"
+    }
+  ]
 }


### PR DESCRIPTION
There was a bug where the output returned from resolve_packages could
never contain any environment variables.
    
The argument to the merge_outputs function is an Iterable. An Iterable
may be consumed by iterating it (generators, iterators). If the
iterable does get consumed while collecting the packages list, the
env_vars list will always be empty.
    
Fix the issue and update unit tests to catch it in the future.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- N/A New code has type annotations
- N/A Docs updated (if applicable)
- N/A Docs links in the code are still valid (if docs were updated)
- N/A [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
