### PR TITLE
Don't fail-fast linters

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -63,6 +63,7 @@ jobs:
   linters:
     name: Linters
     strategy:
+      fail-fast: false
       matrix:
         tox_env:
           - bandit


### PR DESCRIPTION
By default, when one job from a `matrix` fails, the others get cancelled. For linters, this is not what you want.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
