### PR TITLE
Yarnberry: resolve package names and versions

### DIFF
--- a/cachi2/core/package_managers/yarn/locators.py
+++ b/cachi2/core/package_managers/yarn/locators.py
@@ -169,7 +169,7 @@ def _parse_patch_locator(locator: "_ParsedLocator") -> PatchLocator:
         else:
             return Path(patch)
 
-    patches = [process_patch_path(p) for p in reference.selector.split("&")]
+    patches = tuple(process_patch_path(p) for p in reference.selector.split("&"))
     if locator_param := reference.get_param("locator"):
         parent_locator = parse_locator(locator_param)
         if not isinstance(parent_locator, WorkspaceLocator):

--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -8,10 +8,7 @@ from cachi2.core.package_managers.yarn.project import (
     get_semver_from_package_manager,
     get_semver_from_yarn_path,
 )
-from cachi2.core.package_managers.yarn.resolver import (
-    create_component_from_package,
-    resolve_packages,
-)
+from cachi2.core.package_managers.yarn.resolver import create_components, resolve_packages
 from cachi2.core.package_managers.yarn.utils import run_yarn_cmd
 from cachi2.core.rooted_path import RootedPath
 
@@ -53,7 +50,7 @@ def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Comp
     finally:
         _undo_changes(project)
 
-    return [create_component_from_package(package, project) for package in packages]
+    return create_components(packages, project)
 
 
 def _configure_yarn_version(project: Project) -> None:

--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -50,7 +50,7 @@ def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Comp
     finally:
         _undo_changes(project)
 
-    return create_components(packages, project)
+    return create_components(packages, project, output_dir)
 
 
 def _configure_yarn_version(project: Project) -> None:

--- a/cachi2/core/package_managers/yarn/resolver.py
+++ b/cachi2/core/package_managers/yarn/resolver.py
@@ -124,16 +124,18 @@ def resolve_packages(source_dir: RootedPath) -> list[Package]:
     return packages
 
 
-def create_component_from_package(package: Package, project: Project) -> Component:
-    """Create a SBOM component from a yarn Package."""
-    # if the SBOM generation code grows too much, it may be a good idea to split it into a dedicated
-    # module.
-
-    name = _resolve_package_name(package)
-
-    return Component(
-        name=name, version=package.version, purl=_generate_purl_for_package(package, name, project)
-    )
+def create_components(packages: list[Package], project: Project) -> list[Component]:
+    """Create SBOM components for all the packages parsed from the 'yarn info' output."""
+    components = []
+    for package in packages:
+        name = _resolve_package_name(package)
+        component = Component(
+            name=name,
+            version=package.version,
+            purl=_generate_purl_for_package(package, name, project),
+        )
+        components.append(component)
+    return components
 
 
 def _resolve_package_name(package: Package) -> str:

--- a/cachi2/core/package_managers/yarn/resolver.py
+++ b/cachi2/core/package_managers/yarn/resolver.py
@@ -124,9 +124,11 @@ def resolve_packages(source_dir: RootedPath) -> list[Package]:
     return packages
 
 
-def create_components(packages: list[Package], project: Project) -> list[Component]:
+def create_components(
+    packages: list[Package], project: Project, output_dir: RootedPath
+) -> list[Component]:
     """Create SBOM components for all the packages parsed from the 'yarn info' output."""
-    component_resolver = _ComponentResolver(project)
+    component_resolver = _ComponentResolver(project, output_dir)
     return [component_resolver.get_component(package) for package in packages]
 
 
@@ -150,8 +152,9 @@ class _ResolvedPackage:
 
 
 class _ComponentResolver:
-    def __init__(self, project: Project) -> None:
+    def __init__(self, project: Project, output_dir: RootedPath) -> None:
         self._project = project
+        self._output_dir = output_dir
 
     def get_component(self, package: Package) -> Component:
         """Create an SBOM component for a yarn Package."""

