### PR TITLE
Add type hints to parts of the pip code and tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "flake8-docstrings",
     "isort[colors]",
     "mypy",
+    "typing-extensions",
 ]
 test = [
     "GitPython",

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -417,6 +417,7 @@ typing-extensions==4.3.0 \
     --hash=sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6
     # via
     #   black
+    #   cachi2 (pyproject.toml)
     #   mypy
     #   pydantic
 urllib3==1.26.15 \


### PR DESCRIPTION
Involves minor refactoring here and there, but no functional changes.

Also add 'typing-extensions' to dev dependencies so that we can make use of typing features not available in python 3.9 (such as TypeGuard).

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
