### PR TITLE
Bumps base image to Fedora 38

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-minimal:37
+FROM registry.fedoraproject.org/fedora-minimal:38
 LABEL maintainer="Red Hat"
 
 WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ original Cachito.*
 
 <https://go.dev/ref/mod>
 
-Current version: 1.19 [^go-version] [^go-compat]
+Current version: 1.20 [^go-version] [^go-compat]
 
 The gomod package manager works by parsing the [go.mod](https://go.dev/ref/mod#go-mod-file) file present in the source
 repository to determine which dependencies to download. Cachi2 does not parse this file on its own - rather, we rely on

--- a/tests/integration/test_data/gomod_e2e_multiple_modules/bom.json
+++ b/tests/integration/test_data/gomod_e2e_multiple_modules/bom.json
@@ -153,6 +153,17 @@
       "type": "library"
     },
     {
+      "name": "internal/coverage/rtcov",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:golang/internal/coverage/rtcov?type=package",
+      "type": "library"
+    },
+    {
       "name": "internal/cpu",
       "properties": [
         {

--- a/tests/integration/test_data/gomod_e2e_test/bom.json
+++ b/tests/integration/test_data/gomod_e2e_test/bom.json
@@ -112,6 +112,17 @@
       "type": "library"
     },
     {
+      "name": "crypto/ecdh",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:golang/crypto/ecdh?type=package",
+      "type": "library"
+    },
+    {
       "name": "crypto/ecdsa",
       "properties": [
         {
@@ -153,6 +164,28 @@
         }
       ],
       "purl": "pkg:golang/crypto/hmac?type=package",
+      "type": "library"
+    },
+    {
+      "name": "crypto/internal/alias",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:golang/crypto/internal/alias?type=package",
+      "type": "library"
+    },
+    {
+      "name": "crypto/internal/bigmod",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:golang/crypto/internal/bigmod?type=package",
       "type": "library"
     },
     {
@@ -241,17 +274,6 @@
         }
       ],
       "purl": "pkg:golang/crypto/internal/randutil?type=package",
-      "type": "library"
-    },
-    {
-      "name": "crypto/internal/subtle",
-      "properties": [
-        {
-          "name": "cachi2:found_by",
-          "value": "cachi2"
-        }
-      ],
-      "purl": "pkg:golang/crypto/internal/subtle?type=package",
       "type": "library"
     },
     {
@@ -862,6 +884,17 @@
         }
       ],
       "purl": "pkg:golang/internal/bytealg?type=package",
+      "type": "library"
+    },
+    {
+      "name": "internal/coverage/rtcov",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:golang/internal/coverage/rtcov?type=package",
       "type": "library"
     },
     {
@@ -1657,28 +1690,6 @@
       "type": "library"
     },
     {
-      "name": "vendor/golang.org/x/crypto/curve25519/internal/field",
-      "properties": [
-        {
-          "name": "cachi2:found_by",
-          "value": "cachi2"
-        }
-      ],
-      "purl": "pkg:golang/vendor/golang.org/x/crypto/curve25519/internal/field?type=package",
-      "type": "library"
-    },
-    {
-      "name": "vendor/golang.org/x/crypto/curve25519",
-      "properties": [
-        {
-          "name": "cachi2:found_by",
-          "value": "cachi2"
-        }
-      ],
-      "purl": "pkg:golang/vendor/golang.org/x/crypto/curve25519?type=package",
-      "type": "library"
-    },
-    {
       "name": "vendor/golang.org/x/crypto/hkdf",
       "properties": [
         {
@@ -1690,6 +1701,17 @@
       "type": "library"
     },
     {
+      "name": "vendor/golang.org/x/crypto/internal/alias",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:golang/vendor/golang.org/x/crypto/internal/alias?type=package",
+      "type": "library"
+    },
+    {
       "name": "vendor/golang.org/x/crypto/internal/poly1305",
       "properties": [
         {
@@ -1698,17 +1720,6 @@
         }
       ],
       "purl": "pkg:golang/vendor/golang.org/x/crypto/internal/poly1305?type=package",
-      "type": "library"
-    },
-    {
-      "name": "vendor/golang.org/x/crypto/internal/subtle",
-      "properties": [
-        {
-          "name": "cachi2:found_by",
-          "value": "cachi2"
-        }
-      ],
-      "purl": "pkg:golang/vendor/golang.org/x/crypto/internal/subtle?type=package",
       "type": "library"
     },
     {

--- a/tests/integration/test_data/gomod_go_generate_imported/bom.json
+++ b/tests/integration/test_data/gomod_go_generate_imported/bom.json
@@ -149,6 +149,17 @@
       "type": "library"
     },
     {
+      "name": "internal/coverage/rtcov",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:golang/internal/coverage/rtcov?type=package",
+      "type": "library"
+    },
+    {
       "name": "internal/cpu",
       "properties": [
         {

--- a/tests/integration/test_data/gomod_local_deps/bom.json
+++ b/tests/integration/test_data/gomod_local_deps/bom.json
@@ -106,6 +106,17 @@
       "type": "library"
     },
     {
+      "name": "internal/coverage/rtcov",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:golang/internal/coverage/rtcov?type=package",
+      "type": "library"
+    },
+    {
       "name": "internal/cpu",
       "properties": [
         {

--- a/tests/integration/test_data/gomod_vendor_check_correct_vendor/bom.json
+++ b/tests/integration/test_data/gomod_vendor_check_correct_vendor/bom.json
@@ -117,6 +117,17 @@
       "type": "library"
     },
     {
+      "name": "internal/coverage/rtcov",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:golang/internal/coverage/rtcov?type=package",
+      "type": "library"
+    },
+    {
       "name": "internal/cpu",
       "properties": [
         {

--- a/tests/integration/test_data/gomod_vendor_check_no_vendor/bom.json
+++ b/tests/integration/test_data/gomod_vendor_check_no_vendor/bom.json
@@ -117,6 +117,17 @@
       "type": "library"
     },
     {
+      "name": "internal/coverage/rtcov",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:golang/internal/coverage/rtcov?type=package",
+      "type": "library"
+    },
+    {
       "name": "internal/cpu",
       "properties": [
         {

--- a/tests/integration/test_data/gomod_vendored_with_flag/bom.json
+++ b/tests/integration/test_data/gomod_vendored_with_flag/bom.json
@@ -117,6 +117,17 @@
       "type": "library"
     },
     {
+      "name": "internal/coverage/rtcov",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:golang/internal/coverage/rtcov?type=package",
+      "type": "library"
+    },
+    {
       "name": "internal/cpu",
       "properties": [
         {

--- a/tests/integration/test_data/gomod_with_deps/bom.json
+++ b/tests/integration/test_data/gomod_with_deps/bom.json
@@ -117,6 +117,17 @@
       "type": "library"
     },
     {
+      "name": "internal/coverage/rtcov",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:golang/internal/coverage/rtcov?type=package",
+      "type": "library"
+    },
+    {
       "name": "internal/cpu",
       "properties": [
         {


### PR DESCRIPTION
This change is primarily meant to get Go 1.20:

https://tip.golang.org/doc/go1.20

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
