### PR TITLE
Remove type-annotations PR checklist item

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -2,6 +2,5 @@
 
 - [ ] Commit messages are descriptive enough
 - [ ] Code coverage from testing does not decrease and new code is covered
-- [ ] New code has type annotations
 - [ ] Docs updated (if applicable)
 - [ ] Docs links in the code are still valid (if docs were updated)


### PR DESCRIPTION
Mypy enforces them after e31c493ac6653338b00a71e87256242fd0fa67c7

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] New code has type annotations
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
