### PR TITLE
Yarn: Set 'globalFolder' in override YarnRc && drop _fetch_dependencies helper

### DIFF
--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -35,6 +35,7 @@ def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Comp
 
     :param project: the directory to be processed.
     :param output_dir: the directory where the prefetched dependencies will be placed.
+    :raises YarnCommandError: if fetching dependencies fails
     """
     log.info(f"Fetching the yarn dependencies at the subpath {output_dir.subpath_from_root}")
 
@@ -53,7 +54,7 @@ def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Comp
     try:
         _set_yarnrc_configuration(project, output_dir)
         packages = resolve_packages(project.source_dir)
-        _fetch_dependencies(project.source_dir, output_dir)
+        _fetch_dependencies(project.source_dir)
     finally:
         _undo_changes(project)
 
@@ -142,17 +143,13 @@ def _check_yarn_cache(source_dir: RootedPath) -> None:
     pass
 
 
-def _fetch_dependencies(source_dir: RootedPath, output_dir: RootedPath) -> None:
+def _fetch_dependencies(source_dir: RootedPath) -> None:
     """Fetch dependencies using 'yarn install'.
 
     :param source_dir: the directory in which the yarn command will be called.
-    :param output_dir: the directory where the yarn dependencies will be downloaded to.
     :raises YarnCommandError: if the 'yarn install' command fails.
     """
-    cachi2_output = output_dir.join_within_root("deps", "yarn")
-
-    args = ["install", "--mode", "skip-build"]
-    run_yarn_cmd(args, source_dir, {"YARN_GLOBAL_FOLDER": str(cachi2_output)})
+    run_yarn_cmd(["install", "--mode", "skip-build"], source_dir)
 
 
 def _undo_changes(project: Project) -> None:

--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -127,7 +127,7 @@ def _set_yarnrc_configuration(project: Project, output_dir: RootedPath) -> None:
     yarn_rc.unsafe_http_whitelist = []
     yarn_rc.enable_mirror = True
     yarn_rc.enable_scripts = False
-    yarn_rc.global_folder = str(output_dir)
+    yarn_rc.global_folder = str(output_dir.join_within_root("deps", "yarn"))
 
     yarn_rc.write()
 

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -212,7 +212,7 @@ def test_set_yarnrc_configuration(mock_write: mock.Mock) -> None:
         "enableScripts": False,
         "enableStrictSsl": True,
         "enableTelemetry": False,
-        "globalFolder": "/tmp/output",
+        "globalFolder": "/tmp/output/deps/yarn",
         "ignorePath": True,
         "unsafeHttpWhitelist": [],
         "pnpMode": "strict",

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -161,19 +161,12 @@ def test_yarn_unsupported_version_fail(
 
 @mock.patch("cachi2.core.package_managers.yarn.main.run_yarn_cmd")
 def test_fetch_dependencies(mock_yarn_cmd: mock.Mock, rooted_tmp_path: RootedPath) -> None:
-    source_dir = rooted_tmp_path
-
     mock_yarn_cmd.side_effect = YarnCommandError("berryscary")
 
-    with pytest.raises(YarnCommandError) as exc_info:
-        _fetch_dependencies(source_dir)
+    with pytest.raises(YarnCommandError):
+        _fetch_dependencies(rooted_tmp_path)
 
-    mock_yarn_cmd.assert_called_once_with(
-        ["install", "--mode", "skip-build"],
-        source_dir,
-    )
-
-    assert str(exc_info.value) == "berryscary"
+    mock_yarn_cmd.assert_called_once_with(["install", "--mode", "skip-build"], rooted_tmp_path)
 
 
 @mock.patch("cachi2.core.package_managers.yarn.main._configure_yarn_version")

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -162,17 +162,15 @@ def test_yarn_unsupported_version_fail(
 @mock.patch("cachi2.core.package_managers.yarn.main.run_yarn_cmd")
 def test_fetch_dependencies(mock_yarn_cmd: mock.Mock, rooted_tmp_path: RootedPath) -> None:
     source_dir = rooted_tmp_path
-    output_dir = rooted_tmp_path.join_within_root("cachi2-output")
 
     mock_yarn_cmd.side_effect = YarnCommandError("berryscary")
 
     with pytest.raises(YarnCommandError) as exc_info:
-        _fetch_dependencies(source_dir, output_dir)
+        _fetch_dependencies(source_dir)
 
     mock_yarn_cmd.assert_called_once_with(
         ["install", "--mode", "skip-build"],
         source_dir,
-        {"YARN_GLOBAL_FOLDER": str(output_dir.join_within_root("deps", "yarn"))},
     )
 
     assert str(exc_info.value) == "berryscary"

--- a/tests/unit/package_managers/yarn/test_utils.py
+++ b/tests/unit/package_managers/yarn/test_utils.py
@@ -1,10 +1,11 @@
 import os
+from subprocess import CalledProcessError
 from typing import Optional
 from unittest import mock
 
 import pytest
 
-from cachi2.core.package_managers.yarn.utils import run_yarn_cmd
+from cachi2.core.package_managers.yarn.utils import YarnCommandError, run_yarn_cmd
 from cachi2.core.rooted_path import RootedPath
 
 
@@ -30,3 +31,15 @@ def test_run_yarn_cmd(
     mock_run_cmd.assert_called_once_with(
         cmd=["yarn", "info", "--json"], params={"cwd": rooted_tmp_path, "env": expect_env}
     )
+
+
+@mock.patch("cachi2.core.package_managers.yarn.utils.run_cmd")
+def test_run_yarn_cmd_fail(
+    mock_run_cmd: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    cmd = ["foo", "bar"]
+    mock_run_cmd.side_effect = CalledProcessError(1, cmd=cmd)
+
+    with pytest.raises(YarnCommandError, match=f"Yarn command failed: {' '.join(cmd)}"):
+        run_yarn_cmd(cmd, rooted_tmp_path)


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- ~[ ] Docs updated (if applicable)~
- ~[ ] Docs links in the code are still valid (if docs were updated)~

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
