### PR TITLE
increase cachi2 coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ skip_covered = True
 show_missing = True
 fail_under = 75
 exclude_lines =
-    pragma: no cover
     if __name__ == .__main__.:
     def __repr__
+    if TYPE_CHECKING:
+    return NotImplemented

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,9 +1,0 @@
-[report]
-skip_covered = True
-show_missing = True
-fail_under = 75
-exclude_lines =
-    if __name__ == .__main__.:
-    def __repr__
-    if TYPE_CHECKING:
-    return NotImplemented

--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -39,7 +39,8 @@ jobs:
       run: |
         pip3 install --upgrade pip
         pip3 install --upgrade setuptools
-        pip3 install --upgrade coveralls==3.2.0
+        pip3 install --upgrade coverage[toml]
+        pip3 install --upgrade coveralls
         coveralls --service=github
 
   coveralls-finish:

--- a/cachi2/core/rooted_path.py
+++ b/cachi2/core/rooted_path.py
@@ -70,9 +70,12 @@ class RootedPath(PathLike[str]):
         return self._path.relative_to(self._root)
 
     def __eq__(self, other: object) -> bool:
-        # Note: __eq__ is implemented mainly for unit tests that do assert_called_with() or similar
         if not isinstance(other, RootedPath):
+            # NotImplemented is a special value which should be returned by the binary special methods
+            # (e.g. __eq__(), __lt__(), __add__(), __rsub__(), etc.)  to indicate that the operation is
+            # not implemented with respect to the other type - https://docs.python.org/3/library/constants.html#NotImplemented
             return NotImplemented
+
         return self.path == other.path and self.root == other.root
 
     def __fspath__(self) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ ignore_missing_imports = true
 [tool.coverage.report]
 skip_covered = true
 show_missing = true
-fail_under = 75
+fail_under = 90
 exclude_lines = [
   "def __repr__",
   "if __name__ == .__main__.:",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,3 +82,14 @@ disallow_untyped_decorators = true
 [[tool.mypy.overrides]]
 module = ["semver"]
 ignore_missing_imports = true
+
+[tool.coverage.report]
+skip_covered = true
+show_missing = true
+fail_under = 75
+exclude_lines = [
+  "def __repr__",
+  "if __name__ == .__main__.:",
+  "if TYPE_CHECKING:",
+  "return NotImplemented",
+]

--- a/tox.ini
+++ b/tox.ini
@@ -20,9 +20,12 @@ deps =
     -rrequirements-extras.txt
 commands =
     py.test \
-      --ignore tests/integration \
-      --cov-config .coveragerc --cov=cachi2 --cov-report term \
-      --cov-report xml --cov-report html {posargs}
+      --ignore=tests/integration \
+      --cov=cachi2 \
+      --cov-config=pyproject.toml \
+      --cov-report=term \
+      --cov-report=html \
+      --cov-report=xml {posargs}
 allowlist_externals =
     make
     mkdir


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
