### PR TITLE
Fix: allow relative path for helper commands

### DIFF
--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -255,10 +255,13 @@ FROM_OUTPUT_DIR_ARG = typer.Argument(
     ...,
     exists=True,
     file_okay=False,
+    resolve_path=True,
     help="The output directory populated by a previous fetch-deps command.",
 )
 FOR_OUTPUT_DIR_OPTION = typer.Option(
-    None, help="Generate output as if the output directory was at this path instead."
+    None,
+    resolve_path=True,
+    help="Generate output as if the output directory was at this path instead.",
 )
 
 
@@ -283,7 +286,7 @@ def generate_env(
 ) -> None:
     """Generate the environment variables needed to use the fetched dependencies."""
     fmt = fmt or (EnvFormat.based_on_suffix(output) if output else EnvFormat.json)
-    for_output_dir = (for_output_dir or from_output_dir).resolve()
+    for_output_dir = for_output_dir or from_output_dir
     fetch_deps_output = _get_build_config(from_output_dir)
 
     env_file_content = generate_envfile(fetch_deps_output, fmt, for_output_dir)
@@ -302,7 +305,7 @@ def inject_files(
     for_output_dir: Optional[Path] = FOR_OUTPUT_DIR_OPTION,
 ) -> None:
     """Inject the project files needed to use the fetched dependencies."""
-    for_output_dir = (for_output_dir or from_output_dir).resolve()
+    for_output_dir = for_output_dir or from_output_dir
     fetch_deps_output = _get_build_config(from_output_dir)
 
     for project_file in fetch_deps_output.project_files:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -628,6 +628,7 @@ class TestGenerateEnv:
         tmp_cwd.joinpath(".build-config.json").write_text(build_config.json())
         return tmp_cwd
 
+    @pytest.mark.parametrize("use_relative_path", [True, False])
     @pytest.mark.parametrize(
         "extra_args, make_output, output_file",
         [
@@ -644,11 +645,15 @@ class TestGenerateEnv:
         extra_args: list[str],
         make_output: Callable[[Path], str],
         output_file: Optional[str],
+        use_relative_path: bool,
         tmp_cwd_as_output_dir: Path,
     ) -> None:
-        result = invoke_expecting_sucess(
-            app, ["generate-env", str(tmp_cwd_as_output_dir), *extra_args]
-        )
+        if use_relative_path:
+            from_output_dir = "."
+        else:
+            from_output_dir = str(tmp_cwd_as_output_dir)
+
+        result = invoke_expecting_sucess(app, ["generate-env", from_output_dir, *extra_args])
 
         expect_output = make_output(tmp_cwd_as_output_dir)
         if output_file is None:


### PR DESCRIPTION
Currently, passing the output directory as a relative path does not work for generate-env and inject-files, because we try to convert a relative path to RootedPath.

    ERROR ValueError: path must be absolute: cachi2-output

Fix by resolving the path before converting to RootedPath.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)
