### PR TITLE
Subprocess handling improvements

### DIFF
--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -19,6 +19,7 @@ from typing import (
     NamedTuple,
     NoReturn,
     Optional,
+    Sequence,
     Tuple,
     Type,
     Union,
@@ -332,7 +333,7 @@ def _create_packages_from_parsed_data(
     return [_create_package(package) for package in parsed_packages]
 
 
-def _run_gomod_cmd(cmd: Iterable[str], params: dict[str, Any]) -> str:
+def _run_gomod_cmd(cmd: Sequence[str], params: dict[str, Any]) -> str:
     try:
         return run_cmd(cmd, params)
     except subprocess.CalledProcessError as e:
@@ -689,7 +690,7 @@ class GoCacheTemporaryDirectory(tempfile.TemporaryDirectory[str]):
             super().__exit__(exc, value, tb)
 
 
-def _run_download_cmd(cmd: Iterable[str], params: Dict[str, Any]) -> str:
+def _run_download_cmd(cmd: Sequence[str], params: Dict[str, Any]) -> str:
     """Run gomod command that downloads dependencies.
 
     Such commands may fail due to network errors (go is bad at retrying), so the entire operation
@@ -708,7 +709,7 @@ def _run_download_cmd(cmd: Iterable[str], params: Dict[str, Any]) -> str:
         max_tries=n_tries,
         logger=log,
     )
-    def run_go(_cmd: Iterable[str], _params: Dict[str, Any]) -> str:
+    def run_go(_cmd: Sequence[str], _params: Dict[str, Any]) -> str:
         log.debug(f"Running {_cmd}")
         return _run_gomod_cmd(_cmd, _params)
 

--- a/cachi2/core/package_managers/yarn/resolver.py
+++ b/cachi2/core/package_managers/yarn/resolver.py
@@ -103,7 +103,7 @@ def resolve_packages(source_dir: RootedPath) -> list[Package]:
     # --all: report dependencies of all workspaces, not just the active workspace
     # --recursive: report transitive dependencies, not just direct ones
     # --cache: include info about the cache entry for each dependency
-    result = run_yarn_cmd(["info", "--all", "--recursive", "--cache", "--json"], source_dir, env={})
+    result = run_yarn_cmd(["info", "--all", "--recursive", "--cache", "--json"], source_dir)
 
     # the result is not a valid json list, but a sequence of json objects separated by line breaks
     packages = [Package.from_info_string(info) for info in result.splitlines()]

--- a/cachi2/core/package_managers/yarn/utils.py
+++ b/cachi2/core/package_managers/yarn/utils.py
@@ -1,19 +1,27 @@
+import os
 import subprocess  # nosec
+from typing import Optional
 
 from cachi2.core.errors import YarnCommandError
 from cachi2.core.rooted_path import RootedPath
 from cachi2.core.utils import run_cmd
 
 
-def run_yarn_cmd(cmd: list[str], source_dir: RootedPath, env: dict[str, str]) -> str:
+def run_yarn_cmd(
+    cmd: list[str], source_dir: RootedPath, env: Optional[dict[str, str]] = None
+) -> str:
     """Run a yarn command on a source directory.
 
     :param cmd: the command that will be executed, split in a list of strings in every space.
     :param source_dir: the directory in the repository containing the yarn source files.
-    :param env: environment variables to be set during the command's execution.
-
+    :param env: environment variables to be set during the command's execution
     :raises YarnCommandError: if the command fails.
     """
+    env = env or {}
+    # if the caller doesn't specify a PATH variable, then pass the PATH from the current
+    # process to the subprocess
+    if "PATH" not in env and (self_path := os.environ.get("PATH")):
+        env = env | {"PATH": self_path}
     try:
         return run_cmd(cmd=["yarn", *cmd], params={"cwd": source_dir, "env": env})
     except subprocess.CalledProcessError:

--- a/cachi2/core/utils.py
+++ b/cachi2/core/utils.py
@@ -3,7 +3,7 @@ import logging
 import re
 import shutil
 import subprocess  # nosec
-from typing import Any, Iterator, Optional
+from typing import Iterator, Optional, Sequence
 
 from cachi2.core.config import get_config
 from cachi2.core.errors import Cachi2Error
@@ -11,7 +11,7 @@ from cachi2.core.errors import Cachi2Error
 log = logging.getLogger(__name__)
 
 
-def run_cmd(cmd: Any, params: dict) -> str:
+def run_cmd(cmd: Sequence[str], params: dict) -> str:
     """
     Run the given command with provided parameters.
 

--- a/tests/unit/package_managers/yarn/test_utils.py
+++ b/tests/unit/package_managers/yarn/test_utils.py
@@ -1,0 +1,34 @@
+import os
+from typing import Optional
+from unittest import mock
+
+import pytest
+
+from cachi2.core.package_managers.yarn.utils import run_yarn_cmd
+from cachi2.core.rooted_path import RootedPath
+
+
+@pytest.mark.parametrize(
+    "env, expect_path",
+    [
+        (None, os.environ["PATH"]),
+        ({}, os.environ["PATH"]),
+        ({"yarn_global_folder": "/tmp/yarnberry"}, os.environ["PATH"]),
+        ({"PATH": "/bin"}, "/bin"),
+    ],
+)
+@mock.patch("subprocess.run")
+def test_run_yarn_cmd(
+    mock_subprocess_run: mock.Mock,
+    env: Optional[dict[str, str]],
+    expect_path: str,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    run_yarn_cmd(["info", "--json"], rooted_tmp_path, env)
+
+    mock_subprocess_run.assert_called_once()
+
+    call = mock_subprocess_run.call_args_list[0]
+    assert call.args[0] == ["yarn", "info", "--json"]
+    assert call.kwargs["cwd"] == rooted_tmp_path
+    assert call.kwargs["env"] == (env or {}) | {"PATH": expect_path}

--- a/tests/unit/package_managers/yarn/test_utils.py
+++ b/tests/unit/package_managers/yarn/test_utils.py
@@ -17,18 +17,16 @@ from cachi2.core.rooted_path import RootedPath
         ({"PATH": "/bin"}, "/bin"),
     ],
 )
-@mock.patch("subprocess.run")
+@mock.patch("cachi2.core.package_managers.yarn.utils.run_cmd")
 def test_run_yarn_cmd(
-    mock_subprocess_run: mock.Mock,
+    mock_run_cmd: mock.Mock,
     env: Optional[dict[str, str]],
     expect_path: str,
     rooted_tmp_path: RootedPath,
 ) -> None:
     run_yarn_cmd(["info", "--json"], rooted_tmp_path, env)
 
-    mock_subprocess_run.assert_called_once()
-
-    call = mock_subprocess_run.call_args_list[0]
-    assert call.args[0] == ["yarn", "info", "--json"]
-    assert call.kwargs["cwd"] == rooted_tmp_path
-    assert call.kwargs["env"] == (env or {}) | {"PATH": expect_path}
+    expect_env = (env or {}) | {"PATH": expect_path}
+    mock_run_cmd.assert_called_once_with(
+        cmd=["yarn", "info", "--json"], params={"cwd": rooted_tmp_path, "env": expect_env}
+    )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -4,10 +4,12 @@ from unittest import mock
 
 import pytest
 
+from cachi2.core.errors import Cachi2Error
 from cachi2.core.utils import run_cmd
 
 
 @mock.patch("subprocess.run")
+@mock.patch("shutil.which")
 @pytest.mark.parametrize(
     "stdout, stderr, expect_logs",
     [
@@ -26,12 +28,14 @@ from cachi2.core.utils import run_cmd
     ],
 )
 def test_run_cmd_logs_stdouterr_on_failure(
+    mock_shutil_which: mock.Mock,
     mock_subprocess_run: mock.Mock,
     stdout: Optional[str],
     stderr: Optional[str],
     expect_logs: list[str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    mock_shutil_which.return_value = "/usr/local/bin/some"
     mock_subprocess_run.return_value = subprocess.CompletedProcess(
         ["some", "command"], returncode=1, stdout=stdout, stderr=stderr
     )
@@ -40,3 +44,38 @@ def test_run_cmd_logs_stdouterr_on_failure(
         run_cmd(["some", "command"], {})
 
     assert caplog.messages == ['The command "some command" failed', *expect_logs]
+
+
+@mock.patch("subprocess.run")
+@mock.patch("shutil.which")
+@pytest.mark.parametrize("extra_args", [True, False])
+def test_run_cmd_execute_by_abspath(
+    mock_shutil_which: mock.Mock,
+    mock_subprocess_run: mock.Mock,
+    extra_args: bool,
+) -> None:
+    mock_shutil_which.return_value = "/usr/local/bin/yarn"
+    mock_subprocess_run.return_value = subprocess.CompletedProcess([], returncode=0)
+
+    if extra_args:
+        cmd = ["yarn", "--version"]
+        expect_cmd = ["/usr/local/bin/yarn", "--version"]
+    else:
+        cmd = ["yarn"]
+        expect_cmd = ["/usr/local/bin/yarn"]
+
+    run_cmd(cmd, params={})
+
+    mock_subprocess_run.assert_called_once()
+    call = mock_subprocess_run.call_args_list[0]
+    assert call.args[0] == expect_cmd
+
+
+@mock.patch("shutil.which")
+def test_run_cmd_executable_not_found(
+    mock_shutil_which: mock.Mock,
+) -> None:
+    mock_shutil_which.return_value = None
+
+    with pytest.raises(Cachi2Error, match="'foo' executable not found in PATH"):
+        run_cmd(["foo"], params={})


### PR DESCRIPTION
- pass PATH to yarn subprocesses
- use shutil.which to execute commands by abspath
- fix a type annotation

See the commits for more details

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
