### PR TITLE
package_managers: yarn: Drop the 'undo_changes' handler

### DIFF
--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -82,12 +82,9 @@ def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Comp
             ),
         )
 
-    try:
-        _set_yarnrc_configuration(project, output_dir)
-        packages = resolve_packages(project.source_dir)
-        _fetch_dependencies(project.source_dir)
-    finally:
-        _undo_changes(project)
+    _set_yarnrc_configuration(project, output_dir)
+    packages = resolve_packages(project.source_dir)
+    _fetch_dependencies(project.source_dir)
 
     return create_components(packages, project, output_dir)
 
@@ -196,12 +193,6 @@ def _fetch_dependencies(source_dir: RootedPath) -> None:
     :raises PackageManagerError: if the 'yarn install' command fails.
     """
     run_yarn_cmd(["install", "--mode", "skip-build"], source_dir)
-
-
-def _undo_changes(project: Project) -> None:
-    """Undo any changes that were made to the files during the request's processing."""
-    # restore the disabled plugins here, as well as undo any additional changes
-    pass
 
 
 def _generate_environment_variables() -> list[EnvironmentVariable]:


### PR DESCRIPTION
Originally introduced by commit a18fda989 to handle erroneous paths during the dependency pre-fetch. However, the handler has always been a NOOP and since we merged b83b621b which always creates a working copy of the input source repository, we don't need any rollback handler at the moment - we can always add it when needed, but until then, let's drop this.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