--- a/tests/unit/package_managers/yarn/test_locators.py
+++ b/tests/unit/package_managers/yarn/test_locators.py
@@ -8,9 +8,11 @@ from cachi2.core.errors import UnexpectedFormat, UnsupportedFeature
 from cachi2.core.package_managers.yarn.locators import (
     FileLocator,
     HttpsLocator,
+    LinkLocator,
     Locator,
     NpmLocator,
     PatchLocator,
+    PortalLocator,
     WorkspaceLocator,
     _parse_locator,
     _parse_reference,
@@ -341,11 +343,13 @@ PARSED_SUPPORTED_LOCATORS = [
     NpmLocator(scope=None, name="agent-base", version="6.0.2"),
     WorkspaceLocator(scope="montypython", name="brian", relpath=Path("packages/the-life-of/brian")),
     WorkspaceLocator(scope=None, name="the-answer", relpath=Path("packages/the-answer")),
-    FileLocator(
+    LinkLocator(
+        scope=None,
+        name="ansi-regex-link",
         relpath=Path("external-packages/ansi-regex"),
         locator=WorkspaceLocator(scope=None, name="berryscary", relpath=Path(".")),
     ),
-    FileLocator(
+    PortalLocator(
         relpath=Path("external-packages/once"),
         locator=WorkspaceLocator(scope=None, name="berryscary", relpath=Path(".")),
     ),

--- a/tests/unit/package_managers/yarn/test_locators.py
+++ b/tests/unit/package_managers/yarn/test_locators.py
@@ -369,39 +369,39 @@ PARSED_SUPPORTED_LOCATORS = [
     NpmLocator(scope=None, name="left-pad", version="1.3.0"),
     PatchLocator(
         package=NpmLocator(scope=None, name="left-pad", version="1.3.0"),
-        patches=[Path("my-patches/left-pad.patch")],
+        patches=(Path("my-patches/left-pad.patch"),),
         locator=WorkspaceLocator(scope=None, name="berryscary", relpath=Path(".")),
     ),
     NpmLocator(scope=None, name="fsevents", version="2.3.2"),
     PatchLocator(
         package=NpmLocator(scope=None, name="fsevents", version="2.3.2"),
-        patches=["builtin<compat/fsevents>"],
+        patches=("builtin<compat/fsevents>",),
         locator=None,
     ),
     PatchLocator(
         package=PatchLocator(
             package=NpmLocator(scope=None, name="fsevents", version="2.3.2"),
-            patches=[Path("my-patches/fsevents.patch")],
+            patches=(Path("my-patches/fsevents.patch"),),
             locator=WorkspaceLocator(scope=None, name="berryscary", relpath=Path(".")),
         ),
-        patches=["builtin<compat/fsevents>"],
+        patches=("builtin<compat/fsevents>",),
         locator=None,
     ),
     NpmLocator(scope=None, name="typescript", version="5.1.6"),
     PatchLocator(
         package=NpmLocator(scope=None, name="typescript", version="5.1.6"),
-        patches=["builtin<compat/typescript>"],
+        patches=("builtin<compat/typescript>",),
         locator=None,
     ),
     NpmLocator(scope=None, name="is-positive", version="3.1.0"),
     PatchLocator(
         package=NpmLocator(scope=None, name="is-positive", version="3.1.0"),
-        patches=[
+        patches=(
             "builtin<foo>",
             Path("my-patches/is-positive.patch"),
             "builtin<bar>",
             Path("baz.patch"),
-        ],
+        ),
         locator=WorkspaceLocator(scope=None, name="berryscary", relpath=Path(".")),
     ),
 ]
@@ -462,6 +462,8 @@ def test_unexpected_reference_format() -> None:
 )
 def test_parse_locator(locator_str: str, expect_locator: Locator) -> None:
     assert parse_locator(locator_str) == expect_locator
+    # test that all locator types are hashable
+    hash(expect_locator)
 
 
 @pytest.mark.parametrize("locator_str", UNSUPPORTED_LOCATORS)

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -467,28 +467,6 @@ def mock_project(project_dir: RootedPath) -> Project:
             ],
             id="https_package",
         ),
-        # Patch package
-        pytest.param(
-            MockedPackage(
-                Package(
-                    raw_locator="fsevents@patch:fsevents@npm%3A2.3.2#./my-patches/fsevents.patch::version=2.3.2&hash=cf0bf0&locator=berryscary%40workspace%3A.",
-                    version="2.3.2",
-                    checksum="f73215b04b52395389a612af4d30f7f412752cdfba1580c9e32c7ec259e448b57b464a4d0474427d6142f5ed9a6260fc1841d61834caf44706d77874fba6f17f",
-                    cache_path="cache/directory/fsevents-patch-9d1204d729-f73215b04b.zip",
-                ),
-                is_hardlink=True,
-                packjson_path="node_modules/fsevents/package.json",
-                packjson_content=json.dumps({"name": "fsevents"}),
-            ),
-            Component(name="fsevents", version="2.3.2", purl=""),
-            [
-                (
-                    "fsevents@patch:fsevents@npm%3A2.3.2#./my-patches/fsevents.patch::version=2.3.2&hash=cf0bf0&locator=berryscary%40workspace%3A.: "
-                    "reading package name from cache/directory/fsevents-patch-9d1204d729-f73215b04b.zip"
-                ),
-            ],
-            id="patch_package",
-        ),
     ],
 )
 @pytest.mark.parametrize("project_uses_zero_installs", [True, False])
