### PR TITLE
tests: unit: yarn: resolver: Drop any zero-install leftovers

### DIFF
--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -134,16 +134,6 @@ def _set_yarnrc_configuration(project: Project, output_dir: RootedPath) -> None:
     yarn_rc.write()
 
 
-def _check_yarn_cache(source_dir: RootedPath) -> None:
-    """Check the contents of the yarn cache using 'yarn install'.
-
-    :param source_dir: the directory in which the yarn command will be called.
-    :raises YarnCommandError: if the 'yarn install' command fails.
-    """
-    # the yarn commands can be called by using the core.utils.run_cmd function
-    pass
-
-
 def _fetch_dependencies(source_dir: RootedPath) -> None:
     """Fetch dependencies using 'yarn install'.
 

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -427,9 +427,6 @@ def mock_project(project_dir: RootedPath) -> Project:
                     raw_locator="strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.",
                     version="4.0.0",
                     checksum="d67629c87783bc1138a64f6495439b40f568424a05e068c341b4fc330745e8ba6e7f93536549883054c1da58761f0ce6ab039a233014b38240304d3c45f85ac6",
-                    # relative to project_dir or output_dir, depending on project_uses_zero_installs
-                    # NOTE: yarn info reports the absolute path, not the relative one. The test code
-                    #   fixes that later.
                     cache_path="cache/directory/strip-ansi-tarball-file-489a50cded-d67629c877.zip",
                 ),
                 is_hardlink=True,
@@ -469,21 +466,17 @@ def mock_project(project_dir: RootedPath) -> Project:
         ),
     ],
 )
-@pytest.mark.parametrize("project_uses_zero_installs", [True, False])
 def test_create_components_single_package(
     mocked_package: MockedPackage,
     expect_component: Component,
     expect_logs: list[str],
-    project_uses_zero_installs: bool,
     tmp_path: Path,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     project_dir = RootedPath(tmp_path / "project")
     output_dir = RootedPath(tmp_path / "output")
 
-    mocked_package = mocked_package.resolve_cache_path(
-        project_dir if project_uses_zero_installs else output_dir
-    )
+    mocked_package = mocked_package.resolve_cache_path(output_dir)
     mock_package_json(mocked_package, project_dir)
 
     components = create_components([mocked_package.package], mock_project(project_dir), output_dir)


### PR DESCRIPTION
Yarn zero-installs were explicitly forbidden in commit 0a913377ba692ba2e6620bbd8d2b55c16b5b7678, but the commit left some bits referring to zero-installs around. Delete them.

Fixes: 0a913377ba692ba2e6620bbd8d2b55c16b5b7678

I noticed this while looking at #374 

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
