### PR TITLE
Fix integration test data

### DIFF
--- a/tests/integration/test_data/gomod_vendor_check_correct_vendor/output.json
+++ b/tests/integration/test_data/gomod_vendor_check_correct_vendor/output.json
@@ -93,6 +93,11 @@
         },
         {
           "type": "go-package",
+          "name": "internal/safefilepath",
+          "version": null
+        },
+        {
+          "type": "go-package",
           "name": "internal/syscall/execenv",
           "version": null
         },

--- a/tests/integration/test_data/gomod_vendor_check_no_vendor/output.json
+++ b/tests/integration/test_data/gomod_vendor_check_no_vendor/output.json
@@ -93,6 +93,11 @@
         },
         {
           "type": "go-package",
+          "name": "internal/safefilepath",
+          "version": null
+        },
+        {
+          "type": "go-package",
           "name": "internal/syscall/execenv",
           "version": null
         },

--- a/tests/integration/test_data/gomod_vendored_with_flag/output.json
+++ b/tests/integration/test_data/gomod_vendored_with_flag/output.json
@@ -93,6 +93,11 @@
         },
         {
           "type": "go-package",
+          "name": "internal/safefilepath",
+          "version": null
+        },
+        {
+          "type": "go-package",
           "name": "internal/syscall/execenv",
           "version": null
         },

--- a/tests/integration/test_data/gomod_with_deps/output.json
+++ b/tests/integration/test_data/gomod_with_deps/output.json
@@ -93,6 +93,11 @@
         },
         {
           "type": "go-package",
+          "name": "internal/safefilepath",
+          "version": null
+        },
+        {
+          "type": "go-package",
           "name": "internal/syscall/execenv",
           "version": null
         },


### PR DESCRIPTION
With the bump of Golang from 1.18.8 to 1.18.9. there was a small change in the reported internal packages.

Signed-off-by: Bruno Pimentel <bpimente@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
