### PR TITLE
feat(npm): fail request if 'node_modules' exists

### DIFF
--- a/cachi2/core/package_managers/npm.py
+++ b/cachi2/core/package_managers/npm.py
@@ -558,6 +558,13 @@ def _resolve_npm(pkg_path: RootedPath) -> ResolvedNpmPackage:
             solution="Please double-check that you have specified the correct path to the package directory containing one of those two files",
         )
 
+    node_modules_path = pkg_path.join_within_root("node_modules")
+    if node_modules_path.path.exists():
+        raise PackageRejected(
+            "The 'node_modules' directory cannot be present in the source repository",
+            solution="Ensure that there are no 'node_modules' directories in your repo",
+        )
+
     package_lock = PackageLock.from_file(package_lock_path)
 
     return {


### PR DESCRIPTION
- https://issues.redhat.com/browse/STONEBLD-1474

Committing node_modules into the repository would allow the user to "vendor" their dependencies, in a way.

The RHTAP build would have no guarantee that the build really used the dependencies that cachi2 prefetched.

The generated SBOM could be inaccurate.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] ~Docs updated (if applicable)~
- [ ] ~Docs links in the code are still valid (if docs were updated)~
