### PR TITLE
 Add full Go 1.21 support

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -36,7 +36,7 @@ RUN npm install && \
 #   - clean any build artifacts Go creates as part of the process.
 RUN go install 'golang.org/dl/go1.20@latest' && \
     "$HOME/go/bin/go1.20" download && \
-    mkdir /usr/local/go && \
+    mkdir -p /usr/local/go && \
     mv "$HOME/sdk/go1.20" /usr/local/go && \
     rm -rf "$HOME/go" "$HOME/.cache/go-build/"
 

--- a/Containerfile
+++ b/Containerfile
@@ -34,10 +34,12 @@ RUN npm install && \
 #   - move the SDK to a host local install system-wide location
 #   - remove the shim as it forces and expects the SDK to be used from $HOME
 #   - clean any build artifacts Go creates as part of the process.
-RUN go install 'golang.org/dl/go1.20@latest' && \
-    "$HOME/go/bin/go1.20" download && \
-    mkdir -p /usr/local/go && \
-    mv "$HOME/sdk/go1.20" /usr/local/go && \
-    rm -rf "$HOME/go" "$HOME/.cache/go-build/"
+RUN for go_ver in "go1.20" "go1.21.0"; do \
+        go install "golang.org/dl/${go_ver}@latest" && \
+        "$HOME/go/bin/$go_ver" download && \
+        mkdir -p /usr/local/go && \
+        mv "$HOME/sdk/$go_ver" /usr/local/go && \
+        rm -rf "$HOME/go" "$HOME/.cache/go-build/"; \
+    done
 
 ENTRYPOINT ["cachi2"]

--- a/README.md
+++ b/README.md
@@ -331,7 +331,9 @@ See [docs/gomod.md](docs/gomod.md) for more details.
   the intended go version, Cachi2 should handle it appropriately. If your go version is *higher* than what Cachi2 uses,
   there is a good chance it will be compatible regardless, as long as the dependency resolution did not change between
   the two versions. For example, dependency resolution did change in [go 1.18][go118-changelog] but not in
