### PR TITLE
test: can I haz custom script in pipeline?

### DIFF
--- a/.tekton/acmiel-evil-test.yaml
+++ b/.tekton/acmiel-evil-test.yaml
@@ -1,0 +1,34 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: acmiel-evil-test
+  annotations:
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+    pipelinesascode.tekton.dev/on-target-branch: "[main]"
+    pipelinesascode.tekton.dev/max-keep-runs: "1"
+spec:
+  pipelineSpec:
+    tasks:
+      - name: do-a-thing
+        taskSpec:
+          steps:
+            - name: do-that-thing
+              image: registry.redhat.io/openshift4/ose-cli:v4.12
+              script: |
+                set -o xtrace
+                # ls -R -la $HOME
+                # ls -R -la /tekton
+                # ls -R -la /run
+
+                oc whoami
+                # oc get secrets
+                oc get secrets -o json >/dev/null
+  workspaces:
+    - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
