### PR TITLE
Add 'dev' attribute for dependencies

### DIFF
--- a/cachi2/core/models/output.py
+++ b/cachi2/core/models/output.py
@@ -16,6 +16,7 @@ class Dependency(pydantic.BaseModel):
     type: PackageType
     name: str
     version: Optional[str]  # go-package stdlib dependencies are allowed not to have versions
+    dev: Optional[bool] = None
 
     @pydantic.validator("version")
     def _check_version_vs_type(cls, version: Optional[str], values: dict) -> Optional[str]:

--- a/tests/integration/test_data/gomod_vendor_check_correct_vendor/output.json
+++ b/tests/integration/test_data/gomod_vendor_check_correct_vendor/output.json
@@ -9,227 +9,272 @@
         {
           "type": "go-package",
           "name": "bytes",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "errors",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "fmt",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "golang.org/x/text/internal/tag",
-          "version": "v0.0.0-20170915032832-14c0d48ead0c"
+          "version": "v0.0.0-20170915032832-14c0d48ead0c",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "golang.org/x/text/language",
-          "version": "v0.0.0-20170915032832-14c0d48ead0c"
+          "version": "v0.0.0-20170915032832-14c0d48ead0c",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/abi",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/bytealg",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/cpu",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/fmtsort",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/goarch",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/goexperiment",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/goos",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/itoa",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/oserror",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/poll",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/race",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/reflectlite",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/syscall/execenv",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/syscall/unix",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/testlog",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/unsafeheader",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "io",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "io/fs",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "math",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "math/bits",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "os",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "path",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "reflect",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "rsc.io/quote",
-          "version": "v1.5.2"
+          "version": "v1.5.2",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "rsc.io/sampler",
-          "version": "v1.3.0"
+          "version": "v1.3.0",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/atomic",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/math",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/sys",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/syscall",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "sort",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "strconv",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "strings",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "sync",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "sync/atomic",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "syscall",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "time",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "unicode",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "unicode/utf8",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "unsafe",
-          "version": null
+          "version": null,
+          "dev": null
         }
       ]
     },
@@ -242,17 +287,20 @@
         {
           "type": "gomod",
           "name": "golang.org/x/text",
-          "version": "v0.0.0-20170915032832-14c0d48ead0c"
+          "version": "v0.0.0-20170915032832-14c0d48ead0c",
+          "dev": null
         },
         {
           "type": "gomod",
           "name": "rsc.io/quote",
-          "version": "v1.5.2"
+          "version": "v1.5.2",
+          "dev": null
         },
         {
           "type": "gomod",
           "name": "rsc.io/sampler",
-          "version": "v1.3.0"
+          "version": "v1.3.0",
+          "dev": null
         }
       ]
     }

--- a/tests/integration/test_data/gomod_vendor_check_no_vendor/output.json
+++ b/tests/integration/test_data/gomod_vendor_check_no_vendor/output.json
@@ -9,227 +9,272 @@
         {
           "type": "go-package",
           "name": "bytes",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "errors",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "fmt",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "golang.org/x/text/internal/tag",
-          "version": "v0.0.0-20170915032832-14c0d48ead0c"
+          "version": "v0.0.0-20170915032832-14c0d48ead0c",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "golang.org/x/text/language",
-          "version": "v0.0.0-20170915032832-14c0d48ead0c"
+          "version": "v0.0.0-20170915032832-14c0d48ead0c",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/abi",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/bytealg",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/cpu",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/fmtsort",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/goarch",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/goexperiment",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/goos",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/itoa",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/oserror",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/poll",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/race",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/reflectlite",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/syscall/execenv",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/syscall/unix",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/testlog",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/unsafeheader",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "io",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "io/fs",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "math",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "math/bits",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "os",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "path",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "reflect",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "rsc.io/quote",
-          "version": "v1.5.2"
+          "version": "v1.5.2",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "rsc.io/sampler",
-          "version": "v1.3.0"
+          "version": "v1.3.0",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/atomic",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/math",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/sys",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/syscall",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "sort",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "strconv",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "strings",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "sync",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "sync/atomic",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "syscall",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "time",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "unicode",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "unicode/utf8",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "unsafe",
-          "version": null
+          "version": null,
+          "dev": null
         }
       ]
     },
