### PR TITLE
Implement classes to parse Yarn files

### DIFF
--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -61,7 +61,11 @@ def _configure_yarn_version(project: Project) -> None:
         if the yarn version can't be determined from either yarnPath or packageManager
         if there is a mismatch between the yarn version specified by yarnPath and PackageManager
     """
-    yarn_path_version = get_semver_from_yarn_path(project.yarn_rc.yarn_path)
+    if project.yarn_rc:
+        yarn_path_version = get_semver_from_yarn_path(project.yarn_rc.yarn_path)
+    else:
+        yarn_path_version = None
+
     package_manager_version = get_semver_from_package_manager(project.package_json.package_manager)
 
     if not yarn_path_version and not package_manager_version:

--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -38,6 +38,8 @@ def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Comp
     :param project: the directory to be processed.
     :param output_dir: the directory where the prefetched dependencies will be placed.
     """
+    log.info(f"Fetching the yarn dependencies at the subpath {output_dir.subpath_from_root}")
+
     _configure_yarn_version(project)
 
     try:

--- a/tests/unit/package_managers/yarn/test_project.py
+++ b/tests/unit/package_managers/yarn/test_project.py
@@ -4,11 +4,199 @@ from typing import Optional
 import pytest
 import semver
 
-from cachi2.core.errors import UnexpectedFormat
+from cachi2.core.errors import PackageRejected, UnexpectedFormat
 from cachi2.core.package_managers.yarn.project import (
+    PackageJson,
+    Project,
+    YarnRc,
     get_semver_from_package_manager,
     get_semver_from_yarn_path,
 )
