### PR TITLE
Yarn: Misc fixes/adjustments/improvements

### DIFF
--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -61,7 +61,7 @@ def _configure_yarn_version(project: Project) -> None:
         if there is a mismatch between the yarn version specified by yarnPath and PackageManager
     """
     if project.yarn_rc:
-        yarn_path_version = get_semver_from_yarn_path(project.yarn_rc.yarn_path)
+        yarn_path_version = get_semver_from_yarn_path(project.yarn_rc["yarnPath"])
     else:
         yarn_path_version = None
 

--- a/cachi2/core/package_managers/yarn/project.py
+++ b/cachi2/core/package_managers/yarn/project.py
@@ -32,7 +32,9 @@ class YarnRc(UserDict):
     configuration file.
     """
 
-    def __init__(self, data: dict[str, Any], defaults: Optional[dict[str, Any]] = None) -> None:
+    def __init__(
+        self, data: dict[str, Any] = {}, defaults: Optional[dict[str, Any]] = None
+    ) -> None:
         """Initialize a YarnRc dictionary.
 
         :param data: the raw data for the yarnrc file.
@@ -183,7 +185,7 @@ class Project(NamedTuple):
     """A directory containing yarn sources."""
 
     source_dir: RootedPath
-    yarn_rc: Optional[YarnRc]
+    yarn_rc: YarnRc
     package_json: PackageJson
 
     @property
@@ -222,7 +224,8 @@ class Project(NamedTuple):
                 source_dir.join_within_root(".yarnrc.yml"), YarnRc.load_defaults(source_dir)
             )
         else:
-            yarn_rc = None
+            # defaults only
+            yarn_rc = YarnRc(YarnRc.load_defaults(source_dir))
 
         package_json = PackageJson.from_file(source_dir.join_within_root("package.json"))
         return cls(source_dir, yarn_rc, package_json)

--- a/cachi2/core/package_managers/yarn/project.py
+++ b/cachi2/core/package_managers/yarn/project.py
@@ -79,9 +79,9 @@ class YarnRc(UserDict):
 
         See: https://v3.yarnpkg.com/configuration/yarnrc#npmScopes
         """
-        registry = self._data.get("npmScopes", {}).get(scope, {}).get("npmRegistryServer")
+        registry = self.get("npmScopes", {}).get(scope, {}).get("npmRegistryServer")
 
-        return registry or self.registry_server
+        return registry or self["npmRegistryServer"]
 
     @staticmethod
     def load_defaults(source_dir: RootedPath) -> dict[str, Any]:
@@ -195,12 +195,12 @@ class Project(NamedTuple):
         This is determined by the existence of a non-empty yarn cache folder. For more details on
         zero-installs, see: https://v3.yarnpkg.com/features/zero-installs.
         """
-        dir = self.yarn_cache
+        cache_rooted_path = self.source_dir.join_within_root(self.yarn_rc["cacheFolder"])
 
-        if not dir.path.is_dir():
+        if not cache_rooted_path.path.is_dir():
             return False
 
-        return any(file.suffix == ".zip" for file in dir.path.iterdir())
+        return any(file.suffix == ".zip" for file in cache_rooted_path.path.iterdir())
 
     @property
     def yarn_cache(self) -> RootedPath:
@@ -210,7 +210,7 @@ class Project(NamedTuple):
         https://v3.yarnpkg.com/configuration/yarnrc#cacheFolder.
         """
         if self.yarn_rc:
-            return self.source_dir.join_within_root(self.yarn_rc.cache_folder)
+            return self.source_dir.join_within_root(self.yarn_rc["cacheFolder"])
 
         return self.source_dir.join_within_root(DEFAULT_CACHE_FOLDER)
 

--- a/cachi2/core/package_managers/yarn/project.py
+++ b/cachi2/core/package_managers/yarn/project.py
@@ -30,13 +30,11 @@ class YarnRc:
     is relevant for the request processing.
     """
 
-    def __init__(self, path: RootedPath, data: dict[str, Any]) -> None:
+    def __init__(self, data: dict[str, Any]) -> None:
         """Initialize a YarnRc object.
 