@@ -242,17 +287,20 @@
         {
           "type": "gomod",
           "name": "golang.org/x/text",
-          "version": "v0.0.0-20170915032832-14c0d48ead0c"
+          "version": "v0.0.0-20170915032832-14c0d48ead0c",
+          "dev": null
         },
         {
           "type": "gomod",
           "name": "rsc.io/quote",
-          "version": "v1.5.2"
+          "version": "v1.5.2",
+          "dev": null
         },
         {
           "type": "gomod",
           "name": "rsc.io/sampler",
-          "version": "v1.3.0"
+          "version": "v1.3.0",
+          "dev": null
         }
       ]
     }

--- a/tests/integration/test_data/gomod_vendored_with_flag/output.json
+++ b/tests/integration/test_data/gomod_vendored_with_flag/output.json
@@ -9,227 +9,272 @@
         {
           "type": "go-package",
           "name": "bytes",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "errors",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "fmt",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "golang.org/x/text/internal/tag",
-          "version": "v0.0.0-20170915032832-14c0d48ead0c"
+          "version": "v0.0.0-20170915032832-14c0d48ead0c",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "golang.org/x/text/language",
-          "version": "v0.0.0-20170915032832-14c0d48ead0c"
+          "version": "v0.0.0-20170915032832-14c0d48ead0c",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/abi",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/bytealg",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/cpu",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/fmtsort",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/goarch",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/goexperiment",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/goos",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/itoa",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/oserror",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/poll",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/race",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/reflectlite",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/syscall/execenv",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/syscall/unix",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/testlog",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/unsafeheader",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "io",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "io/fs",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "math",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "math/bits",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "os",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "path",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "reflect",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "rsc.io/quote",
-          "version": "v1.5.2"
+          "version": "v1.5.2",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "rsc.io/sampler",
-          "version": "v1.3.0"
+          "version": "v1.3.0",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/atomic",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/math",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/sys",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/syscall",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "sort",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "strconv",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "strings",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "sync",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "sync/atomic",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "syscall",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "time",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "unicode",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "unicode/utf8",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "unsafe",
-          "version": null
+          "version": null,
+          "dev": null
         }
       ]
     },
@@ -242,17 +287,20 @@
         {
           "type": "gomod",
           "name": "golang.org/x/text",
-          "version": "v0.0.0-20170915032832-14c0d48ead0c"
+          "version": "v0.0.0-20170915032832-14c0d48ead0c",
+          "dev": null
         },
         {
           "type": "gomod",
           "name": "rsc.io/quote",
-          "version": "v1.5.2"
+          "version": "v1.5.2",
+          "dev": null
         },
         {
           "type": "gomod",
           "name": "rsc.io/sampler",
-          "version": "v1.3.0"
+          "version": "v1.3.0",
+          "dev": null
         }
       ]
     }

