### PR TITLE
toil(bandit): silence request_without_timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ if the `vendor` directory exists and this config option is set to `True`, one of
 [vendoring flags](gomod.md#vendoring) must be used.
 * `goproxy_url` - sets the value of the GOPROXY variable that Cachi2 uses internally
 when downloading Go modules. See [Go environment variables](https://go.dev/ref/mod#environment-variables).
+* `requests_timeout` - a number (in seconds) for `requests.get()`'s 'timeout' parameter,
+  which sets an upper limit on how long `requests` can take to make a connection and/or send a response.
+  Larger numbers set longer timeouts.
 * `subprocess_timeout` - a number (in seconds) to set a timeout for commands executed by
   the `subprocess` module. Set a larger number to give the subprocess execution more time.
 

--- a/cachi2/core/config.py
+++ b/cachi2/core/config.py
@@ -18,6 +18,7 @@ class Config(BaseModel, extra="forbid"):
     gomod_download_max_tries: int = 5
     gomod_strict_vendor: bool = True
     subprocess_timeout: int = 3600
+    requests_timeout: int = 45
 
 
 def get_config() -> Config:

--- a/cachi2/core/package_managers/general.py
+++ b/cachi2/core/package_managers/general.py
@@ -3,6 +3,7 @@ import urllib
 
 import requests
 
+from cachi2.core.config import get_config
 from cachi2.core.errors import FetchError
 from cachi2.core.http_requests import SAFE_REQUEST_METHODS, get_requests_session
 
@@ -20,10 +21,11 @@ def download_binary_file(url, download_path, auth=None, insecure=False, chunk_si
     :param int chunk_size: Chunk size param for Response.iter_content()
     :raise FetchError: If download failed
     """
+    timeout = get_config().requests_timeout
     try:
         resp = pkg_requests_session.get(
-            url, stream=True, verify=not insecure, auth=auth
-        )  # nosec request_without_timeout
+            url, stream=True, verify=not insecure, auth=auth, timeout=timeout
+        )
         resp.raise_for_status()
     except requests.RequestException as e:
         raise FetchError(f"Could not download {url}: {e}")

--- a/cachi2/core/package_managers/pip.py
+++ b/cachi2/core/package_managers/pip.py
@@ -25,6 +25,7 @@ import requests
 from packaging.utils import canonicalize_name, canonicalize_version
 
 from cachi2.core.checksum import ChecksumInfo, must_match_any_checksum
+from cachi2.core.config import get_config
 from cachi2.core.errors import FetchError, PackageRejected, UnexpectedFormat, UnsupportedFeature
 from cachi2.core.models.input import Request
 from cachi2.core.models.output import Component, EnvironmentVariable, ProjectFile, RequestOutput
@@ -1496,15 +1497,14 @@ def _download_pypi_package(requirement, pip_deps_dir, pypi_url, pypi_auth=None):
     :raises FetchError: if PyPI query failed
     :raises PackageRejected: if sdists for the package is not found or yanked
     """
+    timeout = get_config().requests_timeout
     package = requirement.package
     version = requirement.version_specs[0][1]
 
     # See https://www.python.org/dev/peps/pep-0503/
     package_url = f"{pypi_url.rstrip('/')}/simple/{canonicalize_name(package)}/"
     try:
-        pypi_resp = pkg_requests_session.get(
-            package_url, auth=pypi_auth
-        )  # nosec request_without_timeout
+        pypi_resp = pkg_requests_session.get(package_url, auth=pypi_auth, timeout=timeout)
         pypi_resp.raise_for_status()
     except requests.RequestException as e:
         raise FetchError(f"PyPI query failed: {e}")

--- a/tests/unit/package_managers/test_general.py
+++ b/tests/unit/package_managers/test_general.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 import requests
 
+from cachi2.core.config import get_config
 from cachi2.core.errors import FetchError
 from cachi2.core.package_managers import general
 from cachi2.core.package_managers.general import download_binary_file, pkg_requests_session
@@ -16,6 +17,7 @@ GIT_REF = "9a557920b2a6d4110f838506120904a6fda421a2"
 @pytest.mark.parametrize("chunk_size", [1024, 2048])
 @mock.patch.object(pkg_requests_session, "get")
 def test_download_binary_file(mock_get, auth, insecure, chunk_size, tmpdir):
+    timeout = get_config().requests_timeout
     url = "http://example.org/example.tar.gz"
     content = b"file content"
 
@@ -28,7 +30,7 @@ def test_download_binary_file(mock_get, auth, insecure, chunk_size, tmpdir):
     )
 
     assert download_path.read_binary() == content
-    mock_get.assert_called_with(url, stream=True, auth=auth, verify=not insecure)
+    mock_get.assert_called_with(url, stream=True, verify=not insecure, auth=auth, timeout=timeout)
     mock_response.iter_content.assert_called_with(chunk_size=chunk_size)
 
 

--- a/tests/unit/package_managers/test_pip.py
+++ b/tests/unit/package_managers/test_pip.py
@@ -12,6 +12,7 @@ import pytest
 import requests
 
 from cachi2.core.checksum import ChecksumInfo
+from cachi2.core.config import get_config
 from cachi2.core.errors import (
     Cachi2Error,
     FetchError,
@@ -2468,6 +2469,7 @@ class TestDownload:
         rooted_tmp_path,
     ):
         """Test downloading of a single PyPI package."""
+        timeout = get_config().requests_timeout
         mock_requirement = self.mock_requirement(
             package_name, "pypi", version_specs=[("==", "0.7")]
         )
@@ -2515,7 +2517,7 @@ class TestDownload:
             assert str(exc_info.value) == expect_error
 
         mock_get.assert_called_once_with(
-            "https://pypi-proxy.org/simple/aiowsgi/", auth=("user", "password")
+            "https://pypi-proxy.org/simple/aiowsgi/", auth=("user", "password"), timeout=timeout
         )
 
     def test_process_package_links(self):


### PR DESCRIPTION
https://issues.redhat.com/browse/STONEBLD-941

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- N/A New code has type annotations
- [x] Docs updated (if applicable)
- [x] Docs links in the code are still valid (if docs were updated)
