### PR TITLE
Yarn: Add a check for missing lockfile

### DIFF
--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -60,6 +60,18 @@ def _verify_yarnrc_paths(project: Project) -> None:
                 )
 
 
+def _check_zero_installs(project: Project) -> None:
+    if project.is_zero_installs:
+        raise PackageRejected(
+            ("Yarn zero install detected, PnP zero installs are unsupported by cachi2"),
+            solution=(
+                "Please convert your project to a regular install-based one.\n"
+                "Depending on whether you use Yarn's PnP or a different node linker Yarn setting "
+                "make sure to remove '.yarn/cache' or 'node_modules' directories respectively."
+            ),
+        )
+
+
 def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Component]:
     """Process a request for a single yarn source directory.
 
@@ -71,16 +83,7 @@ def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Comp
 
     _configure_yarn_version(project)
     _verify_yarnrc_paths(project)
-
-    if project.is_zero_installs:
-        raise PackageRejected(
-            ("Yarn zero install detected, PnP zero installs are unsupported by cachi2"),
-            solution=(
-                "Please convert your project to a regular install-based one.\n"
-                "Depending on whether you use Yarn's PnP or a different node linker Yarn setting "
-                "make sure to remove '.yarn/cache' or 'node_modules' directories respectively."
-            ),
-        )
+    _check_zero_installs(project)
 
     _set_yarnrc_configuration(project, output_dir)
     packages = resolve_packages(project.source_dir)

--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -72,6 +72,17 @@ def _check_zero_installs(project: Project) -> None:
         )
 
 
+def _check_lockfile(project: Project) -> None:
+    if not project.source_dir.join_within_root(project.yarn_rc.lockfilename).path.exists():
+        raise PackageRejected(
+            f"Yarn lockfile '{project.yarn_rc.lockfilename}' missing, refusing to continue",
+            solution=(
+                "Make sure your repository has a Yarn lockfile (e.g. yarn.lock) checked in "
+                "to the repository"
+            ),
+        )
+
+
 def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Component]:
     """Process a request for a single yarn source directory.
 
@@ -84,6 +95,7 @@ def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Comp
     _configure_yarn_version(project)
     _verify_yarnrc_paths(project)
     _check_zero_installs(project)
+    _check_lockfile(project)
 
     _set_yarnrc_configuration(project, output_dir)
     packages = resolve_packages(project.source_dir)

--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -83,6 +83,12 @@ def _check_lockfile(project: Project) -> None:
         )
 
 
+def _verify_repository(project: Project) -> None:
+    _verify_yarnrc_paths(project)
+    _check_zero_installs(project)
+    _check_lockfile(project)
+
+
 def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Component]:
     """Process a request for a single yarn source directory.
 
@@ -93,9 +99,7 @@ def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Comp
     log.info(f"Fetching the yarn dependencies at the subpath {project.source_dir}")
 
     _configure_yarn_version(project)
-    _verify_yarnrc_paths(project)
-    _check_zero_installs(project)
-    _check_lockfile(project)
+    _verify_repository(project)
 
     _set_yarnrc_configuration(project, output_dir)
     packages = resolve_packages(project.source_dir)

--- a/cachi2/core/package_managers/yarn/project.py
+++ b/cachi2/core/package_managers/yarn/project.py
@@ -140,6 +140,11 @@ class YarnRc:
         self._data["installStatePath"] = path
 
     @property
+    def lockfilename(self) -> str:
+        """Get the installStatePath configuration."""
+        return self._data.get("lockfileFilename", "yarn.lock")
+
+    @property
     def patch_folder(self) -> Optional[str]:
         """Get the patch folder."""
         return self._data.get("patchFolder")

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -13,10 +13,10 @@ from cachi2.core.errors import PackageManagerError, PackageRejected, UnexpectedF
 from cachi2.core.models.input import Request
 from cachi2.core.models.output import BuildConfig, Component, EnvironmentVariable, RequestOutput
 from cachi2.core.package_managers.yarn.main import (
+    _check_zero_installs,
     _configure_yarn_version,
     _fetch_dependencies,
     _generate_environment_variables,
-    _resolve_yarn_project,
     _set_yarnrc_configuration,
     _verify_corepack_yarn_version,
     _verify_yarnrc_paths,
@@ -263,20 +263,15 @@ def test_fetch_dependencies(mock_yarn_cmd: mock.Mock, rooted_tmp_path: RootedPat
     mock_yarn_cmd.assert_called_once_with(["install", "--mode", "skip-build"], rooted_tmp_path)
 
 
-@mock.patch("cachi2.core.package_managers.yarn.main._configure_yarn_version")
-def test_resolve_zero_installs_fail(
-    mock_configure_yarn_version: mock.Mock, rooted_tmp_path: RootedPath
-) -> None:
-    mock_configure_yarn_version.return_value = None
+def test_resolve_zero_installs_fail() -> None:
     project = mock.Mock()
     project.is_zero_installs = True
-    output_dir = rooted_tmp_path.join_within_root("cachi2-output")
 
     with pytest.raises(
         PackageRejected,
         match=("Yarn zero install detected, PnP zero installs are unsupported by cachi2"),
     ):
-        _resolve_yarn_project(project, output_dir)
+        _check_zero_installs(project)
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -13,6 +13,7 @@ from cachi2.core.errors import PackageManagerError, PackageRejected, UnexpectedF
 from cachi2.core.models.input import Request
 from cachi2.core.models.output import BuildConfig, Component, EnvironmentVariable, RequestOutput
 from cachi2.core.package_managers.yarn.main import (
+    _check_lockfile,
     _check_zero_installs,
     _configure_yarn_version,
     _fetch_dependencies,
@@ -335,6 +336,18 @@ def test_verify_yarnrc_paths() -> None:
 
     _set_yarnrc_configuration(project, output_dir)
     _verify_yarnrc_paths(project)
+
+
+def test_check_missing_lockfile(rooted_tmp_path: RootedPath) -> None:
+    project = mock.Mock()
+    project.source_dir = rooted_tmp_path
+    project.yarn_rc = YarnRc(project.source_dir.join_within_root(".yarnrc.yml"), {})
+
+    with pytest.raises(
+        PackageRejected,
+        match=f"Yarn lockfile '{project.yarn_rc.lockfilename}' missing, refusing to continue",
+    ):
+        _check_lockfile(project)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Raised during review in a related work: https://github.com/containerbuildsystem/cachi2/pull/425#discussion_r1426765531

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
