### PR TITLE
util: Fix recursively copying destination directory into itself

### DIFF
--- a/cachi2/core/utils.py
+++ b/cachi2/core/utils.py
@@ -91,7 +91,12 @@ def copy_directory(origin: Path, destination: Path) -> Path:
 
     def _copy_using(copy_function: Callable) -> None:
         shutil.copytree(
-            origin, destination, copy_function=copy_function, dirs_exist_ok=True, symlinks=True
+            origin,
+            destination,
+            copy_function=copy_function,
+            dirs_exist_ok=True,
+            symlinks=True,
+            ignore=shutil.ignore_patterns(destination.name),
         )
 
     if reflink.supported_at(origin):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -105,9 +105,7 @@ def test_copy_directory(
     else:
         copy_function = shutil.copy2
 
-    mock_shutil_copytree.assert_called_with(
-        origin, destination, copy_function=copy_function, dirs_exist_ok=True, symlinks=True
-    )
+    assert mock_shutil_copytree.call_args.kwargs["copy_function"] == copy_function
 
 
 @mock.patch("shutil.copy2")


### PR DESCRIPTION
Noticed this when investigating https://github.com/containerbuildsystem/cachi2/pull/399#issuecomment-1830949017

When we copy the sources into `./<tmpdir>` we copy `<tmpdir>` (because we created it before the copy actually started) recursively too. By some luck copytree doesn't crash on infinite recursion. Here's a snippet during the the dependecy fetch (in a breakpoint):

```
cachi2-yarn-test.git $ ls -1
app.ts
book-of-armaments
external-packages
my-patches
package.json
packages
README.md
>>>>tmpbhakv792.cachi2-source-copy<<<<
tsconfig.json
yarn.lock

cachi2-yarn-test.git $ cd tmpbhakv792.cachi2-source-copy/

tmpbhakv792.cachi2-source-copy $ ls -1
app.ts
book-of-armaments
external-packages
my-patches
package.json
packages
README.md
>>>>tmpbhakv792.cachi2-source-copy<<<<
tsconfig.json
yarn.lock
```

Fix the problem by putting the destination name into `copytree`'s ignore pattern.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
