### PR TITLE
fix pip-e2e integration test for fedora-37

### DIFF
--- a/tests/integration/test_pip.py
+++ b/tests/integration/test_pip.py
@@ -114,7 +114,7 @@ def test_pip_packages(
                 expected_output="All dependencies fetched successfully",
             ),
             ["python3", "/opt/test_package_cachi2"],
-            "registry.fedoraproject.org/fedora-minimal:36",
+            "registry.fedoraproject.org/fedora-minimal:37",
             id="pip_e2e_test",
         ),
     ],


### PR DESCRIPTION
STONEBLD-469

I missed this in the original PR because I had forgotten that the pip-e2e integration test checks the parent image of the cachi2 image on the main branch of the project:
https://github.com/cachito-testing/pip-e2e-test/blob/6cef447b2aa237235fd6698a67d2f08290b0eaea/src/test_package_cachi2/main.py#L13-L14

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