@@ -514,6 +492,79 @@ def test_create_components_single_package(
     # TODO: just assert that components[0] == expect_component once purls are implemented
     assert components[0].name == expect_component.name
     assert components[0].version == expect_component.version
+
+    assert caplog.messages == expect_logs
+
+
+def test_create_components_patched_packages(
+    rooted_tmp_path: RootedPath,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    project_dir = rooted_tmp_path
+
+    mocked_packages = [
+        MockedPackage(
+            Package(
+                raw_locator="fsevents@patch:fsevents@npm%3A2.3.2#./my-patches/fsevents.patch::version=2.3.2&hash=cf0bf0&locator=berryscary%40workspace%3A.",
+                version="2.3.2",
+                checksum="f73215b04b52395389a612af4d30f7f412752cdfba1580c9e32c7ec259e448b57b464a4d0474427d6142f5ed9a6260fc1841d61834caf44706d77874fba6f17f",
+                cache_path=project_dir.join_within_root(
+                    ".yarn/cache/fsevents-patch-9d1204d729-f73215b04b.zip"
+                ).path.as_posix(),
+            ),
+            is_hardlink=True,
+            packjson_path="node_modules/fsevents/package.json",
+            packjson_content=json.dumps({"name": "@patch1/fsevents"}),
+        ),
+        MockedPackage(
+            Package(
+                # Note: this package patches the patched package above
+                raw_locator="fsevents@patch:fsevents@patch%3Afsevents@npm%253A2.3.2%23./my-patches/fsevents.patch%3A%3Aversion=2.3.2&hash=cf0bf0&locator=berryscary%2540workspace%253A.#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1",
+                # normally, the versions would almost certainly be the same, but we need something
+                #   to tell the two packages apart
+                version="2.3.2-patch2",
+                checksum=None,
+                cache_path=project_dir.join_within_root(
+                    ".yarn/cache/fsevents-patch-e4409ad759-8.zip"
+                ).path.as_posix(),
+            ),
+            is_hardlink=True,
+        ),
+    ]
+
+    # the first package has a zip archive in the cache
+    mock_package_json(mocked_packages[0], project_dir)
+    # the second one does not
+    # ~~mock_package_json(mocked_packages[1], project_dir)~~
+
+    components = create_components(
+        [mocked_package.package for mocked_package in mocked_packages],
+        mock_project(project_dir),
+        output_dir=RootedPath("/unused"),
+    )
+
+    expect_components = [
+        Component(name="@patch1/fsevents", version="2.3.2", purl=""),
+        Component(name="@patch1/fsevents", version="2.3.2-patch2", purl=""),
+    ]
+
+    # TODO: just assert that components == expect_components once purls are implemented
+    assert len(components) == len(expect_components)
+    for component, expect_component in zip(components, expect_components):
+        assert component.name == expect_component.name
+        assert component.version == expect_component.version
+
+    patch_locator = "fsevents@patch:fsevents@npm%3A2.3.2#./my-patches/fsevents.patch::version=2.3.2&hash=cf0bf0&locator=berryscary%40workspace%3A."
+    patchpatch_locator = "fsevents@patch:fsevents@patch%3Afsevents@npm%253A2.3.2%23./my-patches/fsevents.patch%3A%3Aversion=2.3.2&hash=cf0bf0&locator=berryscary%2540workspace%253A.#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+
+    expect_logs = [
+        # the first package has an archive in the cache
+        f"{patch_locator}: reading package name from .yarn/cache/fsevents-patch-9d1204d729-f73215b04b.zip",
+        # the second one does not, so we fall back to the original package
+        f"{patchpatch_locator}: resolving the name of the original package",
+        # ...which is the first package
+        f"{patch_locator}: reading package name from .yarn/cache/fsevents-patch-9d1204d729-f73215b04b.zip",
+    ]
 
     assert caplog.messages == expect_logs
 
@@ -693,6 +744,24 @@ def test_create_components_single_package(
                 "expected a zip archive in the cache but 'yarn info' says there is none"
             ),
             id="https_no_cache_path",
+        ),
+        # No cache_path for a Patch package, missing original package
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="fsevents@patch:fsevents@npm%3A2.3.2#./my-patches/fsevents.patch::version=2.3.2&hash=cf0bf0&locator=berryscary%40workspace%3A.",
+                    version="2.3.2",
+                    checksum="f73215b04b52395389a612af4d30f7f412752cdfba1580c9e32c7ec259e448b57b464a4d0474427d6142f5ed9a6260fc1841d61834caf44706d77874fba6f17f",
+                    cache_path=None,
+                ),
+                is_hardlink=True,
+            ),
+            (
+                "Failed to resolve the name and version for "
+                "fsevents@patch:fsevents@npm%3A2.3.2#./my-patches/fsevents.patch::version=2.3.2&hash=cf0bf0&locator=berryscary%40workspace%3A.: "
+                "the 'yarn info' output does not include either an existing zip archive or the original unpatched package"
+            ),
+            id="patch_no_cache_path_no_orig_package",
         ),
     ],
 )

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -1,13 +1,26 @@
 import json
