### PR TITLE
yarn: Forbid zero installs workflow 

### DIFF
--- a/cachi2/core/package_managers/yarn/project.py
+++ b/cachi2/core/package_managers/yarn/project.py
@@ -24,6 +24,7 @@ DEFAULT_REGISTRY = "https://registry.yarnpkg.com"
 
 ChecksumBehavior = Literal["throw", "update", "ignore"]
 PnpMode = Literal["strict", "loose"]
+NodeLinker = Literal["pnp", "pnpm", "node-modules"]
 
 
 class Plugin(TypedDict):
@@ -158,6 +159,15 @@ class YarnRc:
     @unsafe_http_whitelist.setter
     def unsafe_http_whitelist(self, urls: list[str]) -> None:
         self._data["unsafeHttpWhitelist"] = urls
+
+    @property
+    def node_linker(self) -> NodeLinker:
+        """Get the nodeLinker configuration."""
+        return self._data.get("nodeLinker", None)
+
+    @node_linker.setter
+    def node_linker(self, node_linker: Optional[NodeLinker]) -> None:
+        self._data["nodeLinker"] = node_linker
 
     @property
     def plugins(self) -> list[Plugin]:

--- a/tests/unit/package_managers/yarn/test_project.py
+++ b/tests/unit/package_managers/yarn/test_project.py
@@ -29,6 +29,7 @@ enableStrictSsl: false
 enableTelemetry: false
 globalFolder: /a/global/folder
 ignorePath: true
+nodeLinker: pnp
 npmRegistryServer: https://registry.alternative.com
 npmScopes:
     foobar:
@@ -89,6 +90,7 @@ def test_parse_yarnrc(rooted_tmp_path: RootedPath) -> None:
     assert yarn_rc.enable_telemetry is False
     assert yarn_rc.global_folder == "/a/global/folder"
     assert yarn_rc.ignore_path is True
+    assert yarn_rc.node_linker == "pnp"
     assert yarn_rc.pnp_mode == "loose"
     assert yarn_rc.registry_server == "https://registry.alternative.com"
     assert yarn_rc.registry_server_for_scope("foobar") == "https://registry.foobar.com"
@@ -110,6 +112,7 @@ def test_parse_empty_yarnrc(rooted_tmp_path: RootedPath) -> None:
     assert yarn_rc.enable_telemetry is None
     assert yarn_rc.global_folder is None
     assert yarn_rc.ignore_path is None
+    assert yarn_rc.node_linker is None
     assert yarn_rc.pnp_mode is None
     assert yarn_rc.registry_server == "https://registry.yarnpkg.com"
     assert yarn_rc.registry_server_for_scope("foobar") == "https://registry.yarnpkg.com"


### PR DESCRIPTION
The concept of zero installs is inherently flawed in that one has to either store binary ZIP files or an exploded node-modules dependency tree inside their project repository.  While the former may sound like an acceptable use case from cachi2's hermetic build POV because Yarn provides us with a way to check their integrity, the latter surely doesn't (in fact we refuse projects having node-modules in the repository).
    
That said, even with the former case some dependencies may specify post-install scripts which will cause such a dependency to be unpacked and expanded under .yarn/cache/unplugged which in simple terms is nothing else than again an expanded node-modules tree which we have to treat the same way as we do for NPM - reject it - because such zero installs would not work without these unplugged packages (if any dependency needed to be unpacked) and at the same time we cannot verify them reliably.
    
Note that even if one uses the 'immutablePatterns' [1] YarnRc configuration
    option with `**/.yarn/unplugged/**`  or even `**/.yarn/**` Yarn somehow ignores the pattern unless the whole `.yarn/unplugged/<unzipped_package>/node_modules/<package>` subdirectory of a given unplugged package tree was completely removed in which case Yarn finally notices and throws an immutable cache error:
    
```
        The checksum for **/.yarn/unplugged/**/* has been modified by this
        install, which is explicitly forbidden
```
 
The whole glob pattern handling in Yarn happens here:

- https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-core/sources/Project.ts#L1849
- https://github.com/yarnpkg/berry/blob/master/packages/yarnpkg-core/sources/hashUtils.ts#L47

Given that Yarn doesn't provide us with a mechanism to verify integrity of the unplugged packages we're facing essentially the same problem as with `node_modules` handling in NPM which we explicitly forbid. Needless to say that Yarn also provides a backwards compatible way with the NPM ecosystem by creating the `node_modules` directory if the `nodeLinker` setting in the RC config was set to `node-modules` and hence the check detecting zero-installs workflow was updated accordingly to reflect the different configuration values for the setting.

[1] https://v3.yarnpkg.com/configuration/yarnrc#immutablePatterns

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun

