### PR TITLE
Speed up tests that use `git commit`

### DIFF
--- a/tests/unit/package_managers/conftest.py
+++ b/tests/unit/package_managers/conftest.py
@@ -193,10 +193,10 @@ def fake_repo():
         r.git.config("user.email", "tester@localhost")
         open(os.path.join(repo_dir, "readme.rst"), "w").close()
         r.index.add(["readme.rst"])
-        r.index.commit("first commit")
+        r.index.commit("first commit", skip_hooks=True)
         open(os.path.join(repo_dir, "main.py"), "w").close()
         r.index.add(["main.py"])
-        r.index.commit("add main source")
+        r.index.commit("add main source", skip_hooks=True)
         yield repo_dir, repo_dir.lstrip("/")
 
 

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1058,7 +1058,7 @@ def test_vendor_changed(subpath, vendor_before, vendor_changes, expected_change,
 
     write_file_tree(vendor_before, app_dir)
     repo.index.add(os.path.join(app_dir, path) for path in vendor_before)
-    repo.index.commit("before vendoring")
+    repo.index.commit("before vendoring", skip_hooks=True)
 
     write_file_tree(vendor_changes, app_dir, exist_ok=True)
 


### PR DESCRIPTION
Skip commit hooks when creating fake repos for testing. Some commit
hooks may be quite slow and result in, say, quadrupling the time taken
to run the entire test suite.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] New code has type annotations
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)
