### PR TITLE
feat(int tests): add "incorrect checksum" scenario

### DIFF
--- a/tests/integration/test_yarn.py
+++ b/tests/integration/test_yarn.py
@@ -65,6 +65,20 @@ log = logging.getLogger(__name__)
             ),
             id="yarn_immutable_installs",
         ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-yarn-berry.git",
+                ref="c5268f91f0a0b68fa72d4f2c3a570d348d194241",
+                packages=({"path": ".", "type": "yarn"},),
+                check_output=False,
+                check_deps_checksums=False,
+                check_vendor_checksums=False,
+                flags=["--dev-package-managers"],
+                expected_exit_code=1,
+                expected_output="typescript@npm:5.3.3: The remote archive doesn't match the expected checksum",
+            ),
+            id="yarn_incorrect_checksum",
+        ),
     ],
 )
 def test_yarn_packages(


### PR DESCRIPTION
[test data](https://github.com/cachito-testing/cachi2-yarn-berry/tree/incorrect-checksum) (cachi2-yarn-berry, "incorrect-checksum" branch)

STONEBLD-1895

Signed-off-by: Ben Alkov <ben.alkov@redhat.com>

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] ~Docs updated (if applicable)~
- [ ] ~Docs links in the code are still valid (if docs were updated)~

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
