### PR TITLE
Build the cachi2 image in GH actions with podman

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - name: Install required packages
         run: |
-          dnf install -y python python-pip buildah git podman
+          dnf install -y python python-pip git podman
           python -m pip install --upgrade pip
           pip install tox tox-gh-actions
 
@@ -122,17 +122,12 @@ jobs:
           fetch-depth: 0
 
       - name: Build Cachi2 image
-        uses: redhat-actions/buildah-build@v2
-        with:
-          image: cachi2
-          tags: ${{ github.sha }}
-          arch: amd64
-          containerfiles: |
-            ./Containerfile
+        run: |
+          podman build -t cachi2:${{ github.sha }} .
 
       - name: Check image created and Cachi2 version
         run: |
-          buildah images | grep 'cachi2'
+          podman images | grep 'cachi2'
           podman run -t cachi2:${{ github.sha }} --version
 
       - name: Run integration tests on built image


### PR DESCRIPTION
After building the cachi2 image with buildah, `podman run` somehow stops
working.

```
$ podman run -t cachi2:${{ github.sha }} --version
...
time="2023-05-31T11:24:06Z" level=warning msg="Failed to add conmon to cgroupfs sandbox cgroup: creating cgroup path /libpod_parent/conmon: write /sys/fs/cgroup/cgroup.subtree_control: operation not supported"
Error: OCI runtime error: crun: the requested cgroup controller `pids` is not available
```

This doesn't happen when building the image with podman. It also doesn't
happen when building a different image with buildah. It is the specific
combination of `buildah bud` + the cachi2 Containerfile that somehow
breaks podman afterwards.

Use podman build instead of buildah to avoid this issue.

Note: based on further testing, it seems that buildah breaks podman if
the Containerfile has any RUN instruction.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