-from typing import Any
+import re
+import zipfile
+from pathlib import Path
+from typing import Any, NamedTuple, Optional
 from unittest import mock
 
 import pytest
 
-from cachi2.core.errors import UnsupportedFeature
+from cachi2.core.errors import PackageRejected, UnsupportedFeature
+from cachi2.core.models.sbom import Component
 from cachi2.core.package_managers.yarn.locators import parse_locator
-from cachi2.core.package_managers.yarn.resolver import Package, resolve_packages
+from cachi2.core.package_managers.yarn.project import PackageJson, Project, YarnRc
+from cachi2.core.package_managers.yarn.resolver import Package, create_components, resolve_packages
 from cachi2.core.rooted_path import RootedPath
+
+
+def setup_module() -> None:
+    """Re-enable logging that was disabled at some point in previous tests."""
+    from cachi2.core.package_managers.yarn.resolver import log as yarn_resolver_logger
+
+    yarn_resolver_logger.disabled = False
+    yarn_resolver_logger.setLevel("DEBUG")
 
 
 def mock_yarn_info_output(yarn_info_outputs: list[dict[str, Any]]) -> str:
@@ -230,3 +243,495 @@ def test_validate_unsupported_locators(
         "Cachi2 does not support Git or Exec dependencies for Yarn Berry: ccto-wo-deps@git@github.com:cachito-testing/cachito-npm-without-deps.git#commit=2f0ce1d7b1f8b35572d919428b965285a69583f6",
         "Cachi2 does not support Git or Exec dependencies for Yarn Berry: holy-hand-grenade@exec:./generate-holy-hand-grenade.js#./generate-holy-hand-grenade.js::hash=3b5cbd&locator=berryscary%40workspace%3A.",
     ]
