### PR TITLE
Add Tekton pipeline definitions to enable builds in RHTAP

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -1,0 +1,33 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: cachi2-on-pull-request
+  annotations:
+    build.appstudio.redhat.com/commit_sha: "{{revision}}"
+    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
+    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+spec:
+  params:
+    - name: git-url
+      value: "{{repo_url}}"
+    - name: revision
+      value: "{{revision}}"
+    - name: output-image
+      value: "quay.io/redhat-appstudio/pull-request-builds:rhtap-build-cachi2-{{revision}}"
+    - name: dockerfile
+      value: Containerfile
+  pipelineRef:
+    name: docker-build
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -1,0 +1,32 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: cachi2-on-push
+  annotations:
+    build.appstudio.redhat.com/commit_sha: "{{revision}}"
+    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+spec:
+  params:
+    - name: git-url
+      value: "{{repo_url}}"
+    - name: revision
+      value: "{{revision}}"
+    - name: output-image
+      value: "quay.io/redhat-appstudio/cachi2:{{revision}}"
+    - name: dockerfile
+      value: Containerfile
+  pipelineRef:
+    name: docker-build
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi

--- a/.tekton/tag-latest.yaml
+++ b/.tekton/tag-latest.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: cachi2-on-tag-latest
+  annotations:
+    build.appstudio.redhat.com/commit_sha: "{{revision}}"
+    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-event: "[push]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+spec:
+  params:
+    - name: revision
+      value: "{{revision}}"
+  pipelineSpec:
+    params:
+      - name: revision
+    tasks:
+      - name: tag-with-latest
+        params:
+          - name: revision
+            value: "$(params.revision)"
+        timeout: "15m"
+        taskSpec:
+          params:
+            - name: revision
+          steps:
+            - name: tag-with-latest
+              image: registry.access.redhat.com/ubi9/skopeo:latest@sha256:23c9ed4af1f42614bdc56309452568b2110a67f23102f42f6a6582a63b63dcdb
+              script: |
+                #!/usr/bin/env bash
+                SRC_REF="quay.io/redhat-appstudio/cachi2:$(params.revision)"
+                TARGET_REF="quay.io/redhat-appstudio/cachi2:latest"
+
+                echo "Waiting until ${SRC_REF} is pushed"
+
+                while ! skopeo inspect --no-tags docker://${SRC_REF} >/dev/null 2>&1; do
+                  echo -n .
+                  sleep 3
+                done
+
+                echo
+                echo "${SRC_REF} has been pushed, copying to ${TARGET_REF}"
+
+                skopeo copy "docker://${SRC_REF}" "docker://${TARGET_REF}"


### PR DESCRIPTION
This PR enables image builds through the RHTAP pipeline. The change is meant to leverage the exitisting security scanners that are available in RHTAP, making Cachi2 compliant to the Enterprise Contract policies.

Images will now be pushed to quay.io/redhat-appstudio/cachi2.

The follow up PR, #111, proposes the complete removal of the current multi-arch build pipeline.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