-  [go 1.19][go119-changelog].
+  [go 1.19][go119-changelog]. Things are a bit more complicated with [Go 1.21][go121-changelog], if
+  you are or have been experiencing issues with cachi2 related to Go 1.21+, please refer to
+  [docs/gomod.md](docs/gomod.md#go-121-since-cachi2-v050).
 
 ### pip
 

--- a/README.md
+++ b/README.md
@@ -333,17 +333,6 @@ See [docs/gomod.md](docs/gomod.md) for more details.
   the two versions. For example, dependency resolution did change in [go 1.18][go118-changelog] but not in
   [go 1.19][go119-changelog].
 
-#### Go 1.21+ *(since cachi2-v0.5.0)*
-  Starting with [Go 1.21][go121-changelog], Go changed the meaning of the `go 1.X` directive in
-  that it now specifies the [minimum required version](https://go.dev/ref/mod#go-mod-file-go) of Go
-  rather than a suggested version as it originally did. The format of the version string in the
-  `go` directive now also includes the micro release and if you don't include the micro release in
-  your `go.mod` file yourself (i.e. you only specify the language release) Go will try to correct
-  it automatically inside the file. Last but not least, Go 1.21 also introduced a new keyword
-  [`toolchain`](https://go.dev/ref/mod#go-mod-file-toolchain) to the `go.mod` file. What this all
-  means in practice for end users is that you may not be able to process your `go.mod` file with an older version
-  of Go (and hence older cachi2) as you could in the past for various reasons.
-
 ### pip
 
 <https://pip.pypa.io/en/stable/>

--- a/cachi2/core/extras/envfile.py
+++ b/cachi2/core/extras/envfile.py
@@ -52,8 +52,11 @@ def generate_envfile(build_config: BuildConfig, fmt: EnvFormat, relative_to_path
     - env: export GOCACHE=/path/to/output-dir/deps/gomod
            export ...
     """
+    # pass all variables as placeholder mappings to env var template value resolution
+    mappings = {var.name: var.value for var in build_config.environment_variables}
+    mappings["output_dir"] = relative_to_path.as_posix()
     env_vars = [
-        (env_var.name, env_var.resolve_value({"output_dir": relative_to_path.as_posix()}))
+        (env_var.name, env_var.resolve_value(mappings))
         for env_var in build_config.environment_variables
     ]
     if fmt == EnvFormat.json:

--- a/cachi2/core/extras/envfile.py
+++ b/cachi2/core/extras/envfile.py
@@ -43,8 +43,9 @@ class EnvFormat(str, Enum):
 def generate_envfile(build_config: BuildConfig, fmt: EnvFormat, relative_to_path: Path) -> str:
     """Generate an environment file in the specified format.
 
-    Some environment variables need to be resolved relative to a path. Generally, this
-    should be the path to the output directory where dependencies were fetched.
+    Some environment variables need to be resolved relative to a path for which @output_dir is
+    used. Generally, this should be the path to the output directory where dependencies were
+    fetched.
 
     Supported formats:
     - json: [{"name": "GOCACHE", "value": "/path/to/output-dir/deps/gomod"}, ...]
@@ -52,7 +53,7 @@ def generate_envfile(build_config: BuildConfig, fmt: EnvFormat, relative_to_path
            export ...
     """
     env_vars = [
-        (env_var.name, env_var.resolve_value(relative_to_path))
+        (env_var.name, env_var.resolve_value({"output_dir": relative_to_path.as_posix()}))
         for env_var in build_config.environment_variables
     ]
     if fmt == EnvFormat.json:

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -279,7 +279,7 @@ class Go:
         # lazy evaluation: defer running 'go'
         if not self._release:
             output = self(["version"])
-            log.info(f"Go release: {output}")
+            log.debug(f"Go release: {output}")
             release_pattern = f"go{version.VERSION_PATTERN}"
 
             # packaging.version requires passing the re.VERBOSE|re.IGNORECASE flags [1]
@@ -791,6 +791,8 @@ def _resolve_gomod(
         # recipes. Note that at some point they'll have to do that anyway, but until majority of
         # projects in the ecosystem adopt 1.21, we need a fallback to an older toolchain version.
         go = Go(release="go1.20")
+
+    log.info(f"Using Go release: {go.release}")
 
     # Vendor dependencies if the gomod-vendor flag is set
     flags = request.flags

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -653,7 +653,7 @@ def _get_repository_name(source_dir: RootedPath) -> str:
     return f"{url.hostname}{url.path.rstrip('/').removesuffix('.git')}"
 
 
-def _get_gomod_version(source_dir: RootedPath) -> Optional[str]:
+def _get_gomod_version(go_mod_file: RootedPath) -> Optional[str]:
     """Return the required/recommended version of Go from go.mod.
 
     We need to extract the desired version of Go ourselves as older versions of Go might fail
@@ -663,8 +663,7 @@ def _get_gomod_version(source_dir: RootedPath) -> Optional[str]:
     If we cannot extract a version from the 'go' line, we return None, leaving it up to the caller
     to decide what to do next.
     """
-    go_mod = source_dir.join_within_root("go.mod")
-    with open(go_mod) as f:
+    with open(go_mod_file) as f:
         reg = re.compile(r"^\s*go\s+(?P<ver>\d\.\d+(:?.\d+)?)\s*$")
         for line in f:
             if match := re.match(reg, line):
@@ -764,7 +763,7 @@ def _resolve_gomod(
     go_base_version = go.version
     go_mod_version_msg = "go.mod recommends/requires Go version: {}"
 
-    if (_ := _get_gomod_version(app_dir)) is None:
+    if (_ := _get_gomod_version(app_dir.join_within_root("go.mod"))) is None:
         # Go added the 'go' directive to go.mod in 1.12 [1]. If missing, 1.16 is assumed [2].
         # For our version comparison purposes we set the version explicitly to 1.20 if missing.
         # [1] https://go.dev/doc/go1.12#modules

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -737,7 +737,7 @@ def _find_missing_gomod_files(source_path: RootedPath, subpaths: list[str]) -> l
 def _setup_go_toolchain(go_mod_file: RootedPath) -> Go:
     go = Go()
     target_version = None
-    go1_21 = version.Version("1.21")
+    go_max_version = version.Version("1.21")
     go_base_version = go.version
     go_mod_version_msg = "go.mod reported versions: '{}'[go], '{}'[toolchain]"
 
@@ -767,10 +767,19 @@ def _setup_go_toolchain(go_mod_file: RootedPath) -> Go:
     else:
         target_version = go_mod_toolchain_version
 
-    if target_version >= go1_21 and go_base_version < go1_21:
+    if target_version.major > go_max_version.major or target_version.minor > go_max_version.minor:
+        raise PackageManagerError(
+            f"Required/recommended Go toolchain version '{target_version}' is not supported yet.",
+            solution=(
+                "Please lower your required/recommended Go version and retry the request. "
+                "You may also want to open a feature request on adding support for this version."
+            ),
+        )
+
+    if target_version >= go_max_version and go_base_version < go_max_version:
         # our base Go installation is too old and we need a newer one to support new keywords
         go = Go(release="go1.21.0")
-    elif target_version < go1_21 and go_base_version >= go1_21:
+    elif target_version < go_max_version and go_base_version >= go_max_version:
         # Starting with Go 1.21, Go doesn't try to be semantically backwards compatible in that the
         # 'go X.Y' line now denotes the minimum required version of Go, no a "suggested" version.
         # What it means in practice is that a Go toolchain >= 1.21 enforces the biggest

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -241,6 +241,7 @@ class Go:
             if bin_ := self._locate_toolchain(self._release):
                 self._bin = bin_
             else:
+                log.debug(f"Desired toolchain '{self._release}' not found, will download it lazily")
                 self._install_toolchain = True
 
     def __call__(self, cmd: list[str], params: Optional[dict] = None, retry: bool = False) -> str:
@@ -305,7 +306,9 @@ class Go:
         local_cache = get_cache_dir()
         go_path_stub = f"go/{release}/bin/go"
         for p in [Path("/usr/local/", go_path_stub), Path(local_cache, go_path_stub)]:
-            log.debug(f"Trying to locate Go toolchain at '{p}'")
+            status = "SUCCESS" if p.exists() else "FAIL"
+
+            log.debug(f"Trying to locate Go toolchain at '{p}': {status}")
             if p.exists():
                 return str(p)
 

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -743,7 +743,7 @@ def _resolve_gomod(
         "GO111MODULE": "on",
         "GOCACHE": tmp_dir,
         "PATH": os.environ.get("PATH", ""),
-        "GOMODCACHE": "{}/pkg/mod".format(tmp_dir),
+        "GOMODCACHE": f"{tmp_dir}/pkg/mod",
         "GOSUMDB": "sum.golang.org",
         "GOTOOLCHAIN": "local",
     }

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -551,10 +551,10 @@ def fetch_gomod_source(request: Request) -> RequestOutput:
         )
 
     env_vars = {
-        "GOCACHE": {"value": "deps/gomod", "kind": "path"},
-        "GOPATH": {"value": "deps/gomod", "kind": "path"},
-        "GOMODCACHE": {"value": "deps/gomod/pkg/mod", "kind": "path"},
-        "GOTOOLCHAIN": {"value": "local", "kind": "literal"},
+        "GOCACHE": "${output_dir}/deps/gomod",
+        "GOPATH": "${output_dir}/deps/gomod",
+        "GOMODCACHE": "${output_dir}/deps/gomod/pkg/mod",
+        "GOTOOLCHAIN": "local",
     }
     env_vars.update(config.default_environment_variables.get("gomod", {}))
 
@@ -616,7 +616,7 @@ def fetch_gomod_source(request: Request) -> RequestOutput:
     return RequestOutput.from_obj_list(
         components=components,
         environment_variables=[
-            EnvironmentVariable(name=name, **obj) for name, obj in env_vars.items()
+            EnvironmentVariable(name=key, value=value) for key, value in env_vars.items()
         ],
         project_files=[],
     )

--- a/cachi2/core/package_managers/pip.py
+++ b/cachi2/core/package_managers/pip.py
@@ -159,8 +159,8 @@ def fetch_pip_source(request: Request) -> RequestOutput:
 
     if request.pip_packages:
         environment_variables = [
-            EnvironmentVariable(name="PIP_FIND_LINKS", value="deps/pip", kind="path"),
-            EnvironmentVariable(name="PIP_NO_INDEX", value="true", kind="literal"),
+            EnvironmentVariable(name="PIP_FIND_LINKS", value="${output_dir}/deps/pip"),
+            EnvironmentVariable(name="PIP_NO_INDEX", value="true"),
         ]
 
     for package in request.pip_packages:

--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -217,13 +217,13 @@ def _fetch_dependencies(source_dir: RootedPath) -> None:
 def _generate_environment_variables() -> list[EnvironmentVariable]:
     """Generate environment variables that will be used for building the project."""
     env_vars = {
-        "YARN_ENABLE_GLOBAL_CACHE": {"value": "false", "kind": "literal"},
-        "YARN_ENABLE_IMMUTABLE_CACHE": {"value": "false", "kind": "literal"},
-        "YARN_ENABLE_MIRROR": {"value": "true", "kind": "literal"},
-        "YARN_GLOBAL_FOLDER": {"value": "deps/yarn", "kind": "path"},
+        "YARN_ENABLE_GLOBAL_CACHE": "false",
+        "YARN_ENABLE_IMMUTABLE_CACHE": "false",
+        "YARN_ENABLE_MIRROR": "true",
+        "YARN_GLOBAL_FOLDER": "${output_dir}/deps/yarn",
     }
 
-    return [EnvironmentVariable(name=name, **obj) for name, obj in env_vars.items()]
+    return [EnvironmentVariable(name=key, value=value) for key, value in env_vars.items()]
 
 
 def _verify_corepack_yarn_version(expected_version: semver.Version, source_dir: RootedPath) -> None:

--- a/docs/gomod.md
+++ b/docs/gomod.md
@@ -211,6 +211,17 @@ workflow.
   of the affected packages. This can cause Cachi2 to miss the transitive package dependencies of packages from
   checksum-less modules.
 
+### Go 1.21+ *(since cachi2-v0.5.0)*
+  Starting with [Go 1.21][go121-changelog], Go changed the meaning of the `go 1.X` directive in
+  that it now specifies the [minimum required version](https://go.dev/ref/mod#go-mod-file-go) of Go
+  rather than a suggested version as it originally did. The format of the version string in the
+  `go` directive now also includes the micro release and if you don't include the micro release in
+  your `go.mod` file yourself (i.e. you only specify the language release) Go will try to correct
+  it automatically inside the file. Last but not least, Go 1.21 also introduced a new keyword
+  [`toolchain`](https://go.dev/ref/mod#go-mod-file-toolchain) to the `go.mod` file. What this all
+  means in practice for end users is that you may not be able to process your `go.mod` file with an older version
+  of Go (and hence older cachi2) as you could in the past for various reasons.
+
 [readme-gomod]: ../README.md#gomod
 [usage-prefetch]: usage.md#pre-fetch-dependencies
 [usage-genenv]: usage.md#generate-environment-variables
@@ -219,3 +230,4 @@ workflow.
 [gosumdb]: https://go.dev/ref/mod#checksum-database
 [py-modules]: https://docs.python.org/3/tutorial/modules.html
 [npm-modules]: https://docs.npmjs.com/about-packages-and-modules
+[go121-changelog]: https://tip.golang.org/doc/go1.21

--- a/docs/gomod.md
+++ b/docs/gomod.md
@@ -8,6 +8,7 @@
 * [gomod flags](#gomod-flags)
 * [Vendoring](#vendoring)
 * [Understanding reported dependencies](#understanding-reported-dependencies)
+* [Go 1.21+](#go-121-since-cachi2-v050)
 
 ## Specifying modules to process
 
@@ -219,8 +220,17 @@ workflow.
   your `go.mod` file yourself (i.e. you only specify the language release) Go will try to correct
   it automatically inside the file. Last but not least, Go 1.21 also introduced a new keyword
   [`toolchain`](https://go.dev/ref/mod#go-mod-file-toolchain) to the `go.mod` file. What this all
-  means in practice for end users is that you may not be able to process your `go.mod` file with an older version
-  of Go (and hence older cachi2) as you could in the past for various reasons.
+  means in practice for end users is that you may not be able to process your `go.mod` file with an
+  older version of Go (and hence older cachi2) as you could in the past for various reasons.
+  Many projects bump their required Go toolchain's micro release as soon as it becomes available
+  upstream (i.e. not waiting for distributions to bundle them properly). This caused problems for
+  *cachi2-v0.5.0* because the container image's version simply may not have been high enough to
+  process a given project's `go.mod` file. Therefore, *cachi2-v0.6.0* implemented a mechanism to
+  always rely on the origin 0th release of a toolchain (e.g. 1.21.0) and use the `GOTOOLCHAIN=auto`
+  setting to instruct Go to fetch any toolchain as specified by the `go.mod` file automatically,
+  hence allowing us to keep up with frequent micro version bumps. **Note that such a language
+  version would still need to be officially marked as supported by cachi2, i.e. we'd not allow Go
+  to fetch e.g. a 1.22 toolchain if the maximum supported Go version by cachi2 were 1.21!**
 
 [readme-gomod]: ../README.md#gomod
 [usage-prefetch]: usage.md#pre-fetch-dependencies

--- a/tests/integration/test_data/gomod_1.18_e2e_test/.build-config.yaml
+++ b/tests/integration/test_data/gomod_1.18_e2e_test/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: path
-  name: GOCACHE
-  value: deps/gomod
-- kind: path
-  name: GOMODCACHE
-  value: deps/gomod/pkg/mod
-- kind: path
-  name: GOPATH
-  value: deps/gomod
-- kind: literal
-  name: GOTOOLCHAIN
+- name: GOCACHE
+  value: ${output_dir}/deps/gomod
+- name: GOMODCACHE
+  value: ${output_dir}/deps/gomod/pkg/mod
+- name: GOPATH
+  value: ${output_dir}/deps/gomod
+- name: GOTOOLCHAIN
   value: local
 project_files: []

--- a/tests/integration/test_data/gomod_1.18_e2e_test/.build-config.yaml
+++ b/tests/integration/test_data/gomod_1.18_e2e_test/.build-config.yaml
@@ -5,6 +5,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod/pkg/mod
 - name: GOPATH
   value: ${output_dir}/deps/gomod
-- name: GOTOOLCHAIN
-  value: local
+- name: GOPROXY
+  value: file://${GOMODCACHE}/cache/download
 project_files: []

--- a/tests/integration/test_data/gomod_1.20_e2e_dirty_go.mod/.build-config.yaml
+++ b/tests/integration/test_data/gomod_1.20_e2e_dirty_go.mod/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: path
-  name: GOCACHE
-  value: deps/gomod
-- kind: path
-  name: GOMODCACHE
-  value: deps/gomod/pkg/mod
-- kind: path
-  name: GOPATH
-  value: deps/gomod
-- kind: literal
-  name: GOTOOLCHAIN
+- name: GOCACHE
+  value: ${output_dir}/deps/gomod
+- name: GOMODCACHE
+  value: ${output_dir}/deps/gomod/pkg/mod
+- name: GOPATH
+  value: ${output_dir}/deps/gomod
+- name: GOTOOLCHAIN
   value: local
 project_files: []

--- a/tests/integration/test_data/gomod_1.20_e2e_dirty_go.mod/.build-config.yaml
+++ b/tests/integration/test_data/gomod_1.20_e2e_dirty_go.mod/.build-config.yaml
@@ -5,6 +5,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod/pkg/mod
 - name: GOPATH
   value: ${output_dir}/deps/gomod
-- name: GOTOOLCHAIN
-  value: local
+- name: GOPROXY
+  value: file://${GOMODCACHE}/cache/download
 project_files: []

--- a/tests/integration/test_data/gomod_1.21_e2e_test/.build-config.yaml
+++ b/tests/integration/test_data/gomod_1.21_e2e_test/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: path
-  name: GOCACHE
-  value: deps/gomod
-- kind: path
-  name: GOMODCACHE
-  value: deps/gomod/pkg/mod
-- kind: path
-  name: GOPATH
-  value: deps/gomod
-- kind: literal
-  name: GOTOOLCHAIN
+- name: GOCACHE
+  value: ${output_dir}/deps/gomod
+- name: GOMODCACHE
+  value: ${output_dir}/deps/gomod/pkg/mod
+- name: GOPATH
+  value: ${output_dir}/deps/gomod
+- name: GOTOOLCHAIN
   value: local
 project_files: []

--- a/tests/integration/test_data/gomod_1.21_e2e_test/.build-config.yaml
+++ b/tests/integration/test_data/gomod_1.21_e2e_test/.build-config.yaml
@@ -5,6 +5,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod/pkg/mod
 - name: GOPATH
   value: ${output_dir}/deps/gomod
-- name: GOTOOLCHAIN
-  value: local
+- name: GOPROXY
+  value: file://${GOMODCACHE}/cache/download
 project_files: []

--- a/tests/integration/test_data/gomod_1.21_e2e_test/fetch_deps_sha256sums.json
+++ b/tests/integration/test_data/gomod_1.21_e2e_test/fetch_deps_sha256sums.json
@@ -27,6 +27,9 @@
   "gomod/pkg/mod/cache/download/github.com/pkg/errors/@v/v0.8.1.mod": "sha256:df28c6a823f181d76179697177c0c5943c6ffb38f3c10b2dc53be360ee7d4589",
   "gomod/pkg/mod/cache/download/github.com/pkg/errors/@v/v0.8.1.zip": "sha256:4e47d021340b7396a7dee454f527552faf7360a9fc34038b1dc32ba3b5a951d8",
   "gomod/pkg/mod/cache/download/github.com/pkg/errors/@v/v0.8.1.ziphash": "sha256:6f634cf9dbf961d6ef58d3743a1842f5f3443cfe85ac7db1524534a0768d6546",
+  "gomod/pkg/mod/cache/download/golang.org/toolchain/@v/v0.0.1-go1.21.5.linux-amd64.lock": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+  "gomod/pkg/mod/cache/download/golang.org/toolchain/@v/v0.0.1-go1.21.5.linux-amd64.zip": "sha256:5cd486a4e225b4f2cf9960312b8ca44137985e29ef13ba2c65aa4a21a0b6b73c",
+  "gomod/pkg/mod/cache/download/golang.org/toolchain/@v/v0.0.1-go1.21.5.linux-amd64.ziphash": "sha256:45b13dd731b6190a1c8696377a44686c00c5453e2f26699f97e064bd69d85431",
   "gomod/pkg/mod/cache/download/golang.org/x/crypto/@v/list": "sha256:746cbb97253ccbf0130ec0e8785ef3bb3e97509efa192aa435a6d04514bbe0aa",
   "gomod/pkg/mod/cache/download/golang.org/x/crypto/@v/v0.0.0-20190308221718-c2843e01d9a2.mod": "sha256:33ed070a5a66e0960685ac5386440e1b59899e74d8a38a1180685e72a2195ded",
   "gomod/pkg/mod/cache/download/golang.org/x/net/@v/list": "sha256:64a333689fa548b5fd940cf46fbfcefb3e459539b7d361c0ff37c95c666cf356",
@@ -53,5 +56,6 @@
   "gomod/pkg/mod/cache/download/gopkg.in/yaml.v2/@v/v2.2.2.lock": "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
   "gomod/pkg/mod/cache/download/gopkg.in/yaml.v2/@v/v2.2.2.mod": "sha256:88d979d2f093d2397f756bc86efa2ca03f73a60d668ceb391b3510029f3f7cfc",
   "gomod/pkg/mod/cache/download/gopkg.in/yaml.v2/@v/v2.2.2.zip": "sha256:9e0e5492ee218d0b415a33648cdb32c2f544485ac4ebfa0589ebb53d1a841096",
-  "gomod/pkg/mod/cache/download/gopkg.in/yaml.v2/@v/v2.2.2.ziphash": "sha256:ab9eaf1e92ae8a7ad35fac796b73cd1d06feb3faeb0717271771149a800fb7ae"
+  "gomod/pkg/mod/cache/download/gopkg.in/yaml.v2/@v/v2.2.2.ziphash": "sha256:ab9eaf1e92ae8a7ad35fac796b73cd1d06feb3faeb0717271771149a800fb7ae",
+  "gomod/pkg/mod/cache/download/sumdb/sum.golang.org/lookup/golang.org/toolchain@v0.0.1-go1.21.5.linux-amd64": "unstable"
 }

--- a/tests/integration/test_data/gomod_e2e_multiple_modules/.build-config.yaml
+++ b/tests/integration/test_data/gomod_e2e_multiple_modules/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: path
-  name: GOCACHE
-  value: deps/gomod
-- kind: path
-  name: GOMODCACHE
-  value: deps/gomod/pkg/mod
-- kind: path
-  name: GOPATH
-  value: deps/gomod
-- kind: literal
-  name: GOTOOLCHAIN
+- name: GOCACHE
+  value: ${output_dir}/deps/gomod
+- name: GOMODCACHE
+  value: ${output_dir}/deps/gomod/pkg/mod
+- name: GOPATH
+  value: ${output_dir}/deps/gomod
+- name: GOTOOLCHAIN
   value: local
 project_files: []

--- a/tests/integration/test_data/gomod_e2e_multiple_modules/.build-config.yaml
+++ b/tests/integration/test_data/gomod_e2e_multiple_modules/.build-config.yaml
@@ -5,6 +5,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod/pkg/mod
 - name: GOPATH
   value: ${output_dir}/deps/gomod
-- name: GOTOOLCHAIN
-  value: local
+- name: GOPROXY
+  value: file://${GOMODCACHE}/cache/download
 project_files: []

--- a/tests/integration/test_data/gomod_go_generate_imported/.build-config.yaml
+++ b/tests/integration/test_data/gomod_go_generate_imported/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: path
-  name: GOCACHE
-  value: deps/gomod
-- kind: path
-  name: GOMODCACHE
-  value: deps/gomod/pkg/mod
-- kind: path
-  name: GOPATH
-  value: deps/gomod
-- kind: literal
-  name: GOTOOLCHAIN
+- name: GOCACHE
+  value: ${output_dir}/deps/gomod
+- name: GOMODCACHE
+  value: ${output_dir}/deps/gomod/pkg/mod
+- name: GOPATH
+  value: ${output_dir}/deps/gomod
+- name: GOTOOLCHAIN
   value: local
 project_files: []

--- a/tests/integration/test_data/gomod_go_generate_imported/.build-config.yaml
+++ b/tests/integration/test_data/gomod_go_generate_imported/.build-config.yaml
@@ -5,6 +5,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod/pkg/mod
 - name: GOPATH
   value: ${output_dir}/deps/gomod
-- name: GOTOOLCHAIN
-  value: local
+- name: GOPROXY
+  value: file://${GOMODCACHE}/cache/download
 project_files: []

--- a/tests/integration/test_data/gomod_local_deps/.build-config.yaml
+++ b/tests/integration/test_data/gomod_local_deps/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: path
-  name: GOCACHE
-  value: deps/gomod
-- kind: path
-  name: GOMODCACHE
-  value: deps/gomod/pkg/mod
-- kind: path
-  name: GOPATH
-  value: deps/gomod
-- kind: literal
-  name: GOTOOLCHAIN
+- name: GOCACHE
+  value: ${output_dir}/deps/gomod
+- name: GOMODCACHE
+  value: ${output_dir}/deps/gomod/pkg/mod
+- name: GOPATH
+  value: ${output_dir}/deps/gomod
+- name: GOTOOLCHAIN
   value: local
 project_files: []

--- a/tests/integration/test_data/gomod_local_deps/.build-config.yaml
+++ b/tests/integration/test_data/gomod_local_deps/.build-config.yaml
@@ -5,6 +5,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod/pkg/mod
 - name: GOPATH
   value: ${output_dir}/deps/gomod
-- name: GOTOOLCHAIN
-  value: local
+- name: GOPROXY
+  value: file://${GOMODCACHE}/cache/download
 project_files: []

--- a/tests/integration/test_data/gomod_multiple_modules_missing_checksums/.build-config.yaml
+++ b/tests/integration/test_data/gomod_multiple_modules_missing_checksums/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: path
-  name: GOCACHE
-  value: deps/gomod
-- kind: path
-  name: GOMODCACHE
-  value: deps/gomod/pkg/mod
-- kind: path
-  name: GOPATH
-  value: deps/gomod
-- kind: literal
-  name: GOTOOLCHAIN
+- name: GOCACHE
+  value: ${output_dir}/deps/gomod
+- name: GOMODCACHE
+  value: ${output_dir}/deps/gomod/pkg/mod
+- name: GOPATH
+  value: ${output_dir}/deps/gomod
+- name: GOTOOLCHAIN
   value: local
 project_files: []

--- a/tests/integration/test_data/gomod_multiple_modules_missing_checksums/.build-config.yaml
+++ b/tests/integration/test_data/gomod_multiple_modules_missing_checksums/.build-config.yaml
@@ -5,6 +5,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod/pkg/mod
 - name: GOPATH
   value: ${output_dir}/deps/gomod
-- name: GOTOOLCHAIN
-  value: local
+- name: GOPROXY
+  value: file://${GOMODCACHE}/cache/download
 project_files: []

--- a/tests/integration/test_data/gomod_vendor_check_correct_vendor/.build-config.yaml
+++ b/tests/integration/test_data/gomod_vendor_check_correct_vendor/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: path
-  name: GOCACHE
-  value: deps/gomod
-- kind: path
-  name: GOMODCACHE
-  value: deps/gomod/pkg/mod
-- kind: path
-  name: GOPATH
-  value: deps/gomod
-- kind: literal
-  name: GOTOOLCHAIN
+- name: GOCACHE
+  value: ${output_dir}/deps/gomod
+- name: GOMODCACHE
+  value: ${output_dir}/deps/gomod/pkg/mod
+- name: GOPATH
+  value: ${output_dir}/deps/gomod
+- name: GOTOOLCHAIN
   value: local
 project_files: []

--- a/tests/integration/test_data/gomod_vendor_check_correct_vendor/.build-config.yaml
+++ b/tests/integration/test_data/gomod_vendor_check_correct_vendor/.build-config.yaml
@@ -5,6 +5,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod/pkg/mod
 - name: GOPATH
   value: ${output_dir}/deps/gomod
-- name: GOTOOLCHAIN
-  value: local
+- name: GOPROXY
+  value: file://${GOMODCACHE}/cache/download
 project_files: []

--- a/tests/integration/test_data/gomod_vendor_check_no_vendor/.build-config.yaml
+++ b/tests/integration/test_data/gomod_vendor_check_no_vendor/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: path
-  name: GOCACHE
-  value: deps/gomod
-- kind: path
-  name: GOMODCACHE
-  value: deps/gomod/pkg/mod
-- kind: path
-  name: GOPATH
-  value: deps/gomod
-- kind: literal
-  name: GOTOOLCHAIN
+- name: GOCACHE
+  value: ${output_dir}/deps/gomod
+- name: GOMODCACHE
+  value: ${output_dir}/deps/gomod/pkg/mod
+- name: GOPATH
+  value: ${output_dir}/deps/gomod
+- name: GOTOOLCHAIN
   value: local
 project_files: []

--- a/tests/integration/test_data/gomod_vendor_check_no_vendor/.build-config.yaml
+++ b/tests/integration/test_data/gomod_vendor_check_no_vendor/.build-config.yaml
@@ -5,6 +5,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod/pkg/mod
 - name: GOPATH
   value: ${output_dir}/deps/gomod
-- name: GOTOOLCHAIN
-  value: local
+- name: GOPROXY
+  value: file://${GOMODCACHE}/cache/download
 project_files: []

--- a/tests/integration/test_data/gomod_vendored_with_flag/.build-config.yaml
+++ b/tests/integration/test_data/gomod_vendored_with_flag/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: path
-  name: GOCACHE
-  value: deps/gomod
-- kind: path
-  name: GOMODCACHE
-  value: deps/gomod/pkg/mod
-- kind: path
-  name: GOPATH
-  value: deps/gomod
-- kind: literal
-  name: GOTOOLCHAIN
+- name: GOCACHE
+  value: ${output_dir}/deps/gomod
+- name: GOMODCACHE
+  value: ${output_dir}/deps/gomod/pkg/mod
+- name: GOPATH
+  value: ${output_dir}/deps/gomod
+- name: GOTOOLCHAIN
   value: local
 project_files: []

--- a/tests/integration/test_data/gomod_vendored_with_flag/.build-config.yaml
+++ b/tests/integration/test_data/gomod_vendored_with_flag/.build-config.yaml
@@ -5,6 +5,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod/pkg/mod
 - name: GOPATH
   value: ${output_dir}/deps/gomod
-- name: GOTOOLCHAIN
-  value: local
+- name: GOPROXY
+  value: file://${GOMODCACHE}/cache/download
 project_files: []

--- a/tests/integration/test_data/gomod_with_deps/.build-config.yaml
+++ b/tests/integration/test_data/gomod_with_deps/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: path
-  name: GOCACHE
-  value: deps/gomod
-- kind: path
-  name: GOMODCACHE
-  value: deps/gomod/pkg/mod
-- kind: path
-  name: GOPATH
-  value: deps/gomod
-- kind: literal
-  name: GOTOOLCHAIN
+- name: GOCACHE
+  value: ${output_dir}/deps/gomod
+- name: GOMODCACHE
+  value: ${output_dir}/deps/gomod/pkg/mod
+- name: GOPATH
+  value: ${output_dir}/deps/gomod
+- name: GOTOOLCHAIN
   value: local
 project_files: []

--- a/tests/integration/test_data/gomod_with_deps/.build-config.yaml
+++ b/tests/integration/test_data/gomod_with_deps/.build-config.yaml
@@ -5,6 +5,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod/pkg/mod
 - name: GOPATH
   value: ${output_dir}/deps/gomod
-- name: GOTOOLCHAIN
-  value: local
+- name: GOPROXY
+  value: file://${GOMODCACHE}/cache/download
 project_files: []

--- a/tests/integration/test_data/gomod_without_deps/.build-config.yaml
+++ b/tests/integration/test_data/gomod_without_deps/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: path
-  name: GOCACHE
-  value: deps/gomod
-- kind: path
-  name: GOMODCACHE
-  value: deps/gomod/pkg/mod
-- kind: path
-  name: GOPATH
-  value: deps/gomod
-- kind: literal
-  name: GOTOOLCHAIN
+- name: GOCACHE
+  value: ${output_dir}/deps/gomod
+- name: GOMODCACHE
+  value: ${output_dir}/deps/gomod/pkg/mod
+- name: GOPATH
+  value: ${output_dir}/deps/gomod
+- name: GOTOOLCHAIN
   value: local
 project_files: []

--- a/tests/integration/test_data/gomod_without_deps/.build-config.yaml
+++ b/tests/integration/test_data/gomod_without_deps/.build-config.yaml
@@ -5,6 +5,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod/pkg/mod
 - name: GOPATH
   value: ${output_dir}/deps/gomod
-- name: GOTOOLCHAIN
-  value: local
+- name: GOPROXY
+  value: file://${GOMODCACHE}/cache/download
 project_files: []

--- a/tests/integration/test_data/pip_e2e_test/.build-config.yaml
+++ b/tests/integration/test_data/pip_e2e_test/.build-config.yaml
@@ -1,9 +1,7 @@
 environment_variables:
-- kind: path
-  name: PIP_FIND_LINKS
-  value: deps/pip
-- kind: literal
-  name: PIP_NO_INDEX
+- name: PIP_FIND_LINKS
+  value: ${output_dir}/deps/pip
+- name: PIP_NO_INDEX
   value: 'true'
 project_files:
 - abspath: ${test_case_tmpdir}/pip_e2e_test-source/requirements.txt

--- a/tests/integration/test_data/pip_multiple/.build-config.yaml
+++ b/tests/integration/test_data/pip_multiple/.build-config.yaml
@@ -1,9 +1,7 @@
 environment_variables:
-- kind: path
-  name: PIP_FIND_LINKS
-  value: deps/pip
-- kind: literal
-  name: PIP_NO_INDEX
+- name: PIP_FIND_LINKS
+  value: ${output_dir}/deps/pip
+- name: PIP_NO_INDEX
   value: 'true'
 project_files:
 - abspath: ${test_case_tmpdir}/pip_multiple-source/first_pkg/requirements.txt

--- a/tests/integration/test_data/pip_with_deps/.build-config.yaml
+++ b/tests/integration/test_data/pip_with_deps/.build-config.yaml
@@ -1,9 +1,7 @@
 environment_variables:
-- kind: path
-  name: PIP_FIND_LINKS
-  value: deps/pip
-- kind: literal
-  name: PIP_NO_INDEX
+- name: PIP_FIND_LINKS
+  value: ${output_dir}/deps/pip
+- name: PIP_NO_INDEX
   value: 'true'
 project_files:
 - abspath: ${test_case_tmpdir}/pip_with_deps-source/requirements.txt

--- a/tests/integration/test_data/pip_without_deps/.build-config.yaml
+++ b/tests/integration/test_data/pip_without_deps/.build-config.yaml
@@ -1,8 +1,6 @@
 environment_variables:
-- kind: path
-  name: PIP_FIND_LINKS
-  value: deps/pip
-- kind: literal
-  name: PIP_NO_INDEX
+- name: PIP_FIND_LINKS
+  value: ${output_dir}/deps/pip
+- name: PIP_NO_INDEX
   value: 'true'
 project_files: []

--- a/tests/integration/test_data/pip_without_metadata/.build-config.yaml
+++ b/tests/integration/test_data/pip_without_metadata/.build-config.yaml
@@ -1,8 +1,6 @@
 environment_variables:
-- kind: path
-  name: PIP_FIND_LINKS
-  value: deps/pip
-- kind: literal
-  name: PIP_NO_INDEX
+- name: PIP_FIND_LINKS
+  value: ${output_dir}/deps/pip
+- name: PIP_NO_INDEX
   value: 'true'
 project_files: []

--- a/tests/integration/test_data/yarn_correct_version_installed_by_corepack/.build-config.yaml
+++ b/tests/integration/test_data/yarn_correct_version_installed_by_corepack/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: literal
-  name: YARN_ENABLE_GLOBAL_CACHE
+- name: YARN_ENABLE_GLOBAL_CACHE
   value: 'false'
-- kind: literal
-  name: YARN_ENABLE_IMMUTABLE_CACHE
+- name: YARN_ENABLE_IMMUTABLE_CACHE
   value: 'false'
-- kind: literal
-  name: YARN_ENABLE_MIRROR
+- name: YARN_ENABLE_MIRROR
   value: 'true'
-- kind: path
-  name: YARN_GLOBAL_FOLDER
-  value: deps/yarn
+- name: YARN_GLOBAL_FOLDER
+  value: ${output_dir}/deps/yarn
 project_files: []

--- a/tests/integration/test_data/yarn_e2e_test/.build-config.yaml
+++ b/tests/integration/test_data/yarn_e2e_test/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: literal
-  name: YARN_ENABLE_GLOBAL_CACHE
+- name: YARN_ENABLE_GLOBAL_CACHE
   value: 'false'
-- kind: literal
-  name: YARN_ENABLE_IMMUTABLE_CACHE
+- name: YARN_ENABLE_IMMUTABLE_CACHE
   value: 'false'
-- kind: literal
-  name: YARN_ENABLE_MIRROR
+- name: YARN_ENABLE_MIRROR
   value: 'true'
-- kind: path
-  name: YARN_GLOBAL_FOLDER
-  value: deps/yarn
+- name: YARN_GLOBAL_FOLDER
+  value: ${output_dir}/deps/yarn
 project_files: []

--- a/tests/integration/test_data/yarn_e2e_test_multiple_packages/.build-config.yaml
+++ b/tests/integration/test_data/yarn_e2e_test_multiple_packages/.build-config.yaml
@@ -1,14 +1,10 @@
 environment_variables:
-- kind: literal
-  name: YARN_ENABLE_GLOBAL_CACHE
+- name: YARN_ENABLE_GLOBAL_CACHE
   value: 'false'
-- kind: literal
-  name: YARN_ENABLE_IMMUTABLE_CACHE
+- name: YARN_ENABLE_IMMUTABLE_CACHE
   value: 'false'
-- kind: literal
-  name: YARN_ENABLE_MIRROR
+- name: YARN_ENABLE_MIRROR
   value: 'true'
-- kind: path
-  name: YARN_GLOBAL_FOLDER
-  value: deps/yarn
+- name: YARN_GLOBAL_FOLDER
+  value: ${output_dir}/deps/yarn
 project_files: []

--- a/tests/unit/models/test_output.py
+++ b/tests/unit/models/test_output.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from textwrap import dedent
-from typing import Any
+from typing import Any, Dict
 
 import pydantic
 import pytest
@@ -36,14 +36,14 @@ class TestBuildConfig:
     def test_conflicting_env_vars(self) -> None:
         expect_error = (
             "conflict by GOSUMDB: "
-            "name='GOSUMDB' value='on' kind='literal' "
-            "X name='GOSUMDB' value='sum.golang.org' kind='literal'"
+            "name='GOSUMDB' value='on' kind=None "
+            "X name='GOSUMDB' value='sum.golang.org' kind=None"
         )
         with pytest.raises(pydantic.ValidationError, match=expect_error):
             BuildConfig(
                 environment_variables=[
-                    {"name": "GOSUMDB", "value": "on", "kind": "literal"},
-                    {"name": "GOSUMDB", "value": "sum.golang.org", "kind": "literal"},
+                    {"name": "GOSUMDB", "value": "on"},
+                    {"name": "GOSUMDB", "value": "sum.golang.org"},
                 ],
                 project_files=[],
             )
@@ -51,15 +51,15 @@ class TestBuildConfig:
     def test_sort_and_dedupe_env_vars(self) -> None:
         build_config = BuildConfig(
             environment_variables=[
-                {"name": "B", "value": "y", "kind": "literal"},
-                {"name": "A", "value": "x", "kind": "literal"},
-                {"name": "B", "value": "y", "kind": "literal"},
+                {"name": "B", "value": "y"},
+                {"name": "A", "value": "x"},
+                {"name": "B", "value": "y"},
             ],
             project_files=[],
         )
         assert build_config.environment_variables == [
-            EnvironmentVariable(name="A", value="x", kind="literal"),
-            EnvironmentVariable(name="B", value="y", kind="literal"),
+            EnvironmentVariable(name="A", value="x"),
+            EnvironmentVariable(name="B", value="y"),
         ]
 
     def test_conflicting_project_files(self) -> None:
@@ -102,15 +102,13 @@ class TestRequestOutput:
             (
                 {
                     "components": [{"name": "mypkg", "purl": "pkg:generic/mypkg"}],
-                    "environment_variables": [{"name": "a", "value": "y", "kind": "literal"}],
+                    "environment_variables": [{"name": "a", "value": "y"}],
                     "project_files": [{"abspath": "/first/path", "template": "foo"}],
                 },
                 RequestOutput(
                     components=[{"name": "mypkg", "purl": "pkg:generic/mypkg"}],
                     build_config=BuildConfig(
-                        environment_variables=[
-                            EnvironmentVariable(name="a", value="y", kind="literal")
-                        ],
+                        environment_variables=[EnvironmentVariable(name="a", value="y")],
                         project_files=[ProjectFile(abspath="/first/path", template="foo")],
                     ),
                 ),
@@ -122,3 +120,56 @@ class TestRequestOutput:
     ) -> None:
         request_output = RequestOutput.from_obj_list(**input_data)
         assert request_output == expected_data
+
+
+ENVVAR_TEMPLATE_MAPPINGS = {
+    "LEGACY_LITERAL": "foobar",
+    "LEGACY_PATH": "relative/path",
+    "SIMPLE": "${deadbeef}",
+    "NESTED": "monty_${FOO}",
+    "FOO": "python_${BAR}_${BAZ}",
+    "BAR": "and",
+    "BAZ": "the_holy_grail",
+}
+
+
+class TestEnvironmentVariable:
+    @pytest.fixture(scope="class")
+    def env_variables(self) -> Dict[str, EnvironmentVariable]:
+        ret = {k: EnvironmentVariable(name=k, value=v) for k, v in ENVVAR_TEMPLATE_MAPPINGS.items()}
+
+        # need to inject 'kind' for legacy variable templates
+        ret["LEGACY_LITERAL"].kind = "literal"
+        ret["LEGACY_PATH"].kind = "path"
+        return ret
+
+    @pytest.mark.parametrize(
+        "var, expected, mappings",
+        [
+            pytest.param(
+                "LEGACY_LITERAL",
+                "foobar",
+                {"output_dir": "/absolute/path"},
+                id="compatibility_test_legacy_literal",
+            ),
+            pytest.param(
+                "LEGACY_PATH",
+                "/absolute/path/relative/path",
+                {"output_dir": "/absolute/path"},
+                id="compatibility_test_legacy_path",
+            ),
+            pytest.param(
+                "SIMPLE", "badf00d", {"deadbeef": "badf00d"}, id="simple_template_variable"
+            ),
+        ],
+    )
+    def test_resolution(
+        self,
+        env_variables: Dict[str, EnvironmentVariable],
+        var: str,
+        expected: str,
+        mappings: Dict[str, str],
+    ) -> None:
+
+        assert env_variables[var].resolve_value(mappings) == expected
+        assert "kind" not in env_variables[var].model_dump()

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1587,7 +1587,7 @@ def test_fetch_tags_fail(repo_remote_with_tag: tuple[RootedPath, RootedPath]) ->
 def test_get_gomod_version(
     rooted_tmp_path: RootedPath, go_mod_file: Path, go_mod_version: str
 ) -> None:
-    assert _get_gomod_version(rooted_tmp_path) == go_mod_version
+    assert _get_gomod_version(rooted_tmp_path.join_within_root("go.mod")) == go_mod_version
 
 
 @pytest.mark.parametrize(
@@ -1596,7 +1596,7 @@ def test_get_gomod_version(
     indirect=True,
 )
 def test_get_gomod_version_fail(rooted_tmp_path: RootedPath, go_mod_file: Path) -> None:
-    assert _get_gomod_version(rooted_tmp_path) is None
+    assert _get_gomod_version(rooted_tmp_path.join_within_root("go.mod")) is None
 
 
 class TestGo:

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -14,7 +14,7 @@ import pytest
 
 from cachi2.core.errors import FetchError, PackageManagerError, PackageRejected, UnexpectedFormat
 from cachi2.core.models.input import Flag, Request
-from cachi2.core.models.output import BuildConfig, RequestOutput
+from cachi2.core.models.output import BuildConfig, EnvironmentVariable, RequestOutput
 from cachi2.core.models.sbom import Component, Property
 from cachi2.core.package_managers import gomod
 from cachi2.core.package_managers.gomod import (
@@ -54,12 +54,12 @@ def setup_module() -> None:
 
 
 @pytest.fixture(scope="module")
-def env_variables() -> list[dict[str, str]]:
+def env_variables() -> list[EnvironmentVariable]:
     return [
-        {"name": "GOCACHE", "value": "deps/gomod", "kind": "path"},
-        {"name": "GOMODCACHE", "value": "deps/gomod/pkg/mod", "kind": "path"},
-        {"name": "GOPATH", "value": "deps/gomod", "kind": "path"},
-        {"name": "GOTOOLCHAIN", "value": "local", "kind": "literal"},
+        EnvironmentVariable(name="GOCACHE", value="deps/gomod", kind="path"),
+        EnvironmentVariable(name="GOMODCACHE", value="deps/gomod/pkg/mod", kind="path"),
+        EnvironmentVariable(name="GOPATH", value="deps/gomod", kind="path"),
+        EnvironmentVariable(name="GOTOOLCHAIN", value="local", kind="literal"),
     ]
 
 

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -56,10 +56,10 @@ def setup_module() -> None:
 @pytest.fixture(scope="module")
 def env_variables() -> list[EnvironmentVariable]:
     return [
-        EnvironmentVariable(name="GOCACHE", value="deps/gomod", kind="path"),
-        EnvironmentVariable(name="GOMODCACHE", value="deps/gomod/pkg/mod", kind="path"),
-        EnvironmentVariable(name="GOPATH", value="deps/gomod", kind="path"),
-        EnvironmentVariable(name="GOTOOLCHAIN", value="local", kind="literal"),
+        EnvironmentVariable(name="GOCACHE", value="${output_dir}/deps/gomod"),
+        EnvironmentVariable(name="GOMODCACHE", value="${output_dir}/deps/gomod/pkg/mod"),
+        EnvironmentVariable(name="GOPATH", value="${output_dir}/deps/gomod"),
+        EnvironmentVariable(name="GOTOOLCHAIN", value="local"),
     ]
 
 

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -49,10 +49,10 @@ def yarn_request(tmp_path: Path, yarn_input_packages: list[dict[str, str]]) -> R
 @pytest.fixture(scope="module")
 def yarn_env_variables() -> list[EnvironmentVariable]:
     return [
-        EnvironmentVariable(name="YARN_ENABLE_GLOBAL_CACHE", value="false", kind="literal"),
-        EnvironmentVariable(name="YARN_ENABLE_IMMUTABLE_CACHE", value="false", kind="literal"),
-        EnvironmentVariable(name="YARN_ENABLE_MIRROR", value="true", kind="literal"),
-        EnvironmentVariable(name="YARN_GLOBAL_FOLDER", value="deps/yarn", kind="path"),
+        EnvironmentVariable(name="YARN_ENABLE_GLOBAL_CACHE", value="false"),
+        EnvironmentVariable(name="YARN_ENABLE_IMMUTABLE_CACHE", value="false"),
+        EnvironmentVariable(name="YARN_ENABLE_MIRROR", value="true"),
+        EnvironmentVariable(name="YARN_GLOBAL_FOLDER", value="${output_dir}/deps/yarn"),
     ]
 
 

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -46,7 +46,7 @@ def yarn_request(tmp_path: Path, yarn_input_packages: list[dict[str, str]]) -> R
     )
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def yarn_env_variables() -> list[EnvironmentVariable]:
     return [
         EnvironmentVariable(name="YARN_ENABLE_GLOBAL_CACHE", value="false", kind="literal"),

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -115,7 +115,7 @@ class TestTopLevelOpts:
                 )
             ],
             environment_variables=[
-                EnvironmentVariable(name="GOMOD_SOMETHING", value="yes", kind="literal"),
+                EnvironmentVariable(name="GOMOD_SOMETHING", value="yes"),
             ],
             project_files=[],
         )
@@ -589,7 +589,7 @@ class TestFetchDeps:
                     )
                 ],
                 environment_variables=[
-                    EnvironmentVariable(name="GOMOD_SOMETHING", value="yes", kind="literal"),
+                    EnvironmentVariable(name="GOMOD_SOMETHING", value="yes"),
                 ],
                 project_files=[],
             ),
@@ -643,8 +643,8 @@ def env_file_as_env(for_output_dir: Path) -> str:
 
 class TestGenerateEnv:
     ENV_VARS = [
-        {"name": "GOCACHE", "value": "deps/gomod", "kind": "path"},
-        {"name": "GOSUMDB", "value": "sum.golang.org", "kind": "literal"},
+        {"name": "GOCACHE", "value": "${output_dir}/deps/gomod"},
+        {"name": "GOSUMDB", "value": "sum.golang.org"},
     ]
 
     @pytest.fixture


### PR DESCRIPTION
# Maintainers will complete the following section

This PR enables full Go 1.21 support by the means of instructing Go to download the desired toolchain via`GOTOOLCHAIN=auto`. This is limited to 1.21 only, so 1.22 will be explicitly refused (1.22 will be added by a standalone PR).

Notes:
- first 3 patches are some generic tiny fixes
- `EnvironmentVariable` was adjusted to act as a more generic resolvable template (e.g. to allow `GOPROXY=file://${GOMODCACHE}/foo`)
- Go 1.21 full support is enabled using `GOTOOLCHAIN` and `GOPROXY`

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
