### PR TITLE
feat(cli): add 'dev-mode' flag

### DIFF
--- a/cachi2/core/models/input.py
+++ b/cachi2/core/models/input.py
@@ -99,7 +99,7 @@ class PipPackageInput(_PackageInputBase):
 
 
 class YarnPackageInput(_PackageInputBase):
-    """Accepted input for a npm package."""
+    """Accepted input for a yarn package."""
 
     type: Literal["yarn"]
 
@@ -168,7 +168,7 @@ class Request(pydantic.BaseModel):
 
     @property
     def yarn_packages(self) -> list[YarnPackageInput]:
-        """Get the gomod packages specified for this request."""
+        """Get the yarn packages specified for this request."""
         return self._packages_by_type(YarnPackageInput)
 
     def _packages_by_type(self, pkgtype: type[T]) -> list[T]:

--- a/cachi2/core/models/input.py
+++ b/cachi2/core/models/input.py
@@ -49,7 +49,9 @@ def _present_user_input_error(validation_error: pydantic.ValidationError) -> str
 # Supported package managers
 PackageManagerType = Literal["gomod", "npm", "pip", "yarn"]
 
-Flag = Literal["cgo-disable", "force-gomod-tidy", "gomod-vendor", "gomod-vendor-check"]
+Flag = Literal[
+    "cgo-disable", "dev-package-managers", "force-gomod-tidy", "gomod-vendor", "gomod-vendor-check"
+]
 
 
 class _PackageInputBase(pydantic.BaseModel, extra="forbid"):

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -4,7 +4,7 @@ from typing import Callable
 from cachi2.core.errors import UnsupportedFeature
 from cachi2.core.models.input import PackageManagerType, Request
 from cachi2.core.models.output import RequestOutput
-from cachi2.core.package_managers import gomod, npm, pip
+from cachi2.core.package_managers import gomod, npm, pip, yarn
 
 Handler = Callable[[Request], RequestOutput]
 
@@ -15,7 +15,7 @@ _package_managers: dict[PackageManagerType, Handler] = {
 }
 
 _dev_package_managers: dict[PackageManagerType, Handler] = {
-
+    "yarn": yarn.fetch_yarn_source,
 }
 
 # This is *only* used to provide a list for `cachi2 --version`

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -14,21 +14,28 @@ _package_managers: dict[PackageManagerType, Handler] = {
     "pip": pip.fetch_pip_source,
 }
 
+_dev_package_managers: dict[PackageManagerType, Handler] = {
 
+}
+
+# This is *only* used to provide a list for `cachi2 --version`
 supported_package_managers = list(_package_managers)
 
 
 def resolve_packages(request: Request) -> RequestOutput:
     """Run all requested package managers, return their combined output."""
+    _supported_package_managers = _package_managers
     requested_types = set(pkg.type for pkg in request.packages)
-    unsupported_types = requested_types - _package_managers.keys()
+    if "dev-package-managers" in request.flags:
+        _supported_package_managers = _package_managers | _dev_package_managers
+    unsupported_types = requested_types - _supported_package_managers.keys()
     if unsupported_types:
         raise UnsupportedFeature(
             f"Package manager(s) not yet supported: {', '.join(sorted(unsupported_types))}",
             # unknown package managers shouldn't get past input validation
             solution="But the good news is that we're already working on it!",
         )
-    pkg_managers = [_package_managers[type_] for type_ in sorted(requested_types)]
+    pkg_managers = [_supported_package_managers[type_] for type_ in sorted(requested_types)]
     return _merge_outputs(pkg_manager(request) for pkg_manager in pkg_managers)
 
 

--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -132,6 +132,7 @@ def fetch_deps(
         resolve_path=True,
         help="Write output files to this directory.",
     ),
+    dev_package_managers: bool = typer.Option(False, "--dev-package-managers", hidden=True),
     cgo_disable: bool = typer.Option(
         False, "--cgo-disable", help="Set CGO_ENABLED=0 while processing gomod packages."
     ),
@@ -216,8 +217,20 @@ def fetch_deps(
             return {"packages": [{"type": raw_input}]}
 
     def combine_option_and_json_flags(json_flags: list[Flag]) -> list[str]:
-        flag_names = ["cgo-disable", "force-gomod-tidy", "gomod-vendor", "gomod-vendor-check"]
-        flag_values = [cgo_disable, force_gomod_tidy, gomod_vendor, gomod_vendor_check]
+        flag_names = [
+            "cgo-disable",
+            "dev-package-managers",
+            "force-gomod-tidy",
+            "gomod-vendor",
+            "gomod-vendor-check",
+        ]
+        flag_values = [
+            cgo_disable,
+            dev_package_managers,
+            force_gomod_tidy,
+            gomod_vendor,
+            gomod_vendor_check,
+        ]
         flags = [name for name, value in zip(flag_names, flag_values) if value]
 
         if json_flags:

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -211,7 +211,7 @@ class TestRequest:
             )
 
     def test_invalid_flags(self) -> None:
-        expect_error = r"Input should be 'cgo-disable', 'force-gomod-tidy', 'gomod-vendor' or 'gomod-vendor-check'"
+        expect_error = r"Input should be 'cgo-disable', 'dev-package-managers', 'force-gomod-tidy', 'gomod-vendor' or 'gomod-vendor-check'"
         with pytest.raises(pydantic.ValidationError, match=expect_error):
             Request(
                 source_dir="/source",

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -532,6 +532,13 @@ class TestFetchDeps:
                     "force-gomod-tidy",
                 },
             ),
+            (
+                [
+                    '{"packages": [{"type":"gomod"}]}',
+                    "--dev-package-managers",
+                ],
+                {"dev-package-managers"},
+            ),
         ],
     )
     def test_specify_flags(

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -560,7 +560,7 @@ class TestFetchDeps:
             ),
             (
                 ['{"packages": [{"type": "gomod"}], "flags": ["no-such-flag"]}'],
-                "Input should be 'cgo-disable', 'force-gomod-tidy', 'gomod-vendor' or 'gomod-vendor-check'",
+                "Input should be 'cgo-disable', 'dev-package-managers', 'force-gomod-tidy', 'gomod-vendor' or 'gomod-vendor-check'",
             ),
         ],
     )


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] ~Docs updated (if applicable)~ (will be done in a follow up PR)
- [ ] Docs links in the code are still valid (if docs were updated)

Add a flag which allows for creating requests using a package manager
which is still under development

Any such package manager(s) will be "hidden" behind the new flag, which
should prevent their use by end-users (at least those using Cachi2 in
pipelines)

This story is part of the "Yarn for Node.js" epic

- STONEBLD-1750

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
