### PR TITLE
cachi2 yarn: test cases

### DIFF
--- a/tests/integration/test_yarn.py
+++ b/tests/integration/test_yarn.py
@@ -1,0 +1,61 @@
+import logging
+from pathlib import Path
+
+import pytest
+
+from . import utils
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    "test_params",
+    [
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-yarn-berry.git",
+                ref="4b77c878694e656e7d0ceac6771131273f98f5df",
+                packages=({"path": ".", "type": "yarn"},),
+                check_vendor_checksums=False,
+                expected_exit_code=0,
+                expected_output="All dependencies fetched successfully",
+            ),
+            marks=pytest.mark.xfail,  # temporary
+            id="yarn_zero_installs",
+        ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-yarn-berry.git",
+                ref="452d7f530513206de63af402536e9ff736c2aa79",
+                packages=({"path": ".", "type": "yarn"},),
+                check_vendor_checksums=False,
+                expected_exit_code=0,
+                expected_output="All dependencies fetched successfully",
+            ),
+            marks=pytest.mark.xfail,  # temporary
+            id="yarn_no_zero_installs",
+        ),
+    ],
+)
+def test_yarn_packages(
+    test_params: utils.TestParameters,
+    cachi2_image: utils.ContainerImage,
+    tmp_path: Path,
+    test_data_dir: Path,
+    request: pytest.FixtureRequest,
+) -> None:
+    """
+    Test fetched dependencies for yarn 2+.
+
+    :param test_params: Test case arguments
+    :param tmp_path: Temp directory for pytest
+    """
+    test_case = request.node.callspec.id
+
+    source_folder = utils.clone_repository(
+        test_params.repo, test_params.ref, f"{test_case}-source", tmp_path
+    )
+
+    utils.fetch_deps_and_check_output(
+        tmp_path, test_case, test_params, source_folder, test_data_dir, cachi2_image
+    )


### PR DESCRIPTION
STONEBLD-1686

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [n/a] Code coverage from testing does not decrease and new code is covered
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)
