### PR TITLE
Require that a request specifies at least one valid package

### DIFF
--- a/cachi2/core/models/input.py
+++ b/cachi2/core/models/input.py
@@ -132,6 +132,13 @@ class Request(pydantic.BaseModel):
                 )
         return package
 
+    @pydantic.validator("packages")
+    def _packages_not_empty(cls, packages: list[PackageInput]) -> list[PackageInput]:
+        """Check that the packages list is not empty."""
+        if len(packages) == 0:
+            raise ValueError("at least one package must be defined, got an empty list")
+        return packages
+
     @property
     def gomod_packages(self) -> list[GomodPackageInput]:
         """Get the gomod packages specified for this request."""

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -200,3 +200,12 @@ class TestRequest:
                 packages=[],
                 flags=["no-such-flag"],
             )
+
+    def test_empty_packages(self):
+        expect_error = r"packages\n  at least one package must be defined, got an empty list"
+        with pytest.raises(pydantic.ValidationError, match=expect_error):
+            Request(
+                source_dir="/source",
+                output_dir="/output",
+                packages=[],
+            )

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1570,7 +1570,6 @@ def test_dep_replacements(
 @pytest.mark.parametrize(
     "gomod_input_packages, packages_output",
     (
-        ([], []),
         (
             [{"type": "gomod", "path": "."}],
             [

--- a/tests/unit/package_managers/test_pip.py
+++ b/tests/unit/package_managers/test_pip.py
@@ -3295,7 +3295,6 @@ def test_replace_external_requirements(
 @pytest.mark.parametrize(
     "packages, n_pip_packages",
     [
-        ([], 0),
         ([{"type": "gomod"}], 0),
         ([{"type": "pip", "requirements_files": ["requirements.txt"]}], 1),
         (


### PR DESCRIPTION
Previously, it was possible to successfully call fetch-deps passing a empty list:

```sh
# will now throw a validation error
cachi2 fetch-deps "[]"
```

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- n/a Docs updated (if applicable)
- n/a Docs links in the code are still valid (if docs were updated)
