### PR TITLE
Add gomod vendored integration test without flags

### DIFF
--- a/cachi2/core/config.py
+++ b/cachi2/core/config.py
@@ -16,7 +16,7 @@ class Config:
     }
     cachito_gomod_download_max_tries = 5
     cachito_gomod_file_deps_allowlist: Dict[str, Dict[str, str]] = {}
-    cachito_gomod_strict_vendor = False
+    cachito_gomod_strict_vendor = True
     cachito_subprocess_timeout = 3600
 
 

--- a/tests/integration/test_package_managers.py
+++ b/tests/integration/test_package_managers.py
@@ -39,6 +39,17 @@ log = logging.getLogger(__name__)
             ),
             id="gomod_without_deps",
         ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/gomod-vendored.git",
+                ref="ff1960095dd158d3d2a4f31d15b244c24930248b",
+                packages=({"path": ".", "type": "gomod"},),
+                expected_rc=2,
+                expected_output='The "gomod-vendor" or "gomod-vendor-check" flag'
+                " must be set when your repository has vendored dependencies",
+            ),
+            id="gomod_vendored_without_flag",
+        ),
     ],
 )
 def test_packages(


### PR DESCRIPTION
Test case is supposed to fail without gomod-vendor flags when a repository with vendor directory is provided.

CLOUDBLD-12625

Signed-off-by: Ladislav Kolacek <lkolacek@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a Docs updated (if applicable)
- n/a Docs links in the code are still valid (if docs were updated)
- n/a [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
