### PR TITLE
Add integration test for handling missing project metadata

### DIFF
--- a/tests/integration/test_data/pip_without_metadata/.build-config.json
+++ b/tests/integration/test_data/pip_without_metadata/.build-config.json
@@ -1,0 +1,15 @@
+{
+  "environment_variables": [
+    {
+      "kind": "path",
+      "name": "PIP_FIND_LINKS",
+      "value": "deps/pip"
+    },
+    {
+      "kind": "literal",
+      "name": "PIP_NO_INDEX",
+      "value": "true"
+    }
+  ],
+  "project_files": []
+}

--- a/tests/integration/test_data/pip_without_metadata/bom.json
+++ b/tests/integration/test_data/pip_without_metadata/bom.json
@@ -1,0 +1,145 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "aiowsgi",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:pypi/aiowsgi@0.8",
+      "type": "library",
+      "version": "0.8"
+    },
+    {
+      "name": "cachito-pip-without-metadata-subpath1-subpath2",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:pypi/cachito-pip-without-metadata-subpath1-subpath2?vcs_url=git%2Bhttps://github.com/cachito-testing/cachito-pip-without-metadata.git%404fb61a80f9bb19fdd422a74602b108d405ede299#subpath1/subpath2",
+      "type": "library"
+    },
+    {
+      "name": "cachito-pip-without-metadata",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:pypi/cachito-pip-without-metadata?vcs_url=git%2Bhttps://github.com/cachito-testing/cachito-pip-without-metadata.git%404fb61a80f9bb19fdd422a74602b108d405ede299",
+      "type": "library"
+    },
+    {
+      "name": "certifi",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:pypi/certifi@2023.7.22",
+      "type": "library",
+      "version": "2023.7.22"
+    },
+    {
+      "name": "charset-normalizer",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:pypi/charset-normalizer@3.2.0",
+      "type": "library",
+      "version": "3.2.0"
+    },
+    {
+      "name": "idna",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:pypi/idna@3.4",
+      "type": "library",
+      "version": "3.4"
+    },
+    {
+      "name": "requests",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.31.0",
+      "type": "library",
+      "version": "2.31.0"
+    },
+    {
+      "name": "six",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0",
+      "type": "library",
+      "version": "1.16.0"
+    },
+    {
+      "name": "urllib3",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:pypi/urllib3@2.0.4",
+      "type": "library",
+      "version": "2.0.4"
+    },
+    {
+      "name": "waitress",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:pypi/waitress@2.1.2",
+      "type": "library",
+      "version": "2.1.2"
+    },
+    {
+      "name": "WebOb",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:pypi/webob@1.8.7",
+      "type": "library",
+      "version": "1.8.7"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "name": "cachi2",
+        "vendor": "red hat"
+      }
+    ]
+  },
+  "specVersion": "1.4",
+  "version": 1
+}

--- a/tests/integration/test_data/pip_without_metadata/fetch_deps_sha256sums.json
+++ b/tests/integration/test_data/pip_without_metadata/fetch_deps_sha256sums.json
@@ -1,0 +1,11 @@
+{
+  "pip/WebOb-1.8.7.tar.gz": "sha256:b64ef5141be559cfade448f044fa45c2260351edcb6a8ef6b7e00c7dcef0c323",
+  "pip/aiowsgi-0.8.tar.gz": "sha256:71f8177016cd85d5744c663dc078da02134c8409659374c1bff878c6169b0d7a",
+  "pip/certifi-2023.7.22.tar.gz": "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
+  "pip/charset-normalizer-3.2.0.tar.gz": "sha256:3bb3d25a8e6c0aedd251753a79ae98a093c7e7b471faa3aa9a93a81431987ace",
+  "pip/idna-3.4.tar.gz": "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+  "pip/requests-2.31.0.tar.gz": "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1",
+  "pip/six-1.16.0.tar.gz": "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+  "pip/urllib3-2.0.4.tar.gz": "sha256:8d22f86aae8ef5e410d4f539fde9ce6b2113a001bb4d189e0aed70642d602b11",
+  "pip/waitress-2.1.2.tar.gz": "sha256:780a4082c5fbc0fde6a2fcfe5e26e6efc1e8f425730863c04085769781f51eba"
+}

--- a/tests/integration/test_pip.py
+++ b/tests/integration/test_pip.py
@@ -66,6 +66,20 @@ log = logging.getLogger(__name__)
             ),
             id="pip_local_path",
         ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachito-pip-without-metadata.git",
+                ref="4fb61a80f9bb19fdd422a74602b108d405ede299",
+                packages=(
+                    {"path": ".", "type": "pip"},
+                    {"path": "subpath1/subpath2", "type": "pip"},
+                ),
+                check_vendor_checksums=False,
+                expected_exit_code=0,
+                expected_output="All dependencies fetched successfully",
+            ),
+            id="pip_without_metadata",
+        ),
     ],
 )
 def test_pip_packages(


### PR DESCRIPTION
Test case if there no setup files in the repository or cachi2 fails to resolve the name.

JIRA: https://issues.redhat.com/browse/STONEBLD-1181
REPO: https://github.com/cachito-testing/cachito-pip-without-metadata

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- n/a Docs updated (if applicable)
- n/a Docs links in the code are still valid (if docs were updated)
