### PR TITLE
Add failure notifications to on-push pipelines

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -18,6 +18,8 @@ spec:
       value: "quay.io/redhat-appstudio/cachi2:{{revision}}"
     - name: dockerfile
       value: Containerfile
+    - name: slack-webhook-notification-team
+      value: build
   pipelineRef:
     name: docker-build
     bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest

--- a/.tekton/release.yaml
+++ b/.tekton/release.yaml
@@ -13,6 +13,8 @@ spec:
       value: "{{repo_url}}"
     - name: revision
       value: "{{revision}}"
+    - name: slack-webhook-notification-team
+      value: build
   pipelineSpec:
     tasks:
       - name: fetch-repository
@@ -51,7 +53,7 @@ spec:
               script: |
                 #!/usr/bin/env bash
                 set -eufx
-                
+
                 git config --global --add safe.directory "${WORKSPACE_OUTPUT_PATH}"
                 git fetch --tag -v
                 version=$(git  --no-pager tag --points-at HEAD)
@@ -78,10 +80,34 @@ spec:
               script: |
                 #!/usr/bin/env bash
                 set -eufx
-                
+
                 version=$(cat $(results.version.path)) 
                 skopeo copy docker://quay.io/redhat-appstudio/cachi2:$PARAM_REVISION \
                   docker://quay.io/redhat-appstudio/cachi2:$version
+
+    finally:
+      - name: slack-webhook-notification
+        taskRef:
+          resolver: bundles
+          params:
+            - name: name
+              value: slack-webhook-notification
+            - name: bundle
+              value: quay.io/redhat-appstudio-tekton-catalog/task-slack-webhook-notification:0.1
+            - name: kind
+              value: task
+        when:
+        - input: $(tasks.status)
+          operator: in
+          values: ["Failed"]
+        params:
+        - name: message
+          value: |-
+            Tekton pipelineRun $(context.pipelineRun.name) failed.
+            See https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/k8s/ns/tekton-ci/tekton.dev~v1beta1~PipelineRun/$(context.pipelineRun.name)
+            (Quick! It may disappear soon!)
+        - name: key-name
+          value: $(params.slack-webhook-notification-team)
 
   workspaces:
     - name: workspace

--- a/.tekton/tag-latest.yaml
+++ b/.tekton/tag-latest.yaml
@@ -13,6 +13,8 @@ spec:
   params:
     - name: revision
       value: "{{revision}}"
+    - name: slack-webhook-notification-team
+      value: build
   pipelineSpec:
     params:
       - name: revision
@@ -44,3 +46,27 @@ spec:
                 echo "${SRC_REF} has been pushed, copying to ${TARGET_REF}"
 
                 skopeo copy "docker://${SRC_REF}" "docker://${TARGET_REF}"
+
+    finally:
+      - name: slack-webhook-notification
+        taskRef:
+          resolver: bundles
+          params:
+            - name: name
+              value: slack-webhook-notification
+            - name: bundle
+              value: quay.io/redhat-appstudio-tekton-catalog/task-slack-webhook-notification:0.1
+            - name: kind
+              value: task
+        when:
+        - input: $(tasks.status)
+          operator: in
+          values: ["Failed"]
+        params:
+        - name: message
+          value: |-
+            Tekton pipelineRun $(context.pipelineRun.name) failed.
+            See https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/k8s/ns/tekton-ci/tekton.dev~v1beta1~PipelineRun/$(context.pipelineRun.name)
+            (Quick! It may disappear soon!)
+        - name: key-name
+          value: $(params.slack-webhook-notification-team)


### PR DESCRIPTION
The GitHub UI does not show on-push Tekton pipelines at all. There's no
way to know when one fails.

Add Slack notifications. When a pipeline fails, it will send a
notification in the Slack channel configured as the "build" team channel
in the RHTAP instance where our pipelines run.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
