### PR TITLE
Fix gomod SBOM generation

### DIFF
--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -102,18 +102,16 @@ def fetch_gomod_source(request: Request) -> RequestOutput:
                 log.error("Failed to fetch gomod dependencies")
                 raise
 
-            module_info = gomod["module"]
-
-            components.append(Component(name=module_info["name"], version=module_info["version"]))
-
+            components.append(Component.from_package_dict(gomod["module"]))
+            components.extend(
+                Component.from_package_dict(module_dep) for module_dep in gomod["module_deps"]
+            )
             # add package deps
             for package in gomod["packages"]:
-                pkg_info = package["pkg"]
-
-                components.append(Component.from_package_dict(pkg_info))
-
-                for dependency in package.get("pkg_deps", []):
-                    components.append(Component.from_package_dict(dependency))
+                components.append(Component.from_package_dict(package["pkg"]))
+                components.extend(
+                    Component.from_package_dict(pkg_dep) for pkg_dep in package["pkg_deps"]
+                )
 
         if "gomod-vendor-check" not in request.flags and "gomod-vendor" not in request.flags:
             tmp_download_cache_dir = Path(tmp_dir).joinpath(request.go_mod_cache_download_part)

--- a/tests/integration/test_data/gomod_e2e_multiple_modules/bom.json
+++ b/tests/integration/test_data/gomod_e2e_multiple_modules/bom.json
@@ -39,6 +39,11 @@
       "version": "v0.0.0-20170915032832-14c0d48ead0c"
     },
     {
+      "name": "golang.org/x/text",
+      "type": "library",
+      "version": "v0.0.0-20170915032832-14c0d48ead0c"
+    },
+    {
       "name": "internal/abi",
       "type": "library"
     },

--- a/tests/integration/test_data/gomod_e2e_test/bom.json
+++ b/tests/integration/test_data/gomod_e2e_test/bom.json
@@ -195,6 +195,21 @@
       "version": "v1.4.2"
     },
     {
+      "name": "github.com/kr/pretty",
+      "type": "library",
+      "version": "v0.1.0"
+    },
+    {
+      "name": "github.com/kr/pty",
+      "type": "library",
+      "version": "v1.1.1"
+    },
+    {
+      "name": "github.com/kr/text",
+      "type": "library",
+      "version": "v0.1.0"
+    },
+    {
       "name": "github.com/op/go-logging",
       "type": "library",
       "version": "v0.0.0-20160315200505-970db520ece7"
@@ -256,9 +271,39 @@
       "type": "library"
     },
     {
+      "name": "golang.org/x/crypto",
+      "type": "library",
+      "version": "v0.0.0-20190308221718-c2843e01d9a2"
+    },
+    {
+      "name": "golang.org/x/net",
+      "type": "library",
+      "version": "v0.0.0-20190311183353-d8887717615a"
+    },
+    {
+      "name": "golang.org/x/sys",
+      "type": "library",
+      "version": "v0.0.0-20190215142949-d0b11bdaac8a"
+    },
+    {
+      "name": "golang.org/x/text",
+      "type": "library",
+      "version": "v0.3.0"
+    },
+    {
       "name": "golang.org/x/tools/go/vcs",
       "type": "library",
       "version": "v0.0.0-20190325161752-5a8dccf5b48a"
+    },
+    {
+      "name": "golang.org/x/tools",
+      "type": "library",
+      "version": "v0.0.0-20190325161752-5a8dccf5b48a"
+    },
+    {
+      "name": "gopkg.in/check.v1",
+      "type": "library",
+      "version": "v1.0.0-20180628173108-788fd7840127"
     },
     {
       "name": "gopkg.in/yaml.v2",

--- a/tests/integration/test_data/gomod_vendor_check_correct_vendor/bom.json
+++ b/tests/integration/test_data/gomod_vendor_check_correct_vendor/bom.json
@@ -29,6 +29,11 @@
       "version": "v0.0.0-20170915032832-14c0d48ead0c"
     },
     {
+      "name": "golang.org/x/text",
+      "type": "library",
+      "version": "v0.0.0-20170915032832-14c0d48ead0c"
+    },
+    {
       "name": "internal/abi",
       "type": "library"
     },

--- a/tests/integration/test_data/gomod_vendor_check_no_vendor/bom.json
+++ b/tests/integration/test_data/gomod_vendor_check_no_vendor/bom.json
@@ -29,6 +29,11 @@
       "version": "v0.0.0-20170915032832-14c0d48ead0c"
     },
     {
+      "name": "golang.org/x/text",
+      "type": "library",
+      "version": "v0.0.0-20170915032832-14c0d48ead0c"
+    },
+    {
       "name": "internal/abi",
       "type": "library"
     },

--- a/tests/integration/test_data/gomod_vendored_with_flag/bom.json
+++ b/tests/integration/test_data/gomod_vendored_with_flag/bom.json
@@ -29,6 +29,11 @@
       "version": "v0.0.0-20170915032832-14c0d48ead0c"
     },
     {
+      "name": "golang.org/x/text",
+      "type": "library",
+      "version": "v0.0.0-20170915032832-14c0d48ead0c"
+    },
+    {
       "name": "internal/abi",
       "type": "library"
     },

--- a/tests/integration/test_data/gomod_with_deps/bom.json
+++ b/tests/integration/test_data/gomod_with_deps/bom.json
@@ -29,6 +29,11 @@
       "version": "v0.0.0-20170915032832-14c0d48ead0c"
     },
     {
+      "name": "golang.org/x/text",
+      "type": "library",
+      "version": "v0.0.0-20170915032832-14c0d48ead0c"
+    },
+    {
       "name": "internal/abi",
       "type": "library"
     },


### PR DESCRIPTION
The code currently reports only package deps, not module deps. Report
modules as well.

Simplify the mocking of the fetch_gomod_source test and make sure it tests this case.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
