### PR TITLE
Don't use live logging in unit tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -88,14 +88,12 @@ skip_install = true
 commands =
     pytest -rA -vvvv \
         --confcutdir=tests/integration \
+        --log-cli-level=DEBUG \
         {posargs:tests/integration}
 passenv = CACHI2_IMAGE
 
 [pytest]
-addopts = --capture=no
 testpaths = tests
-log_cli = True
-log_level = DEBUG
 log_format = %(asctime)s %(levelname)s %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
 env =


### PR DESCRIPTION
The log_cli option makes pytest live-log everything: https://docs.pytest.org/en/7.1.x/how-to/logging.html#live-logs

In unit tests, that generates a lot of unwanted noise. Use live logging only for integration tests with --log-cli-level=DEBUG.

Also drop the --capture=no and log_level options, which are no longer needed.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] ~Code coverage from testing does not decrease and new code is covered~
- [ ] ~New code has type annotations~
- [ ] ~Docs updated (if applicable)~
- [ ] ~Docs links in the code are still valid (if docs were updated)~
