### PR TITLE
Update to fedora-37, python-3.11, and go-1.19

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.9"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:36
+FROM registry.fedoraproject.org/fedora-minimal:37
 LABEL maintainer="Red Hat"
 
 WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ original Cachito.*
 
 <https://go.dev/ref/mod>
 
-Current version: 1.18 [^go-version] [^go-compat]
+Current version: 1.19 [^go-version] [^go-compat]
 
 The gomod package manager works by parsing the [go.mod](https://go.dev/ref/mod#go-mod-file) file present in the source
 repository to determine which dependencies to download. Cachi2 does not parse this file on its own - rather, we rely on

--- a/cachi2/core/extras/envfile.py
+++ b/cachi2/core/extras/envfile.py
@@ -35,8 +35,8 @@ class EnvFormat(str, Enum):
     @classmethod
     def _suffixes_repr(cls) -> str:
         return ", ".join(
-            f"{suffix}[=={fmt}]" if suffix != fmt else suffix
-            for suffix, fmt in cls.__members__.items()
+            f"{name}[=={member.value}]" if name != member.value else name
+            for name, member in cls.__members__.items()
         )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
 ]
 requires-python = ">=3.9"
 dependencies = [

--- a/tests/integration/test_data/gomod_e2e_test/output.json
+++ b/tests/integration/test_data/gomod_e2e_test/output.json
@@ -73,32 +73,47 @@
         },
         {
           "type": "go-package",
-          "name": "crypto/ed25519/internal/edwards25519",
-          "version": null
-        },
-        {
-          "type": "go-package",
-          "name": "crypto/ed25519/internal/edwards25519/field",
-          "version": null
-        },
-        {
-          "type": "go-package",
           "name": "crypto/elliptic",
           "version": null
         },
         {
           "type": "go-package",
-          "name": "crypto/elliptic/internal/fiat",
-          "version": null
-        },
-        {
-          "type": "go-package",
-          "name": "crypto/elliptic/internal/nistec",
-          "version": null
-        },
-        {
-          "type": "go-package",
           "name": "crypto/hmac",
+          "version": null
+        },
+        {
+          "type": "go-package",
+          "name": "crypto/internal/boring",
+          "version": null
+        },
+        {
+          "type": "go-package",
+          "name": "crypto/internal/boring/bbig",
+          "version": null
+        },
+        {
+          "type": "go-package",
+          "name": "crypto/internal/boring/sig",
+          "version": null
+        },
+        {
+          "type": "go-package",
+          "name": "crypto/internal/edwards25519",
+          "version": null
+        },
+        {
+          "type": "go-package",
+          "name": "crypto/internal/edwards25519/field",
+          "version": null
+        },
+        {
+          "type": "go-package",
+          "name": "crypto/internal/nistec",
+          "version": null
+        },
+        {
+          "type": "go-package",
+          "name": "crypto/internal/nistec/fiat",
           "version": null
         },
         {
@@ -273,6 +288,11 @@
         },
         {
           "type": "go-package",
+          "name": "go/doc/comment",
+          "version": null
+        },
+        {
+          "type": "go-package",
           "name": "go/internal/typeparams",
           "version": null
         },
@@ -329,11 +349,6 @@
         {
           "type": "go-package",
           "name": "internal/cpu",
-          "version": null
-        },
-        {
-          "type": "go-package",
-          "name": "internal/execabs",
           "version": null
         },
         {

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = bandit,black,isort,flake8,mypy,python3.9,python3.10
+envlist = bandit,black,isort,flake8,mypy,python3.9,python3.10,python3.11
 
 [gh-actions]
 python =
     3.9: python3.9
     3.10: python3.10
+    3.11: python3.11
 
 [testenv]
 deps =


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a New code has type annotations
- n/a Docs updated (if applicable)
- n/a Docs links in the code are still valid (if docs were updated)
