### PR TITLE
Add container image labels required by the Enterprise Contract

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,19 @@
 FROM registry.fedoraproject.org/fedora-minimal:37
+LABEL name="Cachi2" \
+      vendor="RHTAP Build Team" \
+      maintainer="container-build-guild@redhat.com" \
+      release="1" \
+      build-date=$BUILD_DATE \
+      description="CLI tool for prefetching build dependencies" \
+      url="https://github.com/containerbuildsystem/cachi2" \
+      distribution-scope="public" \
+      io.k8s.description="CLI tool for prefetching build dependencies" \
+      io.k8s.display-name="Cachi2" \
+      vcs-ref=$GIT_ID \
+      vcs-type=git \
+      architecture=$TARGETARCH \
+      com.redhat.component="rhtap-build-cachi2"
+
 LABEL maintainer="Red Hat"
 
 WORKDIR /src


### PR DESCRIPTION
This makes the [label-check ](https://github.com/redhat-appstudio/build-definitions/blob/main/task/label-check/0.1/label-check.yaml)pipeline step [succeed](https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/k8s/ns/tekton-ci/tekton.dev~v1beta1~PipelineRun/cachi2-on-pull-request-jtlfx/logs/label-check). Note that the pipeline proceeds even if this step fails. 




# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