-        :param path: the path to the yarnrc file, relative to the request source dir.
         :param data: the raw data for the yarnrc file.
         """
-        self._path = path
         self._data = data
 
     @property
@@ -74,7 +72,10 @@ class YarnRc:
 
     @classmethod
     def from_file(cls, file_path: RootedPath) -> "YarnRc":
-        """Parse the content of a yarnrc file."""
+        """Parse the content of a yarnrc file.
+
+        :param path: the path to the yarnrc file, relative to the request source dir.
+        """
         try:
             with file_path.path.open("r") as f:
                 yarnrc_data = yaml.safe_load(f)
@@ -90,7 +91,7 @@ class YarnRc:
         if yarnrc_data is None:
             yarnrc_data = {}
 
-        return cls(file_path, yarnrc_data)
+        return cls(yarnrc_data)
 
 
 class PackageJson:

--- a/cachi2/core/package_managers/yarn/project.py
+++ b/cachi2/core/package_managers/yarn/project.py
@@ -7,6 +7,7 @@ should be implemented in other modules.
 import json
 import logging
 import re
+from collections import UserDict
 from pathlib import Path
 from typing import Any, NamedTuple, Optional
 
@@ -23,18 +24,19 @@ DEFAULT_CACHE_FOLDER = "./.yarn/cache"
 DEFAULT_REGISTRY = "https://registry.yarnpkg.com"
 
 
-class YarnRc:
+class YarnRc(UserDict):
     """A yarnrc file.
 
-    This class abstracts the underlying attributes and only exposes what
-    is relevant for the request processing.
+    This class abstracts the underlying attributes of a .yarnrc YAML
+    configuration file.
     """
 
     def __init__(self, data: dict[str, Any]) -> None:
-        """Initialize a YarnRc object.
+        """Initialize a YarnRc dictionary.
 
         :param data: the raw data for the yarnrc file.
         """
+        super().__init__(data)
         self._data = data
 
     @property

--- a/cachi2/core/package_managers/yarn/project.py
+++ b/cachi2/core/package_managers/yarn/project.py
@@ -21,10 +21,6 @@ from cachi2.core.rooted_path import RootedPath
 log = logging.getLogger(__name__)
 
 
-DEFAULT_CACHE_FOLDER = "./.yarn/cache"
-DEFAULT_REGISTRY = "https://registry.yarnpkg.com"
-
-
 class YarnRc(UserDict):
     """A yarnrc file.
 
@@ -40,7 +36,6 @@ class YarnRc(UserDict):
         :param data: the raw data for the yarnrc file.
         """
         super().__init__(data)
-        self._data = data
         self._defaults = defaults if defaults else {}
 
     def __getitem__(self, key: str) -> Any:
@@ -49,27 +44,6 @@ class YarnRc(UserDict):
         except KeyError:
             # try the defaults potentially raising KeyError
             return self._defaults[key]
