### PR TITLE
Add environment variables to yarn request output

### DIFF
--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -160,4 +160,11 @@ def _undo_changes(project: Project) -> None:
 
 def _generate_environment_variables() -> list[EnvironmentVariable]:
     """Generate environment variables that will be used for building the project."""
-    return []
+    env_vars = {
+        "YARN_ENABLE_GLOBAL_CACHE": {"value": "false", "kind": "literal"},
+        "YARN_ENABLE_IMMUTABLE_CACHE": {"value": "false", "kind": "literal"},
+        "YARN_ENABLE_MIRROR": {"value": "true", "kind": "literal"},
+        "YARN_GLOBAL_FOLDER": {"value": "deps/yarn", "kind": "path"},
+    }
+
+    return [EnvironmentVariable(name=name, **obj) for name, obj in env_vars.items()]

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -8,14 +8,26 @@ import pytest
 import semver
 
 from cachi2.core.errors import PackageRejected, UnexpectedFormat, YarnCommandError
+from cachi2.core.models.output import EnvironmentVariable
 from cachi2.core.package_managers.yarn.main import (
     _configure_yarn_version,
     _fetch_dependencies,
+    _generate_environment_variables,
     _resolve_yarn_project,
     _set_yarnrc_configuration,
 )
 from cachi2.core.package_managers.yarn.project import YarnRc
 from cachi2.core.rooted_path import RootedPath
+
+
+@pytest.fixture()
+def yarn_env_variables() -> list[EnvironmentVariable]:
+    return [
+        EnvironmentVariable(name="YARN_ENABLE_GLOBAL_CACHE", value="false", kind="literal"),
+        EnvironmentVariable(name="YARN_ENABLE_IMMUTABLE_CACHE", value="false", kind="literal"),
+        EnvironmentVariable(name="YARN_ENABLE_MIRROR", value="true", kind="literal"),
+        EnvironmentVariable(name="YARN_GLOBAL_FOLDER", value="deps/yarn", kind="path"),
+    ]
 
 
 class YarnVersions(Enum):
@@ -212,3 +224,8 @@ def test_set_yarnrc_configuration(mock_write: mock.Mock) -> None:
 
     assert yarn_rc._data == expected_data
     assert mock_write.called_once()
+
+
+def test_generate_environment_variables(yarn_env_variables: list[EnvironmentVariable]) -> None:
+    result = _generate_environment_variables()
+    assert result == yarn_env_variables


### PR DESCRIPTION
Several yarn settings must be supplied by the cachi2
request output in order for the user to make use of
the prefetched dependencies. These will be supplied by
way of environment variables, which when sourced, will
override any preexisting user configuration in .yarnrc.yml

YARN_GLOBAL_FOLDER must be configured to the deps/yarn
subdirectory of the cachi2 request output directory. This
is the path that cachi2 will populate with the prefetched
dependencies.

YARN_ENABLE_MIRROR must be set to true, otherwise the user
build will not make use of the global cache located at
the globalFolder path that cachi2 prepopulates.

YARN_ENABLE_GLOBAL_CACHE must be set to false, otherwise the
user build will exclusively rely on the cachi2 populated
globalFolder cache rather than copying the dependencies to
cacheFolder. If the volume containing globalFolder is only mounted
at build-time and the dependencies are not copied to cacheFolder,
the dependencies will be missing at run-time.

YARN_ENABLE_IMMUTABLE_CACHE must be set to false, otherwise
the `yarn install` will fail to populate cacheFolder from the
cachi2-supplied globalFolder cache.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] ~Docs updated (if applicable)~
- [ ] ~Docs links in the code are still valid (if docs were updated)~

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
