### PR TITLE
Refactor external requirement filepath generation

### DIFF
--- a/tests/unit/package_managers/test_pip.py
+++ b/tests/unit/package_managers/test_pip.py
@@ -3195,19 +3195,21 @@ def test_get_absolute_pkg_file_paths(tmp_path):
 @pytest.mark.parametrize(
     "component_kind, url",
     (
-        ["vcs", f"git+https://www.github.com/cachito/mypkg.git@{'f'*40}?egg=mypkg"],
+        ["vcs", f"git+https://github.com/cachito/mypkg.git@{'f'*40}?egg=mypkg"],
         ["url", "https://files.cachito.rocks/mypkg.tar.gz"],
     ),
 )
-def test_get_external_requirement_filename(component_kind, url):
+def test_get_external_requirement_filepath(component_kind, url):
     requirement = mock.Mock(
         kind=component_kind, url=url, package="package", hashes=["sha256:noRealHash"]
     )
-    raw_component = pip._get_external_requirement_filename(requirement)
+    filepath = pip._get_external_requirement_filepath(requirement)
     if component_kind == "url":
-        assert raw_component == "package-external-sha256-noRealHash.tar.gz"
+        assert filepath == Path("external-package", "package-external-sha256-noRealHash.tar.gz")
     elif component_kind == "vcs":
-        assert raw_component == f"mypkg-external-gitcommit-{'f'*40}.tar.gz"
+        assert filepath == Path(
+            "github.com", "cachito", "mypkg", f"mypkg-external-gitcommit-{'f'*40}.tar.gz"
+        )
     else:
         assert False
 


### PR DESCRIPTION
CLOUDBLD-11107

We had a weird split where the directory path was generated inline in the _download_X_package functions and the filename was generated by a separate function.

Generate the whole file path in the separate function.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [ ] ~Docs updated (if applicable)~
- [ ] ~Docs links in the code are still valid (if docs were updated)~
- [ ] ~[Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)~