-
-    @property
-    def cache_folder(self) -> str:
-        """Get the configured location for the yarn cache folder.
-
-        Fallback to the default path in case the configuration key is missing.
-        """
-        return self._data.get("cacheFolder", DEFAULT_CACHE_FOLDER)
-
-    @property
-    def registry_server(self) -> str:
-        """Get the globally configured registry server.
-
-        Fallback to the default server in case the configuration key is missing.
-        """
-        return self._data.get("npmRegistryServer", DEFAULT_REGISTRY)
-
-    @property
-    def yarn_path(self) -> Optional[str]:
-        """Path to the yarn script present in this directory."""
-        return self._data.get("yarnPath")
 
     def registry_server_for_scope(self, scope: str) -> str:
         """Get the configured registry server for a scoped package.
@@ -201,18 +175,6 @@ class Project(NamedTuple):
             return False
 
         return any(file.suffix == ".zip" for file in cache_rooted_path.path.iterdir())
-
-    @property
-    def yarn_cache(self) -> RootedPath:
-        """The path to the yarn cache folder.
-
-        The cache location is affected by the cacheFolder configuration in yarnrc. See:
-        https://v3.yarnpkg.com/configuration/yarnrc#cacheFolder.
-        """
-        if self.yarn_rc:
-            return self.source_dir.join_within_root(self.yarn_rc["cacheFolder"])
-
-        return self.source_dir.join_within_root(DEFAULT_CACHE_FOLDER)
 
     @classmethod
     def from_source_dir(cls, source_dir: RootedPath) -> "Project":

--- a/cachi2/core/package_managers/yarn/resolver.py
+++ b/cachi2/core/package_managers/yarn/resolver.py
@@ -74,9 +74,9 @@ class Package:
     cache_path: Optional[str]
 
     @classmethod
-    def from_info_string(cls, info: str) -> "Package":
+    def from_dict(cls, info: dict[str, Any]) -> "Package":
         """Create a Package from the output of yarn info."""
-        entry = _YarnInfoEntry.model_validate_json(info)
+        entry = _YarnInfoEntry.model_validate(info)
         locator = entry.value
         version: Optional[str] = entry.children.version
         if version == "0.0.0-use.local":
@@ -125,8 +125,7 @@ def resolve_packages(source_dir: RootedPath) -> list[Package]:
     # --cache: include info about the cache entry for each dependency
     result = run_yarn_cmd(["info", "--all", "--recursive", "--cache", "--json"], source_dir)
 
-    # the result is not a valid json list, but a sequence of json objects separated by line breaks
-    packages = [Package.from_info_string(info) for info in result.splitlines()]
+    packages = [Package.from_dict(info) for info in json.loads(result)]
 
     n_unsupported = 0
     for package in packages:

--- a/cachi2/core/package_managers/yarn/utils.py
+++ b/cachi2/core/package_managers/yarn/utils.py
@@ -24,7 +24,12 @@ def run_yarn_cmd(
     if "PATH" not in env and (self_path := os.environ.get("PATH")):
         env = env | {"PATH": self_path}
     try:
-        return run_cmd(cmd=["yarn", *cmd], params={"cwd": source_dir, "env": env})
+        stdout = run_cmd(cmd=["yarn", *cmd], params={"cwd": source_dir, "env": env})
+
+        # Fix Yarn's JSON output
+        if "--json" in cmd:
+            return _jsonify(stdout)
+        return stdout
     except subprocess.CalledProcessError:
         raise YarnCommandError(f"Yarn command failed: {' '.join(cmd)}")
 

--- a/cachi2/core/utils.py
+++ b/cachi2/core/utils.py
@@ -24,6 +24,7 @@ def run_cmd(cmd: Sequence[str], params: dict) -> str:
     params.setdefault("capture_output", True)
     params.setdefault("universal_newlines", True)
     params.setdefault("encoding", "utf-8")
+    params.setdefault("text", True)
 
     conf = get_config()
     params.setdefault("timeout", conf.subprocess_timeout)

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1298,7 +1298,11 @@ def test_run_download_cmd_failure(
         {"foo": {}, "bar": {"go.mod": ""}},
     ),
 )
-def test_missing_gomod_file(file_tree: dict[str, Any], tmp_path: Path) -> None:
+@mock.patch("cachi2.core.package_managers.gomod.run_cmd")
+def test_missing_gomod_file(
+    mock_run_cmd: mock.Mock, file_tree: dict[str, Any], tmp_path: Path
+) -> None:
+    mock_run_cmd.return_value = "go version go0.0.1"
     write_file_tree(file_tree, tmp_path, exist_ok=True)
 
     packages = [{"path": path, "type": "gomod"} for path, _ in file_tree.items()]
@@ -1446,7 +1450,9 @@ def test_missing_gomod_file(file_tree: dict[str, Any], tmp_path: Path) -> None:
 @mock.patch("cachi2.core.package_managers.gomod._resolve_gomod")
 @mock.patch("cachi2.core.package_managers.gomod.GoCacheTemporaryDirectory")
 @mock.patch("cachi2.core.package_managers.gomod.ModuleVersionResolver.from_repo_path")
+@mock.patch("cachi2.core.package_managers.gomod.run_cmd")
 def test_fetch_gomod_source(
+    mock_run_cmd: mock.Mock,
     mock_version_resolver: mock.Mock,
     mock_tmp_dir: mock.Mock,
     mock_resolve_gomod: mock.Mock,
@@ -1468,6 +1474,7 @@ def test_fetch_gomod_source(
             app_dir.path.relative_to(gomod_request.source_dir).as_posix()
         ]
 
+    mock_run_cmd.return_value = "go version go0.0.1"
     mock_resolve_gomod.side_effect = resolve_gomod_mocked
     mock_find_missing_gomod_files.return_value = []
     mock_get_repository_name.return_value = "github.com/my-org/my-repo"

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -39,6 +39,7 @@ def test_configure_yarn_version(
 ) -> None:
     mock_project = mock.Mock()
     mock_project.package_json.package_manager = None
+    mock_project.yarn_rc = {"yarnPath": None}
     mock_yarn_path_semver.return_value = yarn_path_version
     mock_package_manager_semver.return_value = package_manager_version
 
@@ -91,6 +92,7 @@ def test_configure_yarn_version_fail(
     expected_error: Exception,
 ) -> None:
     mock_project = mock.Mock()
+    mock_project.yarn_rc = {"yarnPath": None}
     mock_yarn_path_semver.return_value = yarn_path_version
     mock_package_manager_semver.side_effect = [package_manager_version]
 

--- a/tests/unit/package_managers/yarn/test_project.py
+++ b/tests/unit/package_managers/yarn/test_project.py
@@ -148,7 +148,6 @@ def test_parse_project_folder(rooted_tmp_path: RootedPath, is_zero_installs: boo
     assert project.yarn_cache == rooted_tmp_path.join_within_root(cache_path)
 
     assert project.yarn_rc is not None
-    assert project.yarn_rc._path == rooted_tmp_path.join_within_root(".yarnrc.yml")
     assert project.package_json._path == rooted_tmp_path.join_within_root("package.json")
 
 

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -470,7 +470,9 @@ def mock_project(project_dir: RootedPath) -> Project:
     ],
 )
 @pytest.mark.parametrize("project_uses_zero_installs", [True, False])
+@mock.patch("cachi2.core.package_managers.yarn.project.YarnRc.load_defaults")
 def test_create_components_single_package(
+    mock_yarn_rc_load_defaults: mock.Mock,
     mocked_package: MockedPackage,
     expect_component: Component,
     expect_logs: list[str],
@@ -478,6 +480,7 @@ def test_create_components_single_package(
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    mock_yarn_rc_load_defaults.return_value = {}
     project_dir = RootedPath(tmp_path / "project")
     output_dir = RootedPath(tmp_path / "output")
 
@@ -496,10 +499,13 @@ def test_create_components_single_package(
     assert caplog.messages == expect_logs
 
 
+@mock.patch("cachi2.core.package_managers.yarn.project.YarnRc.load_defaults")
 def test_create_components_patched_packages(
+    mock_yarn_rc_load_defaults: mock.Mock,
     rooted_tmp_path: RootedPath,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    mock_yarn_rc_load_defaults.return_value = {}
     project_dir = rooted_tmp_path
 
     mocked_packages = [
@@ -765,11 +771,14 @@ def test_create_components_patched_packages(
         ),
     ],
 )
+@mock.patch("cachi2.core.package_managers.yarn.project.YarnRc.load_defaults")
 def test_create_components_failed_to_resolve(
+    mock_yarn_rc_load_defaults: mock.Mock,
     mocked_package: MockedPackage,
     expect_err_msg: str,
     rooted_tmp_path: RootedPath,
 ) -> None:
+    mock_yarn_rc_load_defaults.return_value = {}
     project_dir = rooted_tmp_path
     mocked_package = mocked_package.resolve_cache_path(project_dir)
     mock_package_json(mocked_package, project_dir)
@@ -782,7 +791,12 @@ def test_create_components_failed_to_resolve(
         )
 
 
-def test_create_components_cache_path_reported_but_missing(rooted_tmp_path: RootedPath) -> None:
+@mock.patch("cachi2.core.package_managers.yarn.project.YarnRc.load_defaults")
+def test_create_components_cache_path_reported_but_missing(
+    mock_yarn_rc_load_defaults: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    mock_yarn_rc_load_defaults.return_value = {}
     package = Package(
         raw_locator="strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.",
         version="4.0.0",

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -180,10 +180,10 @@ EXPECT_PACKAGES = [
 ]
 
 
-@mock.patch("cachi2.core.package_managers.yarn.resolver.run_yarn_cmd")
-def test_resolve_packages(mock_run_yarn_cmd: mock.Mock, rooted_tmp_path: RootedPath) -> None:
+@mock.patch("cachi2.core.package_managers.yarn.utils.run_cmd")
+def test_resolve_packages(mock_run_cmd: mock.Mock, rooted_tmp_path: RootedPath) -> None:
     yarn_info_output = mock_yarn_info_output(YARN_INFO_OUTPUTS)
-    mock_run_yarn_cmd.return_value = yarn_info_output
+    mock_run_cmd.return_value = yarn_info_output
     packages = resolve_packages(rooted_tmp_path)
     assert packages == EXPECT_PACKAGES
 
@@ -191,9 +191,9 @@ def test_resolve_packages(mock_run_yarn_cmd: mock.Mock, rooted_tmp_path: RootedP
         assert package.parsed_locator == parse_locator(package.raw_locator)
 
 
-@mock.patch("cachi2.core.package_managers.yarn.resolver.run_yarn_cmd")
+@mock.patch("cachi2.core.package_managers.yarn.utils.run_cmd")
 def test_validate_unsupported_locators(
-    mock_run_yarn_cmd: mock.Mock, rooted_tmp_path: RootedPath, caplog: pytest.LogCaptureFixture
+    mock_run_cmd: mock.Mock, rooted_tmp_path: RootedPath, caplog: pytest.LogCaptureFixture
 ) -> None:
     unsupported_outputs = [
         {
@@ -231,7 +231,7 @@ def test_validate_unsupported_locators(
         },
     ]
     yarn_info_output = mock_yarn_info_output(unsupported_outputs)
-    mock_run_yarn_cmd.return_value = yarn_info_output
+    mock_run_cmd.return_value = yarn_info_output
 
     with pytest.raises(
         UnsupportedFeature, match="Found 3 unsupported dependencies, more details in the logs."

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -296,7 +296,7 @@ def mock_package_json(
 def mock_project(project_dir: RootedPath) -> Project:
     return Project(
         project_dir,
-        YarnRc(project_dir.join_within_root(".yarnrc.yml"), {}),
+        YarnRc({}),
         PackageJson(project_dir.join_within_root("package.json"), {}),
     )
 

--- a/tests/unit/package_managers/yarn/test_utils.py
+++ b/tests/unit/package_managers/yarn/test_utils.py
@@ -1,11 +1,30 @@
+import json
 import os
 from typing import Optional
 from unittest import mock
 
 import pytest
 
-from cachi2.core.package_managers.yarn.utils import run_yarn_cmd
+from cachi2.core.package_managers.yarn.utils import _jsonify, run_yarn_cmd
 from cachi2.core.rooted_path import RootedPath
+
+YARN_SAMPLE_OUTPUT_SINGLE_JSON_OBJ = '{"foo":"bar", "bar":["baz", "foobar"]}'
+YARN_SAMPLE_JSON_OUTPUT_MULTI_JSON_OBJ = """\
+{"foo":"bar", "bar":["baz", "foobar"]}
+{"foo":"baz", "bar":{"foo": "bar"}}
+{"foo":null}
+"""
+
+SINGLE_JSON_OBJ_EXPECTED_OUTPUT = '[{"foo": "bar", "bar": ["baz", "foobar"]}]'
+MULTI_JSON_OBJ_EXPECTED_OUTPUT = """\
+[\
+{"foo": "bar", "bar": ["baz", "foobar"]}, \
+{"foo": "baz", "bar": {"foo": "bar"}}, \
+{"foo": null}\
+]\
+"""
+
+INVALID_JSON = "definitely not JSON"
 
 
 @pytest.mark.parametrize(
@@ -30,3 +49,31 @@ def test_run_yarn_cmd(
     mock_run_cmd.assert_called_once_with(
         cmd=["yarn", "info", "--json"], params={"cwd": rooted_tmp_path, "env": expect_env}
     )
+
+
+@pytest.mark.parametrize(
+    "input_, expected",
+    [
+        pytest.param(
+            YARN_SAMPLE_OUTPUT_SINGLE_JSON_OBJ,
+            SINGLE_JSON_OBJ_EXPECTED_OUTPUT,
+            id="yarn_single_json_obj",
+        ),
+        pytest.param(
+            YARN_SAMPLE_JSON_OUTPUT_MULTI_JSON_OBJ,
+            MULTI_JSON_OBJ_EXPECTED_OUTPUT,
+            id="yarn_multiple_json_objs",
+        ),
+        pytest.param(
+            MULTI_JSON_OBJ_EXPECTED_OUTPUT, MULTI_JSON_OBJ_EXPECTED_OUTPUT, id="proper_json_array"
+        ),
+        pytest.param("", "[]", id="empty_json"),
+    ],
+)
+def test_jsonify(input_: str, expected: str) -> None:
+    assert _jsonify(input_) == expected
+
+
+def test_jsonify_error() -> None:
+    with pytest.raises(json.JSONDecodeError):
+        _jsonify("invalid_json")

--- a/tests/unit/package_managers/yarn/test_utils.py
+++ b/tests/unit/package_managers/yarn/test_utils.py
@@ -37,12 +37,15 @@ INVALID_JSON = "definitely not JSON"
     ],
 )
 @mock.patch("cachi2.core.package_managers.yarn.utils.run_cmd")
+@mock.patch("cachi2.core.package_managers.yarn.utils._jsonify")
 def test_run_yarn_cmd(
+    mock_yarn_jsonify: mock.Mock,
     mock_run_cmd: mock.Mock,
     env: Optional[dict[str, str]],
     expect_path: str,
     rooted_tmp_path: RootedPath,
 ) -> None:
+    mock_yarn_jsonify.return_value = None
     run_yarn_cmd(["info", "--json"], rooted_tmp_path, env)
 
     expect_env = (env or {}) | {"PATH": expect_path}


### PR DESCRIPTION
- convert YarnRc to a dict-like structure as exposing getters/setters doesn't scale with the number of possible config options
- populate YarnRc defaults from `yarn config`
- always instantiate YarnRc (because we now have defaults populated)
- add a helper that fixes Yarn's JSON output to a properly serialized JSON for the *all* Yarn callers

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
