### PR TITLE
Set python version for dependabot

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,0 +1,3 @@
+# Strictly a dependabot hack, nothing to do with Heroku.
+# https://github.com/dependabot/dependabot-core/issues/4062
+python-3.9


### PR DESCRIPTION
Dependabot keeps thinking we only use python 3.11 and removing dependencies that we still need.

Set python version for dependabot via runtime.txt, which seems to be the least intrusive out of the config files which dependabot respects.

See https://github.com/dependabot/dependabot-core/issues/4062

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