+from cachi2.core.rooted_path import PathOutsideRoot, RootedPath
+
+VALID_YARNRC_FILE = """
+plugins:
+  - path: .yarn/plugins/@yarnpkg/plugin-typescript.cjs
+    spec: "@yarnpkg/plugin-typescript"
+  - path: .yarn/plugins/@yarnpkg/plugin-exec.cjs
+    spec: "@yarnpkg/plugin-exec"
+
+yarnPath: .custom/path/yarn-3.6.1.cjs
+
+enableInlineBuilds: true
+
+supportedArchitectures:
+  os:
+    - "linux"
+
+cacheFolder: ./.custom/cache
+
+npmRegistryServer: https://registry.alternative.com
+
+npmScopes:
+    foobar:
+        npmRegistryServer: https://registry.foobar.com
+"""
+
+EMPTY_YML_FILE = ""
+
+INVALID_YML = "this: is: not: valid: yaml"
+
+VALID_PACKAGE_JSON_FILE = """
+{
+  "name": "camelot",
+  "packageManager": "yarn@3.6.1"
+}
+"""
+
+EMPTY_JSON_FILE = "{}"
+
+INVALID_JSON = "totally not json"
+
+
+# --- YarnRc tests ---
+
+
+def _prepare_yarnrc_file(rooted_tmp_path: RootedPath, data: str) -> YarnRc:
+    path = rooted_tmp_path.join_within_root(".yarnrc.yml")
+
+    with open(path, "w") as f:
+        f.write(data)
+
+    return YarnRc.from_file(path)
+
+
+def test_parse_yarnrc(rooted_tmp_path: RootedPath) -> None:
+    yarn_rc = _prepare_yarnrc_file(rooted_tmp_path, VALID_YARNRC_FILE)
+
+    assert yarn_rc.cache_folder == "./.custom/cache"
+    assert yarn_rc.registry_server == "https://registry.alternative.com"
+    assert yarn_rc.registry_server_for_scope("foobar") == "https://registry.foobar.com"
+    assert yarn_rc.registry_server_for_scope("barfoo") == "https://registry.alternative.com"
+    assert yarn_rc.yarn_path == ".custom/path/yarn-3.6.1.cjs"
+
+
+def test_parse_empty_yarnrc(rooted_tmp_path: RootedPath) -> None:
+    yarn_rc = _prepare_yarnrc_file(rooted_tmp_path, EMPTY_YML_FILE)
+
+    assert yarn_rc.cache_folder == "./.yarn/cache"
+    assert yarn_rc.registry_server == "https://registry.yarnpkg.com"
+    assert yarn_rc.registry_server_for_scope("foobar") == "https://registry.yarnpkg.com"
+    assert yarn_rc.yarn_path is None
+
+
+def test_parse_invalid_yarnrc(rooted_tmp_path: RootedPath) -> None:
+    with pytest.raises(PackageRejected, match="Can't parse the .yarnrc.yml file"):
+        _prepare_yarnrc_file(rooted_tmp_path, INVALID_YML)
+
+
+# --- PackageJson tests ---
+
+
+def _prepare_package_json_file(rooted_tmp_path: RootedPath, data: str) -> PackageJson:
+    path = rooted_tmp_path.join_within_root("package.json")
+
+    with open(path, "w") as f:
+        f.write(data)
+
+    return PackageJson.from_file(path)
+
+
+def test_parse_package_json(rooted_tmp_path: RootedPath) -> None:
+    package_json = _prepare_package_json_file(rooted_tmp_path, VALID_PACKAGE_JSON_FILE)
+    assert package_json.package_manager == "yarn@3.6.1"
+
+
+def test_parse_empty_package_json_file(rooted_tmp_path: RootedPath) -> None:
+    package_json = _prepare_package_json_file(rooted_tmp_path, EMPTY_JSON_FILE)
+    assert package_json.package_manager is None
+
+
+def test_parse_invalid_package_json_file(rooted_tmp_path: RootedPath) -> None:
+    with pytest.raises(PackageRejected, match="Can't parse the package.json file"):
+        _prepare_package_json_file(rooted_tmp_path, INVALID_JSON)
+
+
+# --- Project tests ---
+
+
+def _add_mock_yarn_cache_file(cache_path: RootedPath) -> None:
+    cache_path.path.mkdir(parents=True)
+    file = cache_path.join_within_root("mock-package-0.0.1.zip")
+    file.path.touch()
+
+
+@pytest.mark.parametrize(
+    "is_zero_installs",
+    (
+        pytest.param(True, id="zero-installs-project"),
+        pytest.param(False, id="regular-workflow-project"),
+    ),
+)
+def test_parse_project_folder(rooted_tmp_path: RootedPath, is_zero_installs: bool) -> None:
+    _prepare_package_json_file(rooted_tmp_path, VALID_PACKAGE_JSON_FILE)
+    _prepare_yarnrc_file(rooted_tmp_path, VALID_YARNRC_FILE)
+
+    cache_path = "./.custom/cache"
+
+    if is_zero_installs:
+        _add_mock_yarn_cache_file(rooted_tmp_path.join_within_root(cache_path))
+
+    project = Project.from_source_dir(rooted_tmp_path)
+
+    assert project.is_zero_installs == is_zero_installs
+    assert project.yarn_cache == rooted_tmp_path.join_within_root(cache_path)
+
+    assert project.yarn_rc is not None
+    assert project.yarn_rc._path == rooted_tmp_path.join_within_root(".yarnrc.yml")
+    assert project.package_json._path == rooted_tmp_path.join_within_root("package.json")
+
+
+@pytest.mark.parametrize(
+    "is_zero_installs",
+    (
+        pytest.param(True, id="zero-installs-project"),
+        pytest.param(False, id="regular-workflow-project"),
+    ),
+)
+def test_parse_project_folder_without_yarnrc(
+    rooted_tmp_path: RootedPath, is_zero_installs: bool
+) -> None:
+    _prepare_package_json_file(rooted_tmp_path, VALID_PACKAGE_JSON_FILE)
+
+    if is_zero_installs:
+        _add_mock_yarn_cache_file(rooted_tmp_path.join_within_root("./.yarn/cache"))
+
+    project = Project.from_source_dir(rooted_tmp_path)
+
+    assert project.is_zero_installs == is_zero_installs
+    assert project.yarn_cache == rooted_tmp_path.join_within_root("./.yarn/cache")
+
+    assert project.yarn_rc is None
+    assert project.package_json._path == rooted_tmp_path.join_within_root("package.json")
+
+
+def test_parse_empty_folder(rooted_tmp_path: RootedPath) -> None:
+    message = "The package.json file must be present for the yarn package manager"
+    with pytest.raises(PackageRejected, match=message):
+        Project.from_source_dir(rooted_tmp_path)
+
+
+def test_parsing_cache_folder_that_resolves_outside_of_the_repository(
+    rooted_tmp_path: RootedPath,
+) -> None:
+    yarn_rc = VALID_YARNRC_FILE.replace("./.custom/cache", "../.custom/cache")
+
+    _prepare_yarnrc_file(rooted_tmp_path, yarn_rc)
+    _prepare_package_json_file(rooted_tmp_path, VALID_PACKAGE_JSON_FILE)
+
+    project = Project.from_source_dir(rooted_tmp_path)
+
+    with pytest.raises(PathOutsideRoot):
+        project.yarn_cache
+
+
+# --- Semver parsing tests ---
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Implement the classes stablished by the high-level code design (#309) to parse Yarn files (i.e. package.json and yarnrc.yml). 

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- n/a Docs updated (if applicable)
- n/a Docs links in the code are still valid (if docs were updated)
