### PR TITLE
Makefile changes to improve (slightly) local development experience

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,22 @@ TOX_ARGS ?=
 .PHONY: clean
 all: venv
 
+define make_venv
+	$(PYTHON_BIN) -m venv $(VENV)
+	$(VENV)/bin/pip install --upgrade pip
+endef
+
 clean:
 	rm -rf dist venv .tox *.egg-info *.log*
 
+
+venv: PYTHON_BIN := $(shell which $(PYTHON_VERSION_VENV))
+venv: VENV := venv
 venv:
-	$(shell which $(PYTHON_VERSION_VENV)) -m venv venv
-	venv/bin/pip install --upgrade pip
-	venv/bin/pip install -r requirements.txt
-	venv/bin/pip install tox
-	venv/bin/pip install -e .
+	$(call make_venv)
+	$(VENV)/bin/pip install -r requirements.txt
+	$(VENV)/bin/pip install tox
+	$(VENV)/bin/pip install -e .
 
 test: venv
 	venv/bin/tox

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYTHON_VERSION_VENV ?= python3.9
+PYTHON_VERSION_VENV ?= python3
 TOX_ENVLIST ?= py39
 TOX_ARGS ?=
 
@@ -45,8 +45,12 @@ build-image:
 build-pristine-image:
 	podman build --pull-always --no-cache -t localhost/cachi2:latest .
 
-pip-compile: venv
-	venv/bin/pip install -U pip-tools
+pip-compile: PYTHON_BIN := $(shell which python3.9)
+pip-compile: VENV := $(shell mktemp -d -u --tmpdir --suffix .venv pip_compileXXX)
+pip-compile:
+	$(call make_venv)
+	$(VENV)/bin/pip install -U pip-tools
 	# --allow-unsafe: we use pkg_resources (provided by setuptools) as a runtime dependency
-	venv/bin/pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt pyproject.toml
-	venv/bin/pip-compile --all-extras --allow-unsafe --generate-hashes --output-file=requirements-extras.txt pyproject.toml
+	$(VENV)/bin/pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt pyproject.toml
+	$(VENV)/bin/pip-compile --all-extras --allow-unsafe --generate-hashes --output-file=requirements-extras.txt pyproject.toml
+	rm -rf $(VENV)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ TOX_ARGS ?=
 all: venv
 
 clean:
-	rm -rf venv && rm -rf *.egg-info && rm -rf dist && rm -rf *.log* && rm -rf .tox
+	rm -rf dist venv .tox *.egg-info *.log*
 
 .PHONY: venv
 venv:

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ PYTHON_VERSION_VENV ?= python3.9
 TOX_ENVLIST ?= py39
 TOX_ARGS ?=
 
+.PHONY: clean
 all: venv
 
 clean:
 	rm -rf dist venv .tox *.egg-info *.log*
 
-.PHONY: clean
 venv:
 	virtualenv --python=${PYTHON_VERSION_VENV} venv
 	venv/bin/pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: venv
 clean:
 	rm -rf dist venv .tox *.egg-info *.log*
 
-.PHONY: venv
+.PHONY: clean
 venv:
 	virtualenv --python=${PYTHON_VERSION_VENV} venv
 	venv/bin/pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -15,19 +15,19 @@ venv:
 	venv/bin/pip install tox
 	venv/bin/pip install -e .
 
-test:
+test: venv
 	venv/bin/tox
 
-test-unit:
+test-unit: venv
 	venv/bin/tox -e $(TOX_ENVLIST) -- $(TOX_ARGS)
 
-test-integration:
+test-integration: venv
 	venv/bin/tox -e integration
 
 mock-unittest-data:
 	hack/mock-unittest-data/gomod.sh
 
-generate-test-data:
+generate-test-data: venv
 	CACHI2_GENERATE_TEST_DATA=true venv/bin/tox -e integration
 
 build-image:
@@ -38,7 +38,7 @@ build-image:
 build-pristine-image:
 	podman build --pull-always --no-cache -t localhost/cachi2:latest .
 
-pip-compile:
+pip-compile: venv
 	venv/bin/pip install -U pip-tools
 	# --allow-unsafe: we use pkg_resources (provided by setuptools) as a runtime dependency
 	venv/bin/pip-compile --allow-unsafe --generate-hashes --output-file=requirements.txt pyproject.toml

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 	rm -rf dist venv .tox *.egg-info *.log*
 
 venv:
-	virtualenv --python=${PYTHON_VERSION_VENV} venv
+	$(shell which $(PYTHON_VERSION_VENV)) -m venv venv
 	venv/bin/pip install --upgrade pip
 	venv/bin/pip install -r requirements.txt
 	venv/bin/pip install tox

--- a/README.md
+++ b/README.md
@@ -140,7 +140,10 @@ source venv/bin/activate
 This installs the Cachi2 CLI in [editable mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html),
 which means changes to the source code will reflect in the behavior of the CLI without the need for reinstalling.
 
-You may need to install the following dependencies before creating the virtual environment:
+You may need to install Python 3.9 in case you're adding new dependencies to
+the project as the requirements files are locked to 3.9 by pip-compile or if
+you simply want to test your changes against Python 3.9 locally before
+submitting a pull request.
 
 ```shell
 dnf install python3.9

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ when downloading Go modules. See [Go environment variables](https://go.dev/ref/m
 
 ## Development
 
-### Virtualenv
+### Virtual environment
 
 Set up a virtual environment that has everything you will need for development:
 
@@ -140,10 +140,10 @@ source venv/bin/activate
 This installs the Cachi2 CLI in [editable mode](https://setuptools.pypa.io/en/latest/userguide/development_mode.html),
 which means changes to the source code will reflect in the behavior of the CLI without the need for reinstalling.
 
-You may need to install the following dependencies before creating the virtualenv:
+You may need to install the following dependencies before creating the virtual environment:
 
 ```shell
-dnf install python3.9 python3-virtualenv
+dnf install python3.9
 ```
 
 The CLI also depends on the following non-Python dependencies:


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- n/a Code coverage from testing does not decrease and new code is covered
- [x] Docs updated (if applicable)
- n/a Docs links in the code are still valid (if docs were updated)
---

- optimizes the `clean` target
- drops the `virtualenv` dependency
- drops the hard 3.9 dependency on the local virtual environments

The last 2 patches are a bit controversial in how they address creation of the virtual environments:
- venv doesn't default to python3.9 anymore because whatever the default python3 on the local system is should do just fine
- force only the `pip-compile` target to Python3.9 as that is kind of a hard dependency that would otherwise potentially cause a regression

I'm open to other suggestions for the ^above as unarguably it's not a particularly nice approach.