### PR TITLE
cachi2 yarn: bug fixes

### DIFF
--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -67,7 +67,7 @@ def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Comp
     :param output_dir: the directory where the prefetched dependencies will be placed.
     :raises PackageManagerError: if fetching dependencies fails
     """
-    log.info(f"Fetching the yarn dependencies at the subpath {output_dir.subpath_from_root}")
+    log.info(f"Fetching the yarn dependencies at the subpath {project.source_dir}")
 
     _configure_yarn_version(project)
     _verify_yarnrc_paths(project)

--- a/cachi2/core/package_managers/yarn/resolver.py
+++ b/cachi2/core/package_managers/yarn/resolver.py
@@ -244,7 +244,7 @@ class _ComponentResolver:
             project_path = project.source_dir
             workspace_path = package.locator.relpath
 
-            repo = get_repo_id(project_path)
+            repo = get_repo_id(project_path.root)
 
             qualifiers["vcs_url"] = repo.as_vcs_url_qualifier()
             subpath = str(workspace_path)
@@ -256,7 +256,7 @@ class _ComponentResolver:
 
             normalized = project_path.join_within_root(workspace_path, package_path)
 
-            repo = get_repo_id(project_path)
+            repo = get_repo_id(project_path.root)
             qualifiers["vcs_url"] = repo.as_vcs_url_qualifier()
             subpath = str(normalized.subpath_from_root)
 


### PR DESCRIPTION
While implementing integration test with multiple yarn packages, I came across some bugs.

To reproduce, run integration tests on my local branch: [here](https://github.com/slimreaper35/cachi2/tree/STONEBLD-1899)

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
