### PR TITLE
Bump pip-e2e-test repo revision

### DIFF
--- a/tests/integration/test_pip.py
+++ b/tests/integration/test_pip.py
@@ -101,7 +101,7 @@ def test_pip_packages(
         pytest.param(
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/pip-e2e-test.git",
-                ref="03939ea78542c7cbfe7a86c5a4133612813e9ec6",
+                ref="bae083d57dc265a899b59859b769e88eb8319404",
                 packages=(
                     {
                         "type": "pip",


### PR DESCRIPTION
The new revision pins the url of the tested Containerfile, so the expected output will no longer change when we update the parent image in our Containerfile.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- N/A Code coverage from testing does not decrease and new code is covered
- N/A New code has type annotations
- N/A Docs updated (if applicable)
- N/A Docs links in the code are still valid (if docs were updated)
