### PR TITLE
Fix the handling of npm bundled dependencies

### DIFF
--- a/tests/integration/test_npm.py
+++ b/tests/integration/test_npm.py
@@ -49,7 +49,6 @@ log = logging.getLogger(__name__)
                 check_vendor_checksums=False,
             ),
             id="npm_bundled_lockfile1",
-            marks=pytest.mark.xfail(reason="cachi2 does not handle bundled deps properly"),
         ),
         pytest.param(
             utils.TestParameters(
@@ -59,7 +58,6 @@ log = logging.getLogger(__name__)
                 check_vendor_checksums=False,
             ),
             id="npm_bundled_lockfile3",
-            marks=pytest.mark.xfail(reason="cachi2 does not handle bundled deps properly"),
         ),
     ],
 )


### PR DESCRIPTION
Do not download bundled dependencies, do report them in the SBOM.

Use the same purls as registry dependencies. Bundled dependencies should be differentiated in the future via the `cdx:npm:package:bundled` property (outside the purl).

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- N/A Docs updated (if applicable)
- N/A Docs links in the code are still valid (if docs were updated)
