### PR TITLE
Implement unified way to generate `vcs_url` for the main package purl

### DIFF
--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -34,6 +34,7 @@ from cachi2.core.errors import FetchError, GoModError, PackageRejected, Unexpect
 from cachi2.core.models.input import Request
 from cachi2.core.models.output import Component, EnvironmentVariable, RequestOutput
 from cachi2.core.rooted_path import PathOutsideRoot, RootedPath
+from cachi2.core.scm import get_repo_id
 from cachi2.core.utils import load_json_stream, run_cmd
 
 log = logging.getLogger(__name__)
@@ -393,15 +394,8 @@ def _get_repository_name(source_dir: RootedPath) -> str:
 
     The name is a treated form of the URL, after stripping the scheme, user and .git extension.
     """
-    repo = git.Repo(source_dir)
-    url = repo.remote().url
-
-    # strip scheme and ssh user
-    path = re.sub(r"^(https|ssh)?(:\/\/)?(git@)?", "", url)
-    # strip trailing .git
-    path = re.sub(r"\.git$", "", path)
-    # change colon from ssh urls into slash
-    return path.replace(":", "/")
+    url = get_repo_id(source_dir).parsed_origin_url
+    return f"{url.hostname}{url.path.rstrip('/').removesuffix('.git')}"
 
 
 def _protect_against_symlinks(app_dir: RootedPath) -> None:

--- a/cachi2/core/scm.py
+++ b/cachi2/core/scm.py
@@ -26,6 +26,13 @@ class RepoID(NamedTuple):
         """Get the url as a urllib.parse.SplitResult."""
         return urllib.parse.urlsplit(self.origin_url)
 
+    def as_vcs_url_qualifier(self) -> str:
+        """Turn this RepoID into a 'vcs_url' qualifier as defined by the purl spec.
+
+        See https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst#known-qualifiers-keyvalue-pairs
+        """
+        return f"git+{self.origin_url}@{self.commit_id}"
+
 
 def get_repo_id(repo: Union[str, PathLike[str], Repo]) -> RepoID:
     """Get the RepoID for a git.Repo object or a git directory.

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1342,22 +1342,22 @@ def test_fetch_gomod_source(
 @pytest.mark.parametrize(
     "input_url",
     (
-        "ssh://git@github.com:cachito-testing/gomod-pandemonium",
+        "ssh://github.com/cachito-testing/gomod-pandemonium",
+        "ssh://username@github.com/cachito-testing/gomod-pandemonium",
+        "github.com:cachito-testing/gomod-pandemonium.git",
+        "username@github.com:cachito-testing/gomod-pandemonium.git/",
         "https://github.com/cachito-testing/gomod-pandemonium",
-        "git@github.com:cachito-testing/gomod-pandemonium.git",
+        "https://github.com/cachito-testing/gomod-pandemonium.git",
+        "https://github.com/cachito-testing/gomod-pandemonium.git/",
     ),
 )
-@mock.patch("cachi2.core.package_managers.gomod.git.Repo")
+@mock.patch("cachi2.core.scm.Repo")
 def test_get_repository_name(mock_git_repo: Any, input_url: str) -> None:
     expected_url = "github.com/cachito-testing/gomod-pandemonium"
 
-    def mock_remote() -> Any:
-        mocked_origin = mock.Mock()
-        mocked_origin.url = input_url
-        return mocked_origin
-
     mocked_repo = mock.Mock()
-    mocked_repo.remote.side_effect = mock_remote
+    mocked_repo.remote.return_value.url = input_url
+    mocked_repo.head.commit.hexsha = "f" * 40
     mock_git_repo.return_value = mocked_repo
 
     resolved_url = _get_repository_name(RootedPath("/my-folder/cloned-repo"))

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -8,7 +8,7 @@ import pytest
 from git.repo import Repo
 
 from cachi2.core.errors import FetchError, UnsupportedFeature
-from cachi2.core.scm import clone_as_tarball, get_repo_id
+from cachi2.core.scm import RepoID, clone_as_tarball, get_repo_id
 
 INITIAL_COMMIT = "78510c591e2be635b010a52a7048b562bad855a3"
 
@@ -56,6 +56,12 @@ class TestRepoID:
             match="cannot process repositories that don't have an 'origin' remote",
         ):
             get_repo_id(golang_repo_path)
+
+    def test_as_vcs_url_qualifier(self) -> None:
+        origin_url = "ssh://git@github.com/foo/bar.git"
+        commit_id = "abcdef1234"
+        expect_vcs_url = "git+ssh://git@github.com/foo/bar.git@abcdef1234"
+        assert RepoID(origin_url, commit_id).as_vcs_url_qualifier() == expect_vcs_url
 
 
 def test_clone_as_tarball(golang_repo_path: Path, tmp_path: Path) -> None:


### PR DESCRIPTION
In preparation for the npm (and also pip) purl implementation

This should make it easier to generate purls for the main packages (which should use `vcs_url` qualifiers)

Also use this mechanism for gomod (when getting the repo name for the source dir)

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)
