### PR TITLE
fix npm integration test refs

### DIFF
--- a/tests/integration/test_npm.py
+++ b/tests/integration/test_npm.py
@@ -16,7 +16,7 @@ log = logging.getLogger(__name__)
         pytest.param(
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/npm-cachi2-smoketest.git",
-                ref="cb56134a2543ba56c303b4cd8e7c174cef9de4ea",
+                ref="4baf3d58db432752aa63156597b28a7e775fd862",
                 packages=({"path": ".", "type": "npm"},),
             ),
             id="npm_smoketest_lockfile1",
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
         pytest.param(
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/npm-cachi2-smoketest.git",
-                ref="4baf3d58db432752aa63156597b28a7e775fd862",
+                ref="cb56134a2543ba56c303b4cd8e7c174cef9de4ea",
                 packages=({"path": ".", "type": "npm"},),
             ),
             id="npm_smoketest_lockfile3",


### PR DESCRIPTION
The refs for v1 and v3 lockfiles were transposed

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
