### PR TITLE
Yarn: add integration test for missing lockfile

### DIFF
--- a/tests/integration/test_yarn.py
+++ b/tests/integration/test_yarn.py
@@ -74,6 +74,19 @@ log = logging.getLogger(__name__)
             ),
             id="yarn_incorrect_checksum",
         ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-yarn-berry.git",
+                ref="c1da60842aa94aaab8ed48122dc44522bd2a5ab1",
+                packages=({"path": ".", "type": "yarn"},),
+                check_output=False,
+                check_deps_checksums=False,
+                check_vendor_checksums=False,
+                expected_exit_code=2,
+                expected_output="Yarn lockfile 'yarn_non_existent.lock' missing, refusing to continue",
+            ),
+            id="yarn_no_lockfile",
+        ),
     ],
 )
 def test_yarn_packages(


### PR DESCRIPTION
Adding test for a yarn project which is missing a lockfile. This results in failure in cachi2.

STONEBLD-2075

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- N/A Docs updated (if applicable)
- N/A Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
