### PR TITLE
docs: Bump the supported version of Go to 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ original Cachito.*
 
 <https://go.dev/ref/mod>
 
-Current version: 1.20 [^go-version] [^go-compat]
+Current version: 1.21 [^go-version] [^go-compat]
 
 The gomod package manager works by parsing the [go.mod](https://go.dev/ref/mod#go-mod-file) file present in the source
 repository to determine which dependencies to download. Cachi2 does not parse this file on its own - rather, we rely on
@@ -332,6 +332,17 @@ See [docs/gomod.md](docs/gomod.md) for more details.
   there is a good chance it will be compatible regardless, as long as the dependency resolution did not change between
   the two versions. For example, dependency resolution did change in [go 1.18][go118-changelog] but not in
   [go 1.19][go119-changelog].
+
+#### Go 1.21+ *(since cachi2-v0.5.0)*
+  Starting with [Go 1.21][go121-changelog], Go changed the meaning of the `go 1.X` directive in
+  that it now specifies the [minimum required version](https://go.dev/ref/mod#go-mod-file-go) of Go
+  rather than a suggested version as it originally did. The format of the version string in the
+  `go` directive now also includes the micro release and if you don't include the micro release in
+  your `go.mod` file yourself (i.e. you only specify the language release) Go will try to correct
+  it automatically inside the file. Last but not least, Go 1.21 also introduced a new keyword
+  [`toolchain`](https://go.dev/ref/mod#go-mod-file-toolchain) to the `go.mod` file. What this all
+  means in practice for end users is that you may not be able to process your `go.mod` file with an older version
+  of Go (and hence older cachi2) as you could in the past for various reasons.
 
 ### pip
 
@@ -392,4 +403,5 @@ still in early development phase.
 [go117-changelog]: https://tip.golang.org/doc/go1.17#go-command
 [go118-changelog]: https://tip.golang.org/doc/go1.18#go-command
 [go119-changelog]: https://tip.golang.org/doc/go1.19#go-command
+[go121-changelog]: https://tip.golang.org/doc/go1.21
 [ocp-cachi2-pipelines]: https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/pipelines/ns/tekton-ci/pipeline-runs?name=cachi2

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -249,7 +249,7 @@ class Go:
         :param cmd: Go CLI options
         :param params: additional subprocess arguments, e.g. 'env'
         :param retry: whether the command should be retried on failure (e.g. network actions)
-        :returs: Go command's output
+        :returns: Go command's output
         """
         if params is None:
             params = {}


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Docs updated (if applicable)
- [x] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