+
+
+class MockedPackage(NamedTuple):
+    package: Package
+    is_hardlink: bool
+    packjson_path: Optional[str] = None
+    packjson_content: Optional[str] = None
+
+    def resolve_cache_path(self, root_dir: RootedPath) -> "MockedPackage":
+        cache_path = self.package.cache_path
+        if cache_path:
+            cache_path = root_dir.join_within_root(cache_path).path.as_posix()
+        package = Package(
+            raw_locator=self.package.raw_locator,
+            version=self.package.version,
+            checksum=self.package.checksum,
+            cache_path=cache_path,
+        )
+        return MockedPackage(package, self.is_hardlink, self.packjson_path, self.packjson_content)
+
+
+def mock_package_json(
+    mocked_package: MockedPackage,
+    project_dir: RootedPath,
+) -> None:
+    package, is_hardlink, packjson_path, packjson_content = mocked_package
+
+    if is_hardlink:
+        if not package.cache_path:
+            assert not (
+                packjson_path or packjson_content
+            ), f"cache_path=None, is_hardlink=True => can't mock package.json: {package.raw_locator}"
+            return
+
+        zipfile_path = Path(package.cache_path)
+        zipfile_path.parent.mkdir(exist_ok=True, parents=True)
+
+        # create zip file if the package has a cache_path
+        with zipfile.ZipFile(zipfile_path, "w") as zf:
+            # write package.json if it should exist
+            if packjson_path and packjson_content:
+                zf.writestr(packjson_path, packjson_content)
+
+    elif packjson_path and packjson_content:
+        # write package.json (if it should exist) directly to project dir
+        path = project_dir.join_within_root(packjson_path).path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(packjson_content)
+
+
+def mock_project(project_dir: RootedPath) -> Project:
+    return Project(
+        project_dir,
+        YarnRc(project_dir.join_within_root(".yarnrc.yml"), {}),
+        PackageJson(project_dir.join_within_root("package.json"), {}),
+    )
+
+
+@pytest.mark.parametrize(
+    "mocked_package, expect_component, expect_logs",
+    [
+        # Scoped npm package
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="@isaacs/cliui@npm:8.0.2",
+                    version="8.0.2",
+                    checksum="4a473b9b32a7d4d3cfb7a614226e555091ff0c5a29a1734c28c72a182c2f6699b26fc6b5c2131dfd841e86b185aea714c72201d7c98c2fba5f17709333a67aeb",
+                    # we don't need the cache archive to resolve an npm dependency
+                    cache_path=None,
+                ),
+                is_hardlink=True,
+            ),
+            # TODO: test purls once they are implemented
+            Component(name="@isaacs/cliui", version="8.0.2", purl=""),
+            [],
+            id="scoped_npm_package",
+        ),
+        # Unscoped npm package
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="abbrev@npm:1.1.1",
+                    version="1.1.1",
+                    checksum="a4a97ec07d7ea112c517036882b2ac22f3109b7b19077dc656316d07d308438aac28e4d9746dc4d84bf6b1e75b4a7b0a5f3cb30592419f128ca9a8cee3bcfa17",
+                    cache_path=None,
+                ),
+                is_hardlink=True,
+            ),
+            Component(name="abbrev", version="1.1.1", purl=""),
+            [],
+            id="unscoped_npm_package",
+        ),
+        # Workspace
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="armaments@workspace:./book/armaments",
+                    version=None,
+                    checksum=None,
+                    cache_path=None,
+                ),
+                is_hardlink=False,
+                packjson_path="book/armaments/package.json",
+                packjson_content=json.dumps({"name": "armaments", "version": "42.0.0"}),
+            ),
+            Component(name="armaments", version="42.0.0", purl=""),
+            [
+                "armaments@workspace:./book/armaments: reading package version from book/armaments/package.json"
+            ],
+            id="workspace_package",
+        ),
+        # Portal package
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="antioch@portal:holy-hand-grenade::locator=armaments%40workspace%3A./book/armaments",
+                    version=None,
+                    checksum=None,
+                    cache_path=None,
+                ),
+                is_hardlink=False,
+                # {path_to_workspace}/{path_to_portal}/package.json
+                packjson_path="book/armaments/holy-hand-grenade/package.json",
+                packjson_content=json.dumps(
+                    {"name": "@antioch/holy-hand-grenade", "version": "1.2.5-threesir"}
+                ),
+            ),
+            Component(name="@antioch/holy-hand-grenade", version="1.2.5-threesir", purl=""),
+            [
+                (
+                    "antioch@portal:holy-hand-grenade::locator=armaments%40workspace%3A./book/armaments: "
+                    "reading package name and version from book/armaments/holy-hand-grenade/package.json"
+                )
+            ],
+            id="portal_package",
+        ),
+        # Same as above, but as a Link package
+        # Link packages don't need package.json, but if they have one, let's take it into account
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="antioch@link:holy-hand-grenade::locator=armaments%40workspace%3A./book/armaments",
+                    version=None,
+                    checksum=None,
+                    cache_path=None,
+                ),
+                is_hardlink=False,
+                packjson_path="book/armaments/holy-hand-grenade/package.json",
+                packjson_content=json.dumps(
+                    {"name": "@antioch/holy-hand-grenade", "version": "1.2.5-threesir"}
+                ),
+            ),
+            Component(name="@antioch/holy-hand-grenade", version="1.2.5-threesir", purl=""),
+            [
+                (
+                    "antioch@link:holy-hand-grenade::locator=armaments%40workspace%3A./book/armaments: "
+                    "reading package name and version from book/armaments/holy-hand-grenade/package.json"
+                )
+            ],
+            id="link_package_that_happens_to_have_package_json",
+        ),
+        # A more typical Link package, with no package.json
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="antioch@link:holy-hand-grenade::locator=armaments%40workspace%3A./book/armaments",
+                    version=None,
+                    checksum=None,
+                    cache_path=None,
+                ),
+                is_hardlink=False,
+            ),
+            Component(name="antioch", version=None, purl=""),
+            [],
+            id="link_package",
+        ),
+        # File package
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.",
+                    version="4.0.0",
+                    checksum="d67629c87783bc1138a64f6495439b40f568424a05e068c341b4fc330745e8ba6e7f93536549883054c1da58761f0ce6ab039a233014b38240304d3c45f85ac6",
+                    # relative to project_dir or output_dir, depending on project_uses_zero_installs
+                    # NOTE: yarn info reports the absolute path, not the relative one. The test code
+                    #   fixes that later.
+                    cache_path="cache/directory/strip-ansi-tarball-file-489a50cded-d67629c877.zip",
+                ),
+                is_hardlink=True,
+                packjson_path="node_modules/strip-ansi-tarball/package.json",
+                packjson_content=json.dumps({"name": "strip-ansi"}),
+            ),
+            Component(name="strip-ansi", version="4.0.0", purl=""),
+            [
+                (
+                    "strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.: "
+                    "reading package name from cache/directory/strip-ansi-tarball-file-489a50cded-d67629c877.zip"
+                ),
+            ],
+            id="file_package",
+        ),
+        # Https package
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="@cachito/c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
+                    version="2.0.0",
+                    checksum="b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d",
+                    cache_path="cache/directory/c2-wo-deps-2-https-4261b189d8-b194fd1f4a.zip",
+                ),
+                is_hardlink=True,
+                packjson_path="node_modules/@cachito/c2-wo-deps-2/package.json",
+                packjson_content=json.dumps({"name": "bitbucket-cachi2-npm-without-deps-second"}),
+            ),
+            Component(name="bitbucket-cachi2-npm-without-deps-second", version="2.0.0", purl=""),
+            [
+                (
+                    "@cachito/c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz: "
+                    "reading package name from cache/directory/c2-wo-deps-2-https-4261b189d8-b194fd1f4a.zip"
+                ),
+            ],
+            id="https_package",
+        ),
+        # Patch package
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="fsevents@patch:fsevents@npm%3A2.3.2#./my-patches/fsevents.patch::version=2.3.2&hash=cf0bf0&locator=berryscary%40workspace%3A.",
+                    version="2.3.2",
+                    checksum="f73215b04b52395389a612af4d30f7f412752cdfba1580c9e32c7ec259e448b57b464a4d0474427d6142f5ed9a6260fc1841d61834caf44706d77874fba6f17f",
+                    cache_path="cache/directory/fsevents-patch-9d1204d729-f73215b04b.zip",
+                ),
+                is_hardlink=True,
+                packjson_path="node_modules/fsevents/package.json",
+                packjson_content=json.dumps({"name": "fsevents"}),
+            ),
+            Component(name="fsevents", version="2.3.2", purl=""),
+            [
+                (
+                    "fsevents@patch:fsevents@npm%3A2.3.2#./my-patches/fsevents.patch::version=2.3.2&hash=cf0bf0&locator=berryscary%40workspace%3A.: "
+                    "reading package name from cache/directory/fsevents-patch-9d1204d729-f73215b04b.zip"
+                ),
+            ],
+            id="patch_package",
+        ),
+    ],
+)
+@pytest.mark.parametrize("project_uses_zero_installs", [True, False])
+def test_create_components_single_package(
+    mocked_package: MockedPackage,
+    expect_component: Component,
+    expect_logs: list[str],
+    project_uses_zero_installs: bool,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    project_dir = RootedPath(tmp_path / "project")
+    output_dir = RootedPath(tmp_path / "output")
+
+    mocked_package = mocked_package.resolve_cache_path(
+        project_dir if project_uses_zero_installs else output_dir
+    )
+    mock_package_json(mocked_package, project_dir)
+
+    components = create_components([mocked_package.package], mock_project(project_dir), output_dir)
+
+    assert len(components) == 1
+    # TODO: just assert that components[0] == expect_component once purls are implemented
+    assert components[0].name == expect_component.name
+    assert components[0].version == expect_component.version
+
+    assert caplog.messages == expect_logs
+
+
+@pytest.mark.parametrize(
+    "mocked_package, expect_err_msg",
+    [
+        # No package.json for a Workspace
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="armaments@workspace:./book/armaments",
+                    version=None,
+                    checksum=None,
+                    cache_path=None,
+                ),
+                is_hardlink=False,
+                packjson_path=None,
+            ),
+            (
+                "Failed to resolve the name and version for armaments@workspace:./book/armaments: "
+                "missing book/armaments/package.json"
+            ),
+            id="workspace_no_package_json",
+        ),
+        # Invalid package.json
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="armaments@workspace:./book/armaments",
+                    version=None,
+                    checksum=None,
+                    cache_path=None,
+                ),
+                is_hardlink=False,
+                packjson_path="book/armaments/package.json",
+                packjson_content="{invalid JSON}",
+            ),
+            (
+                "Failed to resolve the name and version for armaments@workspace:./book/armaments: "
+                "book/armaments/package.json: invalid JSON "
+                "(Expecting property name enclosed in double quotes: line 1 column 2 (char 1))"
+            ),
+            id="invalid_package_json",
+        ),
+        # No package.json for a Portal package
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="antioch@portal:holy-hand-grenade::locator=armaments%40workspace%3A./book/armaments",
+                    version=None,
+                    checksum=None,
+                    cache_path=None,
+                ),
+                is_hardlink=False,
+                packjson_path=None,
+            ),
+            (
+                "Failed to resolve the name and version for "
+                "antioch@portal:holy-hand-grenade::locator=armaments%40workspace%3A./book/armaments: "
+                "missing book/armaments/holy-hand-grenade/package.json"
+            ),
+            id="portal_no_package_json",
+        ),
+        # No "name" in package.json for a Portal package
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="antioch@portal:holy-hand-grenade::locator=armaments%40workspace%3A./book/armaments",
+                    version=None,
+                    checksum=None,
+                    cache_path=None,
+                ),
+                is_hardlink=False,
+                packjson_path="book/armaments/holy-hand-grenade/package.json",
+                packjson_content="{}",
+            ),
+            (
+                "Failed to resolve the name and version for "
+                "antioch@portal:holy-hand-grenade::locator=armaments%40workspace%3A./book/armaments: "
+                "book/armaments/holy-hand-grenade/package.json: no 'name' attribute"
+            ),
+            id="portal_no_name_in_package_json",
+        ),
+        # No cache_path for a File package
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.",
+                    version="4.0.0",
+                    checksum="d67629c87783bc1138a64f6495439b40f568424a05e068c341b4fc330745e8ba6e7f93536549883054c1da58761f0ce6ab039a233014b38240304d3c45f85ac6",
+                    cache_path=None,
+                ),
+                is_hardlink=True,
+            ),
+            (
+                "Failed to resolve the name and version for "
+                "strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.: "
+                "expected a zip archive in the cache but 'yarn info' says there is none"
+            ),
+            id="file_no_cache_path",
+        ),
+        # Missing package.json in cache archive
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.",
+                    version="4.0.0",
+                    checksum="d67629c87783bc1138a64f6495439b40f568424a05e068c341b4fc330745e8ba6e7f93536549883054c1da58761f0ce6ab039a233014b38240304d3c45f85ac6",
+                    cache_path="cache/directory/strip-ansi-tarball-file-489a50cded-d67629c877.zip",
+                ),
+                is_hardlink=True,
+            ),
+            (
+                "Failed to resolve the name and version for "
+                "strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.: "
+                "cache/directory/strip-ansi-tarball-file-489a50cded-d67629c877.zip: no package.json"
+            ),
+            id="cache_archive_no_package_json",
+        ),
+        # Invalid package.json in cache archive
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.",
+                    version="4.0.0",
+                    checksum="d67629c87783bc1138a64f6495439b40f568424a05e068c341b4fc330745e8ba6e7f93536549883054c1da58761f0ce6ab039a233014b38240304d3c45f85ac6",
+                    cache_path="cache/directory/strip-ansi-tarball-file-489a50cded-d67629c877.zip",
+                ),
+                is_hardlink=True,
+                packjson_path="node_modules/strip-ansi-tarball/package.json",
+                packjson_content="{invalid JSON}",
+            ),
+            (
+                "Failed to resolve the name and version for "
+                "strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.: "
+                "cache/directory/strip-ansi-tarball-file-489a50cded-d67629c877.zip::node_modules/strip-ansi-tarball/package.json: "
+                "invalid JSON (Expecting property name enclosed in double quotes: line 1 column 2 (char 1))"
+            ),
+            id="cache_archive_invalid_package_json",
+        ),
+        # No "name" in package.json in cache archive
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.",
+                    version="4.0.0",
+                    checksum="d67629c87783bc1138a64f6495439b40f568424a05e068c341b4fc330745e8ba6e7f93536549883054c1da58761f0ce6ab039a233014b38240304d3c45f85ac6",
+                    cache_path="cache/directory/strip-ansi-tarball-file-489a50cded-d67629c877.zip",
+                ),
+                is_hardlink=True,
+                packjson_path="node_modules/strip-ansi-tarball/package.json",
+                packjson_content="{}",
+            ),
+            (
+                "Failed to resolve the name and version for "
+                "strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.: "
+                "cache/directory/strip-ansi-tarball-file-489a50cded-d67629c877.zip::node_modules/strip-ansi-tarball/package.json: "
+                "no 'name' attribute"
+            ),
+            id="cache_archive_no_name_in_package_json",
+        ),
+        # No cache_path for an Https package
+        pytest.param(
+            MockedPackage(
+                Package(
+                    raw_locator="@cachito/c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
+                    version="2.0.0",
+                    checksum="b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d",
+                    cache_path=None,
+                ),
+                is_hardlink=True,
+            ),
+            (
+                "Failed to resolve the name and version for "
+                "@cachito/c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz: "
+                "expected a zip archive in the cache but 'yarn info' says there is none"
+            ),
+            id="https_no_cache_path",
+        ),
+    ],
+)
+def test_create_components_failed_to_resolve(
+    mocked_package: MockedPackage,
+    expect_err_msg: str,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    project_dir = rooted_tmp_path
+    mocked_package = mocked_package.resolve_cache_path(project_dir)
+    mock_package_json(mocked_package, project_dir)
+
+    with pytest.raises(PackageRejected, match=re.escape(expect_err_msg)):
+        create_components(
+            [mocked_package.package],
+            mock_project(project_dir),
+            output_dir=RootedPath("/unused"),
+        )
+
+
+def test_create_components_cache_path_reported_but_missing(rooted_tmp_path: RootedPath) -> None:
+    package = Package(
+        raw_locator="strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.",
+        version="4.0.0",
+        checksum="d67629c87783bc1138a64f6495439b40f568424a05e068c341b4fc330745e8ba6e7f93536549883054c1da58761f0ce6ab039a233014b38240304d3c45f85ac6",
+        cache_path=rooted_tmp_path.join_within_root(
+            "cache/directory/strip-ansi-tarball-file-489a50cded-d67629c877.zip"
+        ).path.as_posix(),
+    )
+
+    expect_err_msg = (
+        "Failed to resolve the name and version for "
+        "strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.: "
+        "cache archive does not exist: cache/directory/strip-ansi-tarball-file-489a50cded-d67629c877.zip"
+    )
+
+    with pytest.raises(PackageRejected, match=re.escape(expect_err_msg)):
+        create_components(
+            [package],
+            mock_project(rooted_tmp_path),
+            output_dir=RootedPath("/unused"),
+        )


### PR DESCRIPTION
STONEBLD-1790

The entries returned by 'yarn info' do not necessarily contain the
correct names and versions of packages.

NAMES:
    Yarnberry lets the user specify an arbitrary name whenever the user
    adds any dependency other than an npm package or a workspace. The
    locator returned by 'yarn info' uses the user-specified name.

VERSIONS:
    When reporting local (soft-link, i.e. workspace, portal, link)
    packages, 'yarn info' uses '0.0.0-use.local' as the version.

Resolve the actual names and versions of packages from their
package.json files when necessary.

HARD-LINK:
* npm: trust the 'yarn info' data, it seems reliable
* Patch, File, Https: trust the version, resolve the name from the
  package.json in the cache archive
* Patch without a cache archive: try to resolve the name of the
  original package

SOFT-LINK:
* Workspace: trust the name, resolve the version from package.json
* Portal: resolve the name and version from package.json
* Link: if they happen to have a package.json, treat them the same as
  portal packages, otherwise use the name from the locator and don't
  report any version

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
