### PR TITLE
Remove OSBS2 breaking changes tracker from PR checklist

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -5,4 +5,3 @@
 - [ ] New code has type annotations
 - [ ] Docs updated (if applicable)
 - [ ] Docs links in the code are still valid (if docs were updated)
-- [ ] [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)


### PR DESCRIPTION
The team decided it was not longer worth the effort of keeping this list up to date.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
- [ ] [Issue](https://github.com/containerbuildsystem/cachi2/issues/13) that tracks breaking changes to the OSBS2 integration is updated (if applicable)
