### PR TITLE
Temporarily ignore bandit's warning about timeouts

### DIFF
--- a/cachi2/core/package_managers/general.py
+++ b/cachi2/core/package_managers/general.py
@@ -21,7 +21,9 @@ def download_binary_file(url, download_path, auth=None, insecure=False, chunk_si
     :raise FetchError: If download failed
     """
     try:
-        resp = pkg_requests_session.get(url, stream=True, verify=not insecure, auth=auth)
+        resp = pkg_requests_session.get(
+            url, stream=True, verify=not insecure, auth=auth
+        )  # nosec request_without_timeout
         resp.raise_for_status()
     except requests.RequestException as e:
         raise FetchError(f"Could not download {url}: {e}")

--- a/cachi2/core/package_managers/pip.py
+++ b/cachi2/core/package_managers/pip.py
@@ -1535,7 +1535,9 @@ def _download_pypi_package(requirement, pip_deps_dir, pypi_url, pypi_auth=None):
     # See https://www.python.org/dev/peps/pep-0503/
     package_url = f"{pypi_url.rstrip('/')}/simple/{canonicalize_name(package)}/"
     try:
-        pypi_resp = pkg_requests_session.get(package_url, auth=pypi_auth)
+        pypi_resp = pkg_requests_session.get(
+            package_url, auth=pypi_auth
+        )  # nosec request_without_timeout
         pypi_resp.raise_for_status()
     except requests.RequestException as e:
         raise FetchError(f"PyPI query failed: {e}")


### PR DESCRIPTION
Bandit 1.7.5 adds a warning about using requests without setting a timeout.

In the near future, we should fix it by having a configurable timeout.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
