### PR TITLE
Dependabot reduce noise (pip)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,9 @@ updates:
       dep-patch-updates:
         update-types:
           - "patch"
+      dep-minor-updates:
+        update-types:
+          - "minor"
 
   - package-ecosystem: "npm"
     directory: "/js-deps"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     groups:
       dep-patch-updates:
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      dep-patch-updates:
+        update-types:
+          - "patch"
+
   - package-ecosystem: "npm"
     directory: "/js-deps"
     schedule:


### PR DESCRIPTION
Dependabot opens several PRs almost every day creating noise in the list of PRs. The vast majority of these updates are just patch updates (note the SemVer reference: `major.minor.patch`) which have essentially no impact on this project.
This PR attempts to reduce the noise by grouping pip dependency updates as following:

1. all dependency patch updates in a single PR
2. all dependency minor updates in a single PR

Major updates are left alone so that each major update is a separate PR as major versions often come with backwards compatibility breaking changes.
Grouping updates alone is not going to achieve the goal of reducing the noise without reducing the update schedule to 'weekly' only. 
Now, it's true that by going with weekly updates we open ourselves to the possibility of using vulnerable libraries for a week, but since dependabot has quite a good integration with GitHub security updates should be handled via [security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) which are unrelated to the YAML settings.

I'm proposing this change in context of pip only for now (as that is causing the biggest noise) and if it works we can follow up with NPM. As for testing, I couldn't test the changes in any way, because the official [dependabot CLI tool](https://github.com/dependabot/cli) is completely useless in this regard (not even talking about the complete lack of docs) and support for dependabot YAML validation [hasn't been implemented yet](https://github.com/dependabot/dependabot-core/issues/4605), so I guess we'll see later if the changes actually worked as expected or we need to revert them ` ¯\_(ツ)_/¯`.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] ~Code coverage from testing does not decrease and new code is covered~
- [ ] ~Docs updated (if applicable)~
- [ ] ~Docs links in the code are still valid (if docs were updated)~

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
