### PR TITLE
Make it harder to omit a locator test by mistake

### DIFF
--- a/tests/unit/package_managers/yarn/test_locators.py
+++ b/tests/unit/package_managers/yarn/test_locators.py
@@ -1,4 +1,5 @@
 import re
+from itertools import zip_longest
 from pathlib import Path
 
 import pytest
@@ -410,7 +411,7 @@ PARSED_SUPPORTED_LOCATORS = [
     "locator_str, expect_parsed_locator, expect_parsed_reference",
     [
         (locator_str, parsed_locator, parsed_reference)
-        for locator_str, (parsed_locator, parsed_reference) in zip(
+        for locator_str, (parsed_locator, parsed_reference) in zip_longest(
             ALL_LOCATORS, PARSED_LOCATORS_AND_REFERENCES
         )
     ],
@@ -457,7 +458,7 @@ def test_unexpected_reference_format() -> None:
 
 
 @pytest.mark.parametrize(
-    "locator_str, expect_locator", zip(SUPPORTED_LOCATORS, PARSED_SUPPORTED_LOCATORS)
+    "locator_str, expect_locator", zip_longest(SUPPORTED_LOCATORS, PARSED_SUPPORTED_LOCATORS)
 )
 def test_parse_locator(locator_str: str, expect_locator: Locator) -> None:
     assert parse_locator(locator_str) == expect_locator


### PR DESCRIPTION
The test parametrization zips the input with the expected output. Zip stops when the shortest iterable ends. That means if the input and output lists have different lengths, cases can be omitted accidentally.

zip(..., strict=True) would solve this on python>=3.10

We support python 3.9, so instead use zip_longest, which will "pad" the shorter list with None

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
