### PR TITLE
Yarn: check version of Yarn and fail requests for non-v3 binaries

### DIFF
--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -79,6 +79,14 @@ def _configure_yarn_version(project: Project) -> None:
             ),
         )
 
+    # Note (mypy): version cannot be None anymore after the next statement
+    version = yarn_path_version if yarn_path_version else package_manager_version
+    if version.compare("3.0.0") < 0 or version.major == 4:  # type: ignore
+        raise PackageRejected(
+            f"Unsupported Yarn version '{version}' detected",
+            solution="Please pick a different version of Yarn (3.0.0<= Yarn version <4.0.0)",
+        )
+
     if (
         yarn_path_version
         and package_manager_version

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -1,5 +1,7 @@
 import re
-from typing import Optional, Union
+from enum import Enum
+from itertools import zip_longest
+from typing import List, Optional, Union
 from unittest import mock
 
 import pytest
@@ -16,14 +18,35 @@ from cachi2.core.package_managers.yarn.project import YarnRc
 from cachi2.core.rooted_path import RootedPath
 
 
+class YarnVersions(Enum):
+    YARN_V1 = semver.VersionInfo(1, 0, 0)
+    YARN_V2 = semver.VersionInfo(2, 0, 0)
+
+    YARN_V3_RC1 = semver.VersionInfo(3, 0, 0, prerelease="rc1")
+    YARN_V3 = semver.VersionInfo(3, 0, 0)
+    YARN_V36_RC1 = semver.VersionInfo(3, 6, 0, prerelease="rc1")
+
+    YARN_V4_RC1 = semver.VersionInfo(4, 0, 0, prerelease="rc1")
+    YARN_V4 = semver.VersionInfo(4, 0, 0)
+
+    @classmethod
+    def supported(cls) -> List["YarnVersions"]:
+        return [cls.YARN_V3, cls.YARN_V36_RC1]
+
+    @classmethod
+    def unsupported(cls) -> List["YarnVersions"]:
+        return list(set(cls.__members__.values()).difference(set(cls.supported())))
+
+
 @pytest.mark.parametrize(
     "yarn_path_version, package_manager_version",
     [
-        pytest.param(semver.VersionInfo(3, 0, 0), None, id="valid-yarnpath-no-packagemanager"),
-        pytest.param(None, semver.VersionInfo(3, 0, 0), id="no-yarnpath-valid-packagemanager"),
+        pytest.param(YarnVersions.YARN_V3.value, None, id="valid-yarnpath-no-packagemanager"),
+        pytest.param(YarnVersions.YARN_V36_RC1.value, None, id="minor-version-with-prerelease"),
+        pytest.param(None, YarnVersions.YARN_V3.value, id="no-yarnpath-valid-packagemanager"),
         pytest.param(
-            semver.VersionInfo(3, 0, 0),
-            semver.VersionInfo(3, 0, 0),
+            YarnVersions.YARN_V3.value,
+            YarnVersions.YARN_V3.value,
             id="matching-yarnpath-and-packagemanager",
         ),
         pytest.param(
@@ -101,6 +124,38 @@ def test_configure_yarn_version_fail(
     mock_package_manager_semver.side_effect = [package_manager_version]
 
     with pytest.raises(type(expected_error), match=re.escape(str(expected_error))):
+        _configure_yarn_version(mock_project)
+
+
+YARN_VERSIONS = [yarn_version.value for yarn_version in YarnVersions.unsupported()]
+
+
+@pytest.mark.parametrize(
+    "package_manager_version, yarn_path_version",
+    [
+        pytest.param(
+            pkg_mgr_version,
+            yarn_path_version,
+            id=f"package_manager,yarn_path-({str(pkg_mgr_version)}, {str(yarn_path_version)})",
+        )
+        for pkg_mgr_version, yarn_path_version in zip_longest(YARN_VERSIONS, YARN_VERSIONS[:1])
+    ],
+)
+@mock.patch("cachi2.core.package_managers.yarn.main.get_semver_from_package_manager")
+@mock.patch("cachi2.core.package_managers.yarn.main.get_semver_from_yarn_path")
+def test_yarn_unsupported_version_fail(
+    mock_yarn_path_semver: mock.Mock,
+    mock_package_manager_semver: mock.Mock,
+    package_manager_version: Union[semver.version.Version, None, Exception],
+    yarn_path_version: semver.version.Version,
+) -> None:
+    mock_project = mock.Mock()
+    mock_yarn_path_semver.return_value = None
+    mock_package_manager_semver.return_value = package_manager_version
+
+    with pytest.raises(
+        PackageRejected, match=f"Unsupported Yarn version '{package_manager_version}'"
+    ):
         _configure_yarn_version(mock_project)
 
 

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -19,17 +19,17 @@ from cachi2.core.rooted_path import RootedPath
 @pytest.mark.parametrize(
     "yarn_path_version, package_manager_version",
     [
-        pytest.param(semver.VersionInfo(1, 0, 0), None, id="valid-yarnpath-no-packagemanager"),
-        pytest.param(None, semver.VersionInfo(1, 0, 0), id="no-yarnpath-valid-packagemanager"),
+        pytest.param(semver.VersionInfo(3, 0, 0), None, id="valid-yarnpath-no-packagemanager"),
+        pytest.param(None, semver.VersionInfo(3, 0, 0), id="no-yarnpath-valid-packagemanager"),
         pytest.param(
-            semver.VersionInfo(1, 0, 0),
-            semver.VersionInfo(1, 0, 0),
+            semver.VersionInfo(3, 0, 0),
+            semver.VersionInfo(3, 0, 0),
             id="matching-yarnpath-and-packagemanager",
         ),
         pytest.param(
-            semver.VersionInfo(1, 0, 0),
+            semver.VersionInfo(3, 0, 0),
             semver.VersionInfo(
-                1, 0, 0, build="sha224.953c8233f7a92884eee2de69a1b92d1f2ec1655e66d08071ba9a02fa"
+                3, 0, 0, build="sha224.953c8233f7a92884eee2de69a1b92d1f2ec1655e66d08071ba9a02fa"
             ),
             id="matching-yarnpath-and-packagemanager-with-build",
         ),
@@ -77,10 +77,10 @@ def test_configure_yarn_version(
             id="exception-parsing-packagemanager",
         ),
         pytest.param(
-            semver.VersionInfo(1, 0, 1),
-            semver.VersionInfo(1, 0, 0),
+            semver.VersionInfo(3, 0, 1),
+            semver.VersionInfo(3, 0, 0),
             PackageRejected(
-                "Mismatch between the yarn versions specified by yarnPath (yarn@1.0.1) and packageManager (yarn@1.0.0)",
+                "Mismatch between the yarn versions specified by yarnPath (yarn@3.0.1) and packageManager (yarn@3.0.0)",
                 solution="Ensure that the yarnPath version in .yarnrc and the packageManager version in package.json agree",
             ),
             id="yarnpath-packagemanager-mismatch",


### PR DESCRIPTION
Reasoning:
----------------

- v1 is legacy, doesn't support PnP and hence primitives we rely on for secure dep fetching/checking
- v2 doesn't support the `config` subcommand and `--mode=skip-build` CLI option
- v4 was released only recently with some breaking changes since v3 (support for v4 will be added separately)

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] ~Docs updated (if applicable)~ (will be covered in a future PR)
- [ ] ~Docs links in the code are still valid (if docs were updated)~

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
