### PR TITLE
Add Make build command for integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ venv:
 	venv/bin/pip install tox
 	venv/bin/pip install -e .
 
+test-integration:
+	podman build -t cachi2-${USER} .
+	CACHI2_IMAGE=localhost/cachi2-${USER}:latest tox -e integration
+
 test:
 	PATH="${PWD}/venv/bin:${PATH}" tox
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,27 @@ tox -e python3.9 -- tests/unit/extras/test_envfile.py::test_cannot_determine_for
 
 In short, tox passes all arguments to the right of `--` directly to pytest.
 
+### Running integration tests
+
+Build Cachi2 image and run all integration tests (but no other checks):
+
+```shell
+make test-integration
+```
+
+To run integration-tests with custom image, specify the CACHI2_IMAGE environment variable. Examples:
+
+```shell
+CACHI2_IMAGE=quay.io/containerbuildsystem/cachi2:{tag} tox -e integration
+CACHI2_IMAGE=localhost/cachi2-${USER}:latest tox -e integration
+```
+
+Similarly to unit tests, for finer control over which tests get executed, e.g. to run only 1 specific test case, execute:
+
+```shell
+CACHI2_IMAGE=localhost/cachi2-${USER}:latest tox -e integration -- tests/integration/test_package_managers.py::test_packages[gomod_without_deps]
+```
+
 ## Package managers
 
 Supported:


### PR DESCRIPTION
Support local integration testing with Makefile build command

Signed-off-by: Ladislav Kolacek <lkolacek@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- [x] Docs updated (if applicable)
- n/a Docs links in the code are still valid (if docs were updated)
- n/a [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
