### PR TITLE
Implement purls for npm packages

### DIFF
--- a/cachi2/core/models/output.py
+++ b/cachi2/core/models/output.py
@@ -58,7 +58,11 @@ class Component(pydantic.BaseModel):
 
         A Cachi2 package has extra fields which are unnecessary and can cause validation errors.
         """
-        return Component(name=package.get("name", None), version=package.get("version", None))
+        return Component(
+            name=package.get("name", None),
+            version=package.get("version", None),
+            purl=package.get("purl", None),
+        )
 
 
 class Sbom(pydantic.BaseModel):

--- a/cachi2/core/package_managers/npm.py
+++ b/cachi2/core/package_managers/npm.py
@@ -255,8 +255,8 @@ class _Purlifier:
 
         url = urlparse(resolved_url)
         if url.scheme in ("github", "gitlab", "bitbucket"):
-            # TODO normalize
-            pass
+            resolved_url = _update_vcs_url_with_full_hostname(resolved_url)
+            url = urlparse(resolved_url)
 
         if url.hostname == "registry.npmjs.org":
             pass
@@ -301,7 +301,7 @@ def _update_vcs_url_with_full_hostname(vcs: str) -> str:
     namespace_repo, _, ref = path.partition("#")
     suffix_domain = "org" if host == "bitbucket" else "com"
 
-    vcs = f"git+ssh://{host}.{suffix_domain}/{namespace_repo}.git"
+    vcs = f"git+ssh://git@{host}.{suffix_domain}/{namespace_repo}.git"
     if ref:
         vcs = f"{vcs}#{ref}"
     return vcs

--- a/tests/integration/test_data/npm_smoketest_lockfile1/bom.json
+++ b/tests/integration/test_data/npm_smoketest_lockfile1/bom.json
@@ -72,7 +72,7 @@
     },
     {
       "name": "cachito-npm-without-deps",
-      "purl": "pkg:npm/cachito-npm-without-deps?download_url=https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
+      "purl": "pkg:npm/cachito-npm-without-deps?checksum=sha512:43e71f90ad5f9eb349ab18a283f8954994def373962ddc61b866bdea4d48249e67913c6b84dca1e8c519e981ca1fcc62b438292104a88ee9ed72db76a41efede&download_url=https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
       "type": "library"
     },
     {

--- a/tests/integration/test_data/npm_smoketest_lockfile1/bom.json
+++ b/tests/integration/test_data/npm_smoketest_lockfile1/bom.json
@@ -3,382 +3,460 @@
   "components": [
     {
       "name": "@types/prop-types",
+      "purl": "pkg:npm/%40types/prop-types@15.7.5",
       "type": "library",
       "version": "15.7.5"
     },
     {
       "name": "@types/react-dom",
+      "purl": "pkg:npm/%40types/react-dom@18.0.11",
       "type": "library",
       "version": "18.0.11"
     },
     {
       "name": "@types/react",
+      "purl": "pkg:npm/%40types/react@18.0.35",
       "type": "library",
       "version": "18.0.35"
     },
     {
       "name": "@types/scheduler",
+      "purl": "pkg:npm/%40types/scheduler@0.16.3",
       "type": "library",
       "version": "0.16.3"
     },
     {
       "name": "abbrev",
+      "purl": "pkg:npm/abbrev@2.0.0",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "accepts",
+      "purl": "pkg:npm/accepts@1.3.8",
       "type": "library",
       "version": "1.3.8"
     },
     {
       "name": "array-flatten",
+      "purl": "pkg:npm/array-flatten@1.1.1",
       "type": "library",
       "version": "1.1.1"
     },
     {
       "name": "bar",
+      "purl": "pkg:npm/bar?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40e5bd11ca3a7aacd81aa195275d679d954848c71c#bar",
       "type": "library"
     },
     {
       "name": "bitbucket-cachi2-npm-without-deps-second",
+      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps-second?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps-second.git%4009992d418fc44a2895b7a9ff27c4e32d6f74a982",
       "type": "library"
     },
     {
       "name": "bitbucket-cachi2-npm-without-deps",
+      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps.git%409e164b97043a2d91bbeb992f6cc68a3d1015086a",
       "type": "library"
     },
     {
       "name": "body-parser",
+      "purl": "pkg:npm/body-parser@1.20.1",
       "type": "library",
       "version": "1.20.1"
     },
     {
       "name": "bytes",
+      "purl": "pkg:npm/bytes@3.1.2",
       "type": "library",
       "version": "3.1.2"
     },
     {
       "name": "cachito-npm-without-deps",
+      "purl": "pkg:npm/cachito-npm-without-deps?download_url=https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
       "type": "library"
     },
     {
       "name": "call-bind",
+      "purl": "pkg:npm/call-bind@1.0.2",
       "type": "library",
       "version": "1.0.2"
     },
     {
       "name": "classnames",
+      "purl": "pkg:npm/classnames@2.3.2",
       "type": "library",
       "version": "2.3.2"
     },
     {
       "name": "colors",
+      "purl": "pkg:npm/colors@1.4.0",
       "type": "library",
       "version": "1.4.0"
     },
     {
       "name": "content-disposition",
+      "purl": "pkg:npm/content-disposition@0.5.4",
       "type": "library",
       "version": "0.5.4"
     },
     {
       "name": "content-type",
+      "purl": "pkg:npm/content-type@1.0.5",
       "type": "library",
       "version": "1.0.5"
     },
     {
       "name": "cookie-signature",
+      "purl": "pkg:npm/cookie-signature@1.0.6",
       "type": "library",
       "version": "1.0.6"
     },
     {
       "name": "cookie",
+      "purl": "pkg:npm/cookie@0.5.0",
       "type": "library",
       "version": "0.5.0"
     },
     {
       "name": "csstype",
+      "purl": "pkg:npm/csstype@3.1.2",
       "type": "library",
       "version": "3.1.2"
     },
     {
       "name": "dateformat",
+      "purl": "pkg:npm/dateformat@5.0.3",
       "type": "library",
       "version": "5.0.3"
     },
     {
       "name": "debug",
+      "purl": "pkg:npm/debug@2.6.9",
       "type": "library",
       "version": "2.6.9"
     },
     {
       "name": "depd",
+      "purl": "pkg:npm/depd@2.0.0",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "destroy",
+      "purl": "pkg:npm/destroy@1.2.0",
       "type": "library",
       "version": "1.2.0"
     },
     {
       "name": "ee-first",
+      "purl": "pkg:npm/ee-first@1.1.1",
       "type": "library",
       "version": "1.1.1"
     },
     {
       "name": "eggs",
+      "purl": "pkg:npm/eggs?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40e5bd11ca3a7aacd81aa195275d679d954848c71c#eggs-packages/eggs",
       "type": "library"
     },
     {
       "name": "encodeurl",
+      "purl": "pkg:npm/encodeurl@1.0.2",
       "type": "library",
       "version": "1.0.2"
     },
     {
       "name": "escape-html",
+      "purl": "pkg:npm/escape-html@1.0.3",
       "type": "library",
       "version": "1.0.3"
     },
     {
       "name": "etag",
+      "purl": "pkg:npm/etag@1.8.1",
       "type": "library",
       "version": "1.8.1"
     },
     {
       "name": "express",
+      "purl": "pkg:npm/express@4.18.2",
       "type": "library",
       "version": "4.18.2"
     },
     {
       "name": "finalhandler",
+      "purl": "pkg:npm/finalhandler@1.2.0",
       "type": "library",
       "version": "1.2.0"
     },
     {
       "name": "foo",
+      "purl": "pkg:npm/foo?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40e5bd11ca3a7aacd81aa195275d679d954848c71c#foo",
       "type": "library"
     },
     {
       "name": "forwarded",
+      "purl": "pkg:npm/forwarded@0.2.0",
       "type": "library",
       "version": "0.2.0"
     },
     {
       "name": "fresh",
+      "purl": "pkg:npm/fresh@0.5.2",
       "type": "library",
       "version": "0.5.2"
     },
     {
       "name": "function-bind",
+      "purl": "pkg:npm/function-bind@1.1.1",
       "type": "library",
       "version": "1.1.1"
     },
     {
       "name": "get-intrinsic",
+      "purl": "pkg:npm/get-intrinsic@1.2.0",
       "type": "library",
       "version": "1.2.0"
     },
     {
       "name": "has-symbols",
+      "purl": "pkg:npm/has-symbols@1.0.3",
       "type": "library",
       "version": "1.0.3"
     },
     {
       "name": "has",
+      "purl": "pkg:npm/has@1.0.3",
       "type": "library",
       "version": "1.0.3"
     },
     {
       "name": "http-errors",
+      "purl": "pkg:npm/http-errors@2.0.0",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "iconv-lite",
+      "purl": "pkg:npm/iconv-lite@0.4.24",
       "type": "library",
       "version": "0.4.24"
     },
     {
       "name": "inherits",
+      "purl": "pkg:npm/inherits@2.0.4",
       "type": "library",
       "version": "2.0.4"
     },
     {
       "name": "ipaddr.js",
+      "purl": "pkg:npm/ipaddr.js@1.9.1",
       "type": "library",
       "version": "1.9.1"
     },
     {
       "name": "is-positive",
+      "purl": "pkg:npm/is-positive?vcs_url=git%2Bssh://git%40github.com/kevva/is-positive.git%4097edff6f525f192a3f83cea1944765f769ae2678",
       "type": "library"
     },
     {
       "name": "media-typer",
+      "purl": "pkg:npm/media-typer@0.3.0",
       "type": "library",
       "version": "0.3.0"
     },
     {
       "name": "merge-descriptors",
+      "purl": "pkg:npm/merge-descriptors@1.0.1",
       "type": "library",
       "version": "1.0.1"
     },
     {
       "name": "methods",
+      "purl": "pkg:npm/methods@1.1.2",
       "type": "library",
       "version": "1.1.2"
     },
     {
       "name": "mime-db",
+      "purl": "pkg:npm/mime-db@1.52.0",
       "type": "library",
       "version": "1.52.0"
     },
     {
       "name": "mime-types",
+      "purl": "pkg:npm/mime-types@2.1.35",
       "type": "library",
       "version": "2.1.35"
     },
     {
       "name": "mime",
+      "purl": "pkg:npm/mime@1.6.0",
       "type": "library",
       "version": "1.6.0"
     },
     {
       "name": "ms",
+      "purl": "pkg:npm/ms@2.0.0",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "ms",
+      "purl": "pkg:npm/ms@2.1.3",
       "type": "library",
       "version": "2.1.3"
     },
     {
       "name": "negotiator",
+      "purl": "pkg:npm/negotiator@0.6.3",
       "type": "library",
       "version": "0.6.3"
     },
     {
       "name": "not-baz",
+      "purl": "pkg:npm/not-baz?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40e5bd11ca3a7aacd81aa195275d679d954848c71c#baz",
       "type": "library"
     },
     {
       "name": "npm_test",
+      "purl": "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40e5bd11ca3a7aacd81aa195275d679d954848c71c",
       "type": "library",
       "version": "1.1.0"
     },
     {
       "name": "object-inspect",
+      "purl": "pkg:npm/object-inspect@1.12.3",
       "type": "library",
       "version": "1.12.3"
     },
     {
       "name": "on-finished",
+      "purl": "pkg:npm/on-finished@2.4.1",
       "type": "library",
       "version": "2.4.1"
     },
     {
       "name": "parseurl",
+      "purl": "pkg:npm/parseurl@1.3.3",
       "type": "library",
       "version": "1.3.3"
     },
     {
       "name": "path-to-regexp",
+      "purl": "pkg:npm/path-to-regexp@0.1.7",
       "type": "library",
       "version": "0.1.7"
     },
     {
       "name": "proxy-addr",
+      "purl": "pkg:npm/proxy-addr@2.0.7",
       "type": "library",
       "version": "2.0.7"
     },
     {
       "name": "qs",
+      "purl": "pkg:npm/qs@6.11.0",
       "type": "library",
       "version": "6.11.0"
     },
     {
       "name": "range-parser",
+      "purl": "pkg:npm/range-parser@1.2.1",
       "type": "library",
       "version": "1.2.1"
     },
     {
       "name": "raw-body",
+      "purl": "pkg:npm/raw-body@2.5.1",
       "type": "library",
       "version": "2.5.1"
     },
     {
       "name": "safe-buffer",
+      "purl": "pkg:npm/safe-buffer@5.2.1",
       "type": "library",
       "version": "5.2.1"
     },
     {
       "name": "safer-buffer",
+      "purl": "pkg:npm/safer-buffer@2.1.2",
       "type": "library",
       "version": "2.1.2"
     },
     {
       "name": "sax",
+      "purl": "pkg:npm/sax@0.1.1",
       "type": "library",
       "version": "0.1.1"
     },
     {
       "name": "send",
+      "purl": "pkg:npm/send@0.18.0",
       "type": "library",
       "version": "0.18.0"
     },
     {
       "name": "serve-static",
+      "purl": "pkg:npm/serve-static@1.15.0",
       "type": "library",
       "version": "1.15.0"
     },
     {
       "name": "setprototypeof",
+      "purl": "pkg:npm/setprototypeof@1.2.0",
       "type": "library",
       "version": "1.2.0"
     },
     {
       "name": "side-channel",
+      "purl": "pkg:npm/side-channel@1.0.4",
       "type": "library",
       "version": "1.0.4"
     },
     {
       "name": "spam",
+      "purl": "pkg:npm/spam?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40e5bd11ca3a7aacd81aa195275d679d954848c71c#spam-packages/spam",
       "type": "library"
     },
     {
       "name": "statuses",
+      "purl": "pkg:npm/statuses@2.0.1",
       "type": "library",
       "version": "2.0.1"
     },
     {
       "name": "toidentifier",
+      "purl": "pkg:npm/toidentifier@1.0.1",
       "type": "library",
       "version": "1.0.1"
     },
     {
       "name": "type-is",
+      "purl": "pkg:npm/type-is@1.6.18",
       "type": "library",
       "version": "1.6.18"
     },
     {
       "name": "unpipe",
+      "purl": "pkg:npm/unpipe@1.0.0",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "utils-merge",
+      "purl": "pkg:npm/utils-merge@1.0.1",
       "type": "library",
       "version": "1.0.1"
     },
     {
       "name": "uuid",
+      "purl": "pkg:npm/uuid@9.0.0",
       "type": "library",
       "version": "9.0.0"
     },
     {
       "name": "vary",
+      "purl": "pkg:npm/vary@1.1.2",
       "type": "library",
       "version": "1.1.2"
     }

--- a/tests/integration/test_data/npm_smoketest_lockfile2/bom.json
+++ b/tests/integration/test_data/npm_smoketest_lockfile2/bom.json
@@ -75,7 +75,7 @@
     },
     {
       "name": "cachito-npm-without-deps",
-      "purl": "pkg:npm/cachito-npm-without-deps@1.0.0?download_url=https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
+      "purl": "pkg:npm/cachito-npm-without-deps@1.0.0?checksum=sha512:43e71f90ad5f9eb349ab18a283f8954994def373962ddc61b866bdea4d48249e67913c6b84dca1e8c519e981ca1fcc62b438292104a88ee9ed72db76a41efede&download_url=https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
       "type": "library",
       "version": "1.0.0"
     },

--- a/tests/integration/test_data/npm_smoketest_lockfile2/bom.json
+++ b/tests/integration/test_data/npm_smoketest_lockfile2/bom.json
@@ -3,391 +3,469 @@
   "components": [
     {
       "name": "@types/prop-types",
+      "purl": "pkg:npm/%40types/prop-types@15.7.5",
       "type": "library",
       "version": "15.7.5"
     },
     {
       "name": "@types/react-dom",
+      "purl": "pkg:npm/%40types/react-dom@18.0.11",
       "type": "library",
       "version": "18.0.11"
     },
     {
       "name": "@types/react",
+      "purl": "pkg:npm/%40types/react@18.0.35",
       "type": "library",
       "version": "18.0.35"
     },
     {
       "name": "@types/scheduler",
+      "purl": "pkg:npm/%40types/scheduler@0.16.3",
       "type": "library",
       "version": "0.16.3"
     },
     {
       "name": "abbrev",
+      "purl": "pkg:npm/abbrev@2.0.0",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "accepts",
+      "purl": "pkg:npm/accepts@1.3.8",
       "type": "library",
       "version": "1.3.8"
     },
     {
       "name": "array-flatten",
+      "purl": "pkg:npm/array-flatten@1.1.1",
       "type": "library",
       "version": "1.1.1"
     },
     {
       "name": "bar",
+      "purl": "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40b9a264fb7244f2cefa782feb1fd8c51ead9fb88b#bar",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "bitbucket-cachi2-npm-without-deps-second",
+      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps-second.git%4009992d418fc44a2895b7a9ff27c4e32d6f74a982",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "bitbucket-cachi2-npm-without-deps",
+      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps@1.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps.git%409e164b97043a2d91bbeb992f6cc68a3d1015086a",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "body-parser",
+      "purl": "pkg:npm/body-parser@1.20.1",
       "type": "library",
       "version": "1.20.1"
     },
     {
       "name": "bytes",
+      "purl": "pkg:npm/bytes@3.1.2",
       "type": "library",
       "version": "3.1.2"
     },
     {
       "name": "cachito-npm-without-deps",
+      "purl": "pkg:npm/cachito-npm-without-deps@1.0.0?download_url=https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "call-bind",
+      "purl": "pkg:npm/call-bind@1.0.2",
       "type": "library",
       "version": "1.0.2"
     },
     {
       "name": "classnames",
+      "purl": "pkg:npm/classnames@2.3.2",
       "type": "library",
       "version": "2.3.2"
     },
     {
       "name": "colors",
+      "purl": "pkg:npm/colors@1.4.0",
       "type": "library",
       "version": "1.4.0"
     },
     {
       "name": "content-disposition",
+      "purl": "pkg:npm/content-disposition@0.5.4",
       "type": "library",
       "version": "0.5.4"
     },
     {
       "name": "content-type",
+      "purl": "pkg:npm/content-type@1.0.5",
       "type": "library",
       "version": "1.0.5"
     },
     {
       "name": "cookie-signature",
+      "purl": "pkg:npm/cookie-signature@1.0.6",
       "type": "library",
       "version": "1.0.6"
     },
     {
       "name": "cookie",
+      "purl": "pkg:npm/cookie@0.5.0",
       "type": "library",
       "version": "0.5.0"
     },
     {
       "name": "csstype",
+      "purl": "pkg:npm/csstype@3.1.2",
       "type": "library",
       "version": "3.1.2"
     },
     {
       "name": "dateformat",
+      "purl": "pkg:npm/dateformat@5.0.3",
       "type": "library",
       "version": "5.0.3"
     },
     {
       "name": "debug",
+      "purl": "pkg:npm/debug@2.6.9",
       "type": "library",
       "version": "2.6.9"
     },
     {
       "name": "depd",
+      "purl": "pkg:npm/depd@2.0.0",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "destroy",
+      "purl": "pkg:npm/destroy@1.2.0",
       "type": "library",
       "version": "1.2.0"
     },
     {
       "name": "ee-first",
+      "purl": "pkg:npm/ee-first@1.1.1",
       "type": "library",
       "version": "1.1.1"
     },
     {
       "name": "eggs",
+      "purl": "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40b9a264fb7244f2cefa782feb1fd8c51ead9fb88b#eggs-packages/eggs",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "encodeurl",
+      "purl": "pkg:npm/encodeurl@1.0.2",
       "type": "library",
       "version": "1.0.2"
     },
     {
       "name": "escape-html",
+      "purl": "pkg:npm/escape-html@1.0.3",
       "type": "library",
       "version": "1.0.3"
     },
     {
       "name": "etag",
+      "purl": "pkg:npm/etag@1.8.1",
       "type": "library",
       "version": "1.8.1"
     },
     {
       "name": "express",
+      "purl": "pkg:npm/express@4.18.2",
       "type": "library",
       "version": "4.18.2"
     },
     {
       "name": "finalhandler",
+      "purl": "pkg:npm/finalhandler@1.2.0",
       "type": "library",
       "version": "1.2.0"
     },
     {
       "name": "foo",
+      "purl": "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40b9a264fb7244f2cefa782feb1fd8c51ead9fb88b#foo",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "forwarded",
+      "purl": "pkg:npm/forwarded@0.2.0",
       "type": "library",
       "version": "0.2.0"
     },
     {
       "name": "fresh",
+      "purl": "pkg:npm/fresh@0.5.2",
       "type": "library",
       "version": "0.5.2"
     },
     {
       "name": "function-bind",
+      "purl": "pkg:npm/function-bind@1.1.1",
       "type": "library",
       "version": "1.1.1"
     },
     {
       "name": "get-intrinsic",
+      "purl": "pkg:npm/get-intrinsic@1.2.0",
       "type": "library",
       "version": "1.2.0"
     },
     {
       "name": "has-symbols",
+      "purl": "pkg:npm/has-symbols@1.0.3",
       "type": "library",
       "version": "1.0.3"
     },
     {
       "name": "has",
+      "purl": "pkg:npm/has@1.0.3",
       "type": "library",
       "version": "1.0.3"
     },
     {
       "name": "http-errors",
+      "purl": "pkg:npm/http-errors@2.0.0",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "iconv-lite",
+      "purl": "pkg:npm/iconv-lite@0.4.24",
       "type": "library",
       "version": "0.4.24"
     },
     {
       "name": "inherits",
+      "purl": "pkg:npm/inherits@2.0.4",
       "type": "library",
       "version": "2.0.4"
     },
     {
       "name": "ipaddr.js",
+      "purl": "pkg:npm/ipaddr.js@1.9.1",
       "type": "library",
       "version": "1.9.1"
     },
     {
       "name": "is-positive",
+      "purl": "pkg:npm/is-positive@3.1.0?vcs_url=git%2Bssh://git%40github.com/kevva/is-positive.git%4097edff6f525f192a3f83cea1944765f769ae2678",
       "type": "library",
       "version": "3.1.0"
     },
     {
       "name": "media-typer",
+      "purl": "pkg:npm/media-typer@0.3.0",
       "type": "library",
       "version": "0.3.0"
     },
     {
       "name": "merge-descriptors",
+      "purl": "pkg:npm/merge-descriptors@1.0.1",
       "type": "library",
       "version": "1.0.1"
     },
     {
       "name": "methods",
+      "purl": "pkg:npm/methods@1.1.2",
       "type": "library",
       "version": "1.1.2"
     },
     {
       "name": "mime-db",
+      "purl": "pkg:npm/mime-db@1.52.0",
       "type": "library",
       "version": "1.52.0"
     },
     {
       "name": "mime-types",
+      "purl": "pkg:npm/mime-types@2.1.35",
       "type": "library",
       "version": "2.1.35"
     },
     {
       "name": "mime",
+      "purl": "pkg:npm/mime@1.6.0",
       "type": "library",
       "version": "1.6.0"
     },
     {
       "name": "ms",
+      "purl": "pkg:npm/ms@2.0.0",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "ms",
+      "purl": "pkg:npm/ms@2.1.3",
       "type": "library",
       "version": "2.1.3"
     },
     {
       "name": "negotiator",
+      "purl": "pkg:npm/negotiator@0.6.3",
       "type": "library",
       "version": "0.6.3"
     },
     {
       "name": "not-baz",
+      "purl": "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40b9a264fb7244f2cefa782feb1fd8c51ead9fb88b#baz",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "npm_test",
+      "purl": "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40b9a264fb7244f2cefa782feb1fd8c51ead9fb88b",
       "type": "library",
       "version": "1.1.0"
     },
     {
       "name": "object-inspect",
+      "purl": "pkg:npm/object-inspect@1.12.3",
       "type": "library",
       "version": "1.12.3"
     },
     {
       "name": "on-finished",
+      "purl": "pkg:npm/on-finished@2.4.1",
       "type": "library",
       "version": "2.4.1"
     },
     {
       "name": "parseurl",
+      "purl": "pkg:npm/parseurl@1.3.3",
       "type": "library",
       "version": "1.3.3"
     },
     {
       "name": "path-to-regexp",
+      "purl": "pkg:npm/path-to-regexp@0.1.7",
       "type": "library",
       "version": "0.1.7"
     },
     {
       "name": "proxy-addr",
+      "purl": "pkg:npm/proxy-addr@2.0.7",
       "type": "library",
       "version": "2.0.7"
     },
     {
       "name": "qs",
+      "purl": "pkg:npm/qs@6.11.0",
       "type": "library",
       "version": "6.11.0"
     },
     {
       "name": "range-parser",
+      "purl": "pkg:npm/range-parser@1.2.1",
       "type": "library",
       "version": "1.2.1"
     },
     {
       "name": "raw-body",
+      "purl": "pkg:npm/raw-body@2.5.1",
       "type": "library",
       "version": "2.5.1"
     },
     {
       "name": "safe-buffer",
+      "purl": "pkg:npm/safe-buffer@5.2.1",
       "type": "library",
       "version": "5.2.1"
     },
     {
       "name": "safer-buffer",
+      "purl": "pkg:npm/safer-buffer@2.1.2",
       "type": "library",
       "version": "2.1.2"
     },
     {
       "name": "sax",
+      "purl": "pkg:npm/sax@0.1.1",
       "type": "library",
       "version": "0.1.1"
     },
     {
       "name": "send",
+      "purl": "pkg:npm/send@0.18.0",
       "type": "library",
       "version": "0.18.0"
     },
     {
       "name": "serve-static",
+      "purl": "pkg:npm/serve-static@1.15.0",
       "type": "library",
       "version": "1.15.0"
     },
     {
       "name": "setprototypeof",
+      "purl": "pkg:npm/setprototypeof@1.2.0",
       "type": "library",
       "version": "1.2.0"
     },
     {
       "name": "side-channel",
+      "purl": "pkg:npm/side-channel@1.0.4",
       "type": "library",
       "version": "1.0.4"
     },
     {
       "name": "spam",
+      "purl": "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40b9a264fb7244f2cefa782feb1fd8c51ead9fb88b#spam-packages/spam",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "statuses",
+      "purl": "pkg:npm/statuses@2.0.1",
       "type": "library",
       "version": "2.0.1"
     },
     {
       "name": "toidentifier",
+      "purl": "pkg:npm/toidentifier@1.0.1",
       "type": "library",
       "version": "1.0.1"
     },
     {
       "name": "type-is",
+      "purl": "pkg:npm/type-is@1.6.18",
       "type": "library",
       "version": "1.6.18"
     },
     {
       "name": "unpipe",
+      "purl": "pkg:npm/unpipe@1.0.0",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "utils-merge",
+      "purl": "pkg:npm/utils-merge@1.0.1",
       "type": "library",
       "version": "1.0.1"
     },
     {
       "name": "uuid",
+      "purl": "pkg:npm/uuid@9.0.0",
       "type": "library",
       "version": "9.0.0"
     },
     {
       "name": "vary",
+      "purl": "pkg:npm/vary@1.1.2",
       "type": "library",
       "version": "1.1.2"
     }

--- a/tests/integration/test_data/npm_smoketest_lockfile3/bom.json
+++ b/tests/integration/test_data/npm_smoketest_lockfile3/bom.json
@@ -3,391 +3,469 @@
   "components": [
     {
       "name": "@types/prop-types",
+      "purl": "pkg:npm/%40types/prop-types@15.7.5",
       "type": "library",
       "version": "15.7.5"
     },
     {
       "name": "@types/react-dom",
+      "purl": "pkg:npm/%40types/react-dom@18.0.11",
       "type": "library",
       "version": "18.0.11"
     },
     {
       "name": "@types/react",
+      "purl": "pkg:npm/%40types/react@18.0.35",
       "type": "library",
       "version": "18.0.35"
     },
     {
       "name": "@types/scheduler",
+      "purl": "pkg:npm/%40types/scheduler@0.16.3",
       "type": "library",
       "version": "0.16.3"
     },
     {
       "name": "abbrev",
+      "purl": "pkg:npm/abbrev@2.0.0",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "accepts",
+      "purl": "pkg:npm/accepts@1.3.8",
       "type": "library",
       "version": "1.3.8"
     },
     {
       "name": "array-flatten",
+      "purl": "pkg:npm/array-flatten@1.1.1",
       "type": "library",
       "version": "1.1.1"
     },
     {
       "name": "bar",
+      "purl": "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40f229b5b9c9085dabf71622cc1204c5deef97fbe8#bar",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "bitbucket-cachi2-npm-without-deps-second",
+      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps-second.git%4009992d418fc44a2895b7a9ff27c4e32d6f74a982",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "bitbucket-cachi2-npm-without-deps",
+      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps@1.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps.git%409e164b97043a2d91bbeb992f6cc68a3d1015086a",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "body-parser",
+      "purl": "pkg:npm/body-parser@1.20.1",
       "type": "library",
       "version": "1.20.1"
     },
     {
       "name": "bytes",
+      "purl": "pkg:npm/bytes@3.1.2",
       "type": "library",
       "version": "3.1.2"
     },
     {
       "name": "cachito-npm-without-deps",
+      "purl": "pkg:npm/cachito-npm-without-deps@1.0.0?download_url=https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "call-bind",
+      "purl": "pkg:npm/call-bind@1.0.2",
       "type": "library",
       "version": "1.0.2"
     },
     {
       "name": "classnames",
+      "purl": "pkg:npm/classnames@2.3.2",
       "type": "library",
       "version": "2.3.2"
     },
     {
       "name": "colors",
+      "purl": "pkg:npm/colors@1.4.0",
       "type": "library",
       "version": "1.4.0"
     },
     {
       "name": "content-disposition",
+      "purl": "pkg:npm/content-disposition@0.5.4",
       "type": "library",
       "version": "0.5.4"
     },
     {
       "name": "content-type",
+      "purl": "pkg:npm/content-type@1.0.5",
       "type": "library",
       "version": "1.0.5"
     },
     {
       "name": "cookie-signature",
+      "purl": "pkg:npm/cookie-signature@1.0.6",
       "type": "library",
       "version": "1.0.6"
     },
     {
       "name": "cookie",
+      "purl": "pkg:npm/cookie@0.5.0",
       "type": "library",
       "version": "0.5.0"
     },
     {
       "name": "csstype",
+      "purl": "pkg:npm/csstype@3.1.2",
       "type": "library",
       "version": "3.1.2"
     },
     {
       "name": "dateformat",
+      "purl": "pkg:npm/dateformat@5.0.3",
       "type": "library",
       "version": "5.0.3"
     },
     {
       "name": "debug",
+      "purl": "pkg:npm/debug@2.6.9",
       "type": "library",
       "version": "2.6.9"
     },
     {
       "name": "depd",
+      "purl": "pkg:npm/depd@2.0.0",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "destroy",
+      "purl": "pkg:npm/destroy@1.2.0",
       "type": "library",
       "version": "1.2.0"
     },
     {
       "name": "ee-first",
+      "purl": "pkg:npm/ee-first@1.1.1",
       "type": "library",
       "version": "1.1.1"
     },
     {
       "name": "eggs",
+      "purl": "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40f229b5b9c9085dabf71622cc1204c5deef97fbe8#eggs-packages/eggs",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "encodeurl",
+      "purl": "pkg:npm/encodeurl@1.0.2",
       "type": "library",
       "version": "1.0.2"
     },
     {
       "name": "escape-html",
+      "purl": "pkg:npm/escape-html@1.0.3",
       "type": "library",
       "version": "1.0.3"
     },
     {
       "name": "etag",
+      "purl": "pkg:npm/etag@1.8.1",
       "type": "library",
       "version": "1.8.1"
     },
     {
       "name": "express",
+      "purl": "pkg:npm/express@4.18.2",
       "type": "library",
       "version": "4.18.2"
     },
     {
       "name": "finalhandler",
+      "purl": "pkg:npm/finalhandler@1.2.0",
       "type": "library",
       "version": "1.2.0"
     },
     {
       "name": "foo",
+      "purl": "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40f229b5b9c9085dabf71622cc1204c5deef97fbe8#foo",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "forwarded",
+      "purl": "pkg:npm/forwarded@0.2.0",
       "type": "library",
       "version": "0.2.0"
     },
     {
       "name": "fresh",
+      "purl": "pkg:npm/fresh@0.5.2",
       "type": "library",
       "version": "0.5.2"
     },
     {
       "name": "function-bind",
+      "purl": "pkg:npm/function-bind@1.1.1",
       "type": "library",
       "version": "1.1.1"
     },
     {
       "name": "get-intrinsic",
+      "purl": "pkg:npm/get-intrinsic@1.2.0",
       "type": "library",
       "version": "1.2.0"
     },
     {
       "name": "has-symbols",
+      "purl": "pkg:npm/has-symbols@1.0.3",
       "type": "library",
       "version": "1.0.3"
     },
     {
       "name": "has",
+      "purl": "pkg:npm/has@1.0.3",
       "type": "library",
       "version": "1.0.3"
     },
     {
       "name": "http-errors",
+      "purl": "pkg:npm/http-errors@2.0.0",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "iconv-lite",
+      "purl": "pkg:npm/iconv-lite@0.4.24",
       "type": "library",
       "version": "0.4.24"
     },
     {
       "name": "inherits",
+      "purl": "pkg:npm/inherits@2.0.4",
       "type": "library",
       "version": "2.0.4"
     },
     {
       "name": "ipaddr.js",
+      "purl": "pkg:npm/ipaddr.js@1.9.1",
       "type": "library",
       "version": "1.9.1"
     },
     {
       "name": "is-positive",
+      "purl": "pkg:npm/is-positive@3.1.0?vcs_url=git%2Bssh://git%40github.com/kevva/is-positive.git%4097edff6f525f192a3f83cea1944765f769ae2678",
       "type": "library",
       "version": "3.1.0"
     },
     {
       "name": "media-typer",
+      "purl": "pkg:npm/media-typer@0.3.0",
       "type": "library",
       "version": "0.3.0"
     },
     {
       "name": "merge-descriptors",
+      "purl": "pkg:npm/merge-descriptors@1.0.1",
       "type": "library",
       "version": "1.0.1"
     },
     {
       "name": "methods",
+      "purl": "pkg:npm/methods@1.1.2",
       "type": "library",
       "version": "1.1.2"
     },
     {
       "name": "mime-db",
+      "purl": "pkg:npm/mime-db@1.52.0",
       "type": "library",
       "version": "1.52.0"
     },
     {
       "name": "mime-types",
+      "purl": "pkg:npm/mime-types@2.1.35",
       "type": "library",
       "version": "2.1.35"
     },
     {
       "name": "mime",
+      "purl": "pkg:npm/mime@1.6.0",
       "type": "library",
       "version": "1.6.0"
     },
     {
       "name": "ms",
+      "purl": "pkg:npm/ms@2.0.0",
       "type": "library",
       "version": "2.0.0"
     },
     {
       "name": "ms",
+      "purl": "pkg:npm/ms@2.1.3",
       "type": "library",
       "version": "2.1.3"
     },
     {
       "name": "negotiator",
+      "purl": "pkg:npm/negotiator@0.6.3",
       "type": "library",
       "version": "0.6.3"
     },
     {
       "name": "not-baz",
+      "purl": "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40f229b5b9c9085dabf71622cc1204c5deef97fbe8#baz",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "npm_test",
+      "purl": "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40f229b5b9c9085dabf71622cc1204c5deef97fbe8",
       "type": "library",
       "version": "1.1.0"
     },
     {
       "name": "object-inspect",
+      "purl": "pkg:npm/object-inspect@1.12.3",
       "type": "library",
       "version": "1.12.3"
     },
     {
       "name": "on-finished",
+      "purl": "pkg:npm/on-finished@2.4.1",
       "type": "library",
       "version": "2.4.1"
     },
     {
       "name": "parseurl",
+      "purl": "pkg:npm/parseurl@1.3.3",
       "type": "library",
       "version": "1.3.3"
     },
     {
       "name": "path-to-regexp",
+      "purl": "pkg:npm/path-to-regexp@0.1.7",
       "type": "library",
       "version": "0.1.7"
     },
     {
       "name": "proxy-addr",
+      "purl": "pkg:npm/proxy-addr@2.0.7",
       "type": "library",
       "version": "2.0.7"
     },
     {
       "name": "qs",
+      "purl": "pkg:npm/qs@6.11.0",
       "type": "library",
       "version": "6.11.0"
     },
     {
       "name": "range-parser",
+      "purl": "pkg:npm/range-parser@1.2.1",
       "type": "library",
       "version": "1.2.1"
     },
     {
       "name": "raw-body",
+      "purl": "pkg:npm/raw-body@2.5.1",
       "type": "library",
       "version": "2.5.1"
     },
     {
       "name": "safe-buffer",
+      "purl": "pkg:npm/safe-buffer@5.2.1",
       "type": "library",
       "version": "5.2.1"
     },
     {
       "name": "safer-buffer",
+      "purl": "pkg:npm/safer-buffer@2.1.2",
       "type": "library",
       "version": "2.1.2"
     },
     {
       "name": "sax",
+      "purl": "pkg:npm/sax@0.1.1",
       "type": "library",
       "version": "0.1.1"
     },
     {
       "name": "send",
+      "purl": "pkg:npm/send@0.18.0",
       "type": "library",
       "version": "0.18.0"
     },
     {
       "name": "serve-static",
+      "purl": "pkg:npm/serve-static@1.15.0",
       "type": "library",
       "version": "1.15.0"
     },
     {
       "name": "setprototypeof",
+      "purl": "pkg:npm/setprototypeof@1.2.0",
       "type": "library",
       "version": "1.2.0"
     },
     {
       "name": "side-channel",
+      "purl": "pkg:npm/side-channel@1.0.4",
       "type": "library",
       "version": "1.0.4"
     },
     {
       "name": "spam",
+      "purl": "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/cachito-testing/npm-cachi2-smoketest.git%40f229b5b9c9085dabf71622cc1204c5deef97fbe8#spam-packages/spam",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "statuses",
+      "purl": "pkg:npm/statuses@2.0.1",
       "type": "library",
       "version": "2.0.1"
     },
     {
       "name": "toidentifier",
+      "purl": "pkg:npm/toidentifier@1.0.1",
       "type": "library",
       "version": "1.0.1"
     },
     {
       "name": "type-is",
+      "purl": "pkg:npm/type-is@1.6.18",
       "type": "library",
       "version": "1.6.18"
     },
     {
       "name": "unpipe",
+      "purl": "pkg:npm/unpipe@1.0.0",
       "type": "library",
       "version": "1.0.0"
     },
     {
       "name": "utils-merge",
+      "purl": "pkg:npm/utils-merge@1.0.1",
       "type": "library",
       "version": "1.0.1"
     },
     {
       "name": "uuid",
+      "purl": "pkg:npm/uuid@9.0.0",
       "type": "library",
       "version": "9.0.0"
     },
     {
       "name": "vary",
+      "purl": "pkg:npm/vary@1.1.2",
       "type": "library",
       "version": "1.1.2"
     }

--- a/tests/integration/test_data/npm_smoketest_lockfile3/bom.json
+++ b/tests/integration/test_data/npm_smoketest_lockfile3/bom.json
@@ -75,7 +75,7 @@
     },
     {
       "name": "cachito-npm-without-deps",
-      "purl": "pkg:npm/cachito-npm-without-deps@1.0.0?download_url=https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
+      "purl": "pkg:npm/cachito-npm-without-deps@1.0.0?checksum=sha512:43e71f90ad5f9eb349ab18a283f8954994def373962ddc61b866bdea4d48249e67913c6b84dca1e8c519e981ca1fcc62b438292104a88ee9ed72db76a41efede&download_url=https://github.com/cachito-testing/cachito-npm-without-deps/raw/tarball/cachito-npm-without-deps-1.0.0.tgz",
       "type": "library",
       "version": "1.0.0"
     },

--- a/tests/unit/package_managers/test_npm.py
+++ b/tests/unit/package_managers/test_npm.py
@@ -340,6 +340,18 @@ class TestPurlifier:
                 ("gitplus-dep", None, "git+https://github.com/org/git-dep.git#deadbeef"),
                 f"pkg:npm/gitplus-dep?vcs_url={urlq('git+https://github.com/org/git-dep.git@deadbeef')}",
             ),
+            (
+                ("github-dep", None, "github:org/git-dep#deadbeef"),
+                f"pkg:npm/github-dep?vcs_url={urlq('git+ssh://git@github.com/org/git-dep.git@deadbeef')}",
+            ),
+            (
+                ("gitlab-dep", None, "gitlab:org/git-dep#deadbeef"),
+                f"pkg:npm/gitlab-dep?vcs_url={urlq('git+ssh://git@gitlab.com/org/git-dep.git@deadbeef')}",
+            ),
+            (
+                ("bitbucket-dep", None, "bitbucket:org/git-dep#deadbeef"),
+                f"pkg:npm/bitbucket-dep?vcs_url={urlq('git+ssh://git@bitbucket.org/org/git-dep.git@deadbeef')}",
+            ),
         ],
     )
     def test_get_purl_for_remote_package(
@@ -1180,13 +1192,16 @@ def test_extract_git_info_with_missing_ref() -> None:
 @pytest.mark.parametrize(
     "vcs, expected",
     [
-        ("github:kevva/is-positive#97edff6", "git+ssh://github.com/kevva/is-positive.git#97edff6"),
-        ("github:kevva/is-positive", "git+ssh://github.com/kevva/is-positive.git"),
+        (
+            "github:kevva/is-positive#97edff6",
+            "git+ssh://git@github.com/kevva/is-positive.git#97edff6",
+        ),
+        ("github:kevva/is-positive", "git+ssh://git@github.com/kevva/is-positive.git"),
         (
             "bitbucket:cachi-testing/cachi2-without-deps#9e164b9",
-            "git+ssh://bitbucket.org/cachi-testing/cachi2-without-deps.git#9e164b9",
+            "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps.git#9e164b9",
         ),
-        ("gitlab:foo/bar#YOLO", "git+ssh://gitlab.com/foo/bar.git#YOLO"),
+        ("gitlab:foo/bar#YOLO", "git+ssh://git@gitlab.com/foo/bar.git#YOLO"),
     ],
 )
 def test_update_vcs_url_with_full_hostname(vcs: str, expected: str) -> None:

--- a/tests/unit/package_managers/test_npm.py
+++ b/tests/unit/package_managers/test_npm.py
@@ -313,6 +313,14 @@ class TestPurlifier:
                 "pkg:npm/%40scoped/registry-dep@2.0.0",
             ),
             (
+                (
+                    "sus-registry-dep",
+                    "1.0.0",
+                    "https://registry.yarnpkg.com/sus-registry-dep-1.0.0.tgz",
+                ),
+                "pkg:npm/sus-registry-dep@1.0.0",
+            ),
+            (
                 ("https-dep", None, "https://host.org/https-dep-1.0.0.tar.gz"),
                 "pkg:npm/https-dep?download_url=https://host.org/https-dep-1.0.0.tar.gz",
             ),
@@ -1243,9 +1251,14 @@ def test_clone_repo_pack_archive(
                     "integrity": "sha512-YOLO2222==",
                 },
                 "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz": {
-                    "name": "react-dom",
+                    "name": "@types/react-dom",
                     "version": "18.0.11",
                     "integrity": "sha512-YOLO00000==",
+                },
+                "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz": {
+                    "name": "abbrev",
+                    "version": "2.0.0",
+                    "integrity": "sha512-YOLO33333==",
                 },
                 "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps-second.git#09992d418fc44a2895b7a9ff27c4e32d6f74a982": {
                     "version": "2.0.0",
@@ -1266,7 +1279,8 @@ def test_clone_repo_pack_archive(
                 "https://github.com/cachito-testing/ms-1.0.0.tgz": "external-ms/ms-external-sha256-YOLO1111.tgz",
                 "https://github.com/cachito-testing/ms-2.0.0.tgz": "external-ms/ms-external-sha256-YOLO2222.tgz",
                 "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps-second.git#09992d418fc44a2895b7a9ff27c4e32d6f74a982": "bitbucket.org/cachi-testing/cachi2-without-deps-second/cachi2-without-deps-second-external-gitcommit-09992d418fc44a2895b7a9ff27c4e32d6f74a982.tgz",
-                "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz": "react-dom-18.0.11.tgz",
+                "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz": "types-react-dom-18.0.11.tgz",
+                "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz": "abbrev-2.0.0.tgz",
                 "git+ssh://git@github.com/kevva/is-positive.git#97edff6f": "github.com/kevva/is-positive/is-positive-external-gitcommit-97edff6f.tgz",
                 "git+ssh://git@gitlab.foo.bar.com/osbs/cachito-tests.git#c300503": "gitlab.foo.bar.com/osbs/cachito-tests/cachito-tests-external-gitcommit-c300503.tgz",
             },


### PR DESCRIPTION
STONEBLD-1112

```
- registry dependencies: pkg:npm/name@version
- git dependencies: pkg:npm/name[@version]?vcs_url=url[#subpath]
- http dependencies: pkg:npm/name[@version]?download_url=url
- file dependencies: treated as git dependencies from the source repo
- main package: treated as a `file:.` dependency
```

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] New code has type annotations
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)
