### PR TITLE
Remove libkrb5-dev from Github CI

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -21,10 +21,6 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Install required packages
-      run: |
-        sudo apt-get install -y \
-          libkrb5-dev
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
@@ -74,10 +70,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Install required packages
-      run: |
-        sudo apt-get install -y \
-          libkrb5-dev
     - name: Set up Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
This library is a leftover from Cachito and is not necessary for Cachi2. 

This also solves the current problem we are having with the CI.

```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/k/krb5/libgssrpc4_1.19.2-2ubuntu0.2_amd64.deb  404  Not Found [IP: 52.147.219.192 80]
```

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)
