### PR TITLE
Allows the CLI to parse packages and flags using a single parameter

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -137,7 +137,7 @@ jobs:
             fetch-deps \
             --source /tmp/source \
             --output ./cachi2-output \
-            --package '{"path": ".", "type": "gomod"}'
+            '{"path": ".", "type": "gomod"}'
 
       - name: Run integration tests on built image
         env:

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ and nowhere else.
 cachi2 fetch-deps \
   --source ./my-repo \
   --output ./cachi2-output \
-  --package gomod
+  gomod
 ```
 
 The `fetch-deps` command fetches your project's dependencies and stores them on your disk. You can then use these

--- a/docs/gomod.md
+++ b/docs/gomod.md
@@ -15,8 +15,7 @@
 cachi2 fetch-deps \
   --source ./my-repo \
   --output ./cachi2-output \
-  --package '<module-1 JSON>' \
-  --package '<module-2 JSON>'
+  '<modules JSON>'
 ```
 
 Module[^misnomer] JSON:
@@ -30,9 +29,9 @@ Module[^misnomer] JSON:
 }
 ```
 
-The `--package` argument accepts alternative forms of input, see [usage: pre-fetch-dependencies][usage-prefetch].
+The main argument accepts alternative forms of input, see [usage: pre-fetch-dependencies][usage-prefetch].
 
-[^misnomer]: You may have noticed a slight naming issue. You use the `--package` argument to specify a *module* to
+[^misnomer]: You may have noticed a slight naming issue. You use the main argument, also called PKG, to specify a *module* to
   process. Even worse, Go has packages as well (see [gomod vs go-package](#gomod-vs-go-package)). What gives?
   As far as we know, most languages/package managers use the opposite naming. For example, in [Python][py-modules],
   modules are `*.py` files, packages are collections of modules. In [npm][npm-modules], modules are directories/files

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,22 +17,24 @@ The best way to run `cachi2` is via the [container image](../README.md#container
 cachi2 fetch-deps \
   --source ./fzf \
   --output ./cachi2-output \
-  --package '{"path": ".", "type": "gomod"}'
+  '{"path": ".", "type": "gomod"}'
 ```
 
 * `--source` - the path to a *git repository* on the local disk
 * `--output` - the path to the directory where Cachi2 will write all output
-* `--package` - specifies a *package* (a directory) within the repository to process
+* `{JSON}`      - specifies a *package* (a directory) within the repository to process
 
 Note that Cachi2 does not auto-detect which package managers your project uses. You need to tell Cachi2 what to process
-using the `--package` parameter. In the example above, the package is a go module located at the root of the fzf repo,
+when calling fetch-deps. In the example above, the package is a go module located at the root of the fzf repo,
 hence the relative path is `.`.
 
-The `--package` parameter can be used more than once and accepts alternative forms of input:
+The main parameter (PKG) can handle different types of definitions:
 
-* simple: `--package=gomod`, same as `{"path": ".", "type": "gomod"}`
+* simple: `gomod`, same as `{"path": ".", "type": "gomod"}`
 * JSON object: `{"path": "subpath/to/other/module", "type": "gomod"}`
 * JSON array: `[{"path": ".", "type": "gomod"}, {"path": "subpath/to/other/module", "type": "gomod"}]`
+* JSON object with flags: 
+`{"packages": [{"path": ".", "type": "gomod"}], "flags": ["gomod-vendor"]}`
 
 See also `cachi2 fetch-deps --help`.
 

--- a/hack/test_gomod.sh
+++ b/hack/test_gomod.sh
@@ -5,4 +5,4 @@ git clone git@github.com:release-engineering/retrodep workdir/sources
 ./venv/bin/cachi2 fetch-deps \
     --source workdir/sources \
     --output workdir/output \
-    --package gomod
+    gomod

--- a/hack/test_pip.sh
+++ b/hack/test_pip.sh
@@ -14,4 +14,4 @@ popd
 venv/bin/cachi2 fetch-deps \
     --source workdir/cachito-pip-with-deps \
     --output workdir/pip-output \
-    --package pip
+    pip

--- a/tests/integration/test_package_managers.py
+++ b/tests/integration/test_package_managers.py
@@ -122,8 +122,7 @@ def test_packages(
     if test_params.flags:
         cmd += test_params.flags
 
-    for package in test_params.packages:
-        cmd += ["--package", json.dumps(package).encode("utf-8")]
+    cmd.append(json.dumps(test_params.packages).encode("utf-8"))
 
     (output, rc) = cachi2_image.run_cmd_on_image(cmd, tmpdir)
     assert rc == test_params.expected_rc, (


### PR DESCRIPTION
To help handling the parameters in Stone Soup pipelines, we need to allow both packages and flags to be set in a single parameter. 

Instead of keeping the current `package` and `flags` parameters, they are being merged into a single Typer argument that will cover both use cases, as follow: 

```
cachi2 fetch-deps gomod
cachi2 fetch-deps '{"type": "gomod"}'
cachi2 fetch-deps '[{"type": "gomod"}, {"type": "pip"}]'
cachi2 fetch-deps '{"packages": [{"type": "gomod"}], "flags": ["gomod-vendor"]}'
cachi2 fetch-deps gomod --gomod-vendor
```

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [x] Docs updated (if applicable)
- [x] Docs links in the code are still valid (if docs were updated)
