### PR TITLE
docs(dev): '--dev-package-managers' flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ dnf install golang-bin git
 You should now have everything needed to [try out](#basic-usage) the CLI or hack on the code in ~~vim~~ your favorite
 editor.
 
+### Developer flags
+
+* `--dev-package-managers` (hidden): enables in-development package manager(s)
+  for test. Please refer to other existing package managers to see how they're
+  enabled and wired to the CLI.
+
+  Invoke it as `cachi2 fetch-deps --dev-package-managers FOO`
+
+  More explicitly
+
+  * `--dev-package-managers` is a *flag for* `fetch-deps`
+  * `FOO` is an *argument to* `fetch-deps` (i.e. the language to fetch for)
+
 ### Coding standards
 
 Cachi2's codebase conforms to standards enforced by a collection of formatters, linters and other code checkers:

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -18,6 +18,8 @@ _package_managers: dict[PackageManagerType, Handler] = {
     "pip": pip.fetch_pip_source,
 }
 
+# This is where we put package managers currently under development in order to
+# invoke them via CLI
 _dev_package_managers: dict[PackageManagerType, Handler] = {
     "yarn": yarn.fetch_yarn_source,
 }


### PR DESCRIPTION
Documentation for the `--dev-package-managers` flag

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>