--- a/tests/integration/test_data/gomod_with_deps/output.json
+++ b/tests/integration/test_data/gomod_with_deps/output.json
@@ -9,227 +9,272 @@
         {
           "type": "go-package",
           "name": "bytes",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "errors",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "fmt",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "golang.org/x/text/internal/tag",
-          "version": "v0.0.0-20170915032832-14c0d48ead0c"
+          "version": "v0.0.0-20170915032832-14c0d48ead0c",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "golang.org/x/text/language",
-          "version": "v0.0.0-20170915032832-14c0d48ead0c"
+          "version": "v0.0.0-20170915032832-14c0d48ead0c",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/abi",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/bytealg",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/cpu",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/fmtsort",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/goarch",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/goexperiment",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/goos",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/itoa",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/oserror",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/poll",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/race",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/reflectlite",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/syscall/execenv",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/syscall/unix",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/testlog",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "internal/unsafeheader",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "io",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "io/fs",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "math",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "math/bits",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "os",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "path",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "reflect",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "rsc.io/quote",
-          "version": "v1.5.2"
+          "version": "v1.5.2",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "rsc.io/sampler",
-          "version": "v1.3.0"
+          "version": "v1.3.0",
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/atomic",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/math",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/sys",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "runtime/internal/syscall",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "sort",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "strconv",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "strings",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "sync",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "sync/atomic",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "syscall",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "time",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "unicode",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "unicode/utf8",
-          "version": null
+          "version": null,
+          "dev": null
         },
         {
           "type": "go-package",
           "name": "unsafe",
-          "version": null
+          "version": null,
+          "dev": null
         }
       ]
     },
@@ -242,17 +287,20 @@
         {
           "type": "gomod",
           "name": "golang.org/x/text",
-          "version": "v0.0.0-20170915032832-14c0d48ead0c"
+          "version": "v0.0.0-20170915032832-14c0d48ead0c",
+          "dev": null
         },
         {
           "type": "gomod",
           "name": "rsc.io/quote",
-          "version": "v1.5.2"
+          "version": "v1.5.2",
+          "dev": null
         },
         {
           "type": "gomod",
           "name": "rsc.io/sampler",
-          "version": "v1.3.0"
+          "version": "v1.3.0",
+          "dev": null
         }
       ]
     }

--- a/tests/unit/models/test_output.py
+++ b/tests/unit/models/test_output.py
@@ -21,11 +21,18 @@ class TestDependency:
         [
             {"type": "gomod", "name": "github.com/org/cool-dep", "version": "v1.0.0"},
             {"type": "go-package", "name": "fmt", "version": None},
+            {"type": "pip", "name": "poetry", "version": "1.3.1", "dev": True},
+            {"type": "pip", "name": "requests", "version": "2.27.1", "dev": False},
         ],
     )
     def test_valid_deps(self, input_data: dict[str, Any]):
         dep = Dependency.parse_obj(input_data)
-        assert dep.dict() == input_data
+
+        for attr, value in input_data.items():
+            assert getattr(dep, attr) == value
+
+        if "dev" not in input_data:
+            assert dep.dev is None
 
     @pytest.mark.parametrize(
         "input_data, expect_error",

--- a/tests/unit/package_managers/test_pip.py
+++ b/tests/unit/package_managers/test_pip.py
@@ -3390,9 +3390,8 @@ def test_fetch_pip_source(
         "type": "pip",
         "path": Path("."),
         "dependencies": [
-            # TODO: add 'dev' attribute for non-gomod dependencies
-            {"name": "bar", "version": "https://x.org/bar.zip", "type": "pip"},  # "dev": False},
-            {"name": "baz", "version": "0.0.5", "type": "pip"},  # "dev": True},
+            {"name": "bar", "version": "https://x.org/bar.zip", "type": "pip", "dev": False},
+            {"name": "baz", "version": "0.0.5", "type": "pip", "dev": True},
         ],
     }
     expect_package_b = {
@@ -3401,8 +3400,8 @@ def test_fetch_pip_source(
         "type": "pip",
         "path": Path("foo"),
         "dependencies": [
-            {"name": "eggs", "version": "https://x.org/eggs.zip", "type": "pip"},  # "dev": False},
-            {"name": "ham", "version": "3.2", "type": "pip"},  # "dev": False},
+            {"name": "eggs", "version": "https://x.org/eggs.zip", "type": "pip", "dev": False},
+            {"name": "ham", "version": "3.2", "type": "pip", "dev": False},
         ],
     }
 


### PR DESCRIPTION
To indicate whether a dependency is used at runtime or only for development / while building the app.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
