### PR TITLE
Support for prefetching RPMs [PoC]

### DIFF
--- a/cachi2/core/models/input.py
+++ b/cachi2/core/models/input.py
@@ -47,7 +47,7 @@ def _present_user_input_error(validation_error: pydantic.ValidationError) -> str
 
 
 # Supported package managers
-PackageManagerType = Literal["gomod", "npm", "pip", "yarn"]
+PackageManagerType = Literal["gomod", "npm", "pip", "rpm", "yarn"]
 
 Flag = Literal[
     "cgo-disable", "dev-package-managers", "force-gomod-tidy", "gomod-vendor", "gomod-vendor-check"
@@ -100,6 +100,12 @@ class PipPackageInput(_PackageInputBase):
         return paths
 
 
+class RpmPackageInput(_PackageInputBase):
+    """Accepted input for a rpm package."""
+
+    type: Literal["rpm"]
+
+
 class YarnPackageInput(_PackageInputBase):
     """Accepted input for a yarn package."""
 
@@ -107,7 +113,7 @@ class YarnPackageInput(_PackageInputBase):
 
 
 PackageInput = Annotated[
-    Union[GomodPackageInput, NpmPackageInput, PipPackageInput, YarnPackageInput],
+    Union[GomodPackageInput, NpmPackageInput, PipPackageInput, RpmPackageInput, YarnPackageInput],
     # https://pydantic-docs.helpmanual.io/usage/types/#discriminated-unions-aka-tagged-unions
     pydantic.Field(discriminator="type"),
 ]
@@ -167,6 +173,11 @@ class Request(pydantic.BaseModel):
     def pip_packages(self) -> list[PipPackageInput]:
         """Get the pip packages specified for this request."""
         return self._packages_by_type(PipPackageInput)
+
+    @property
+    def rpm_packages(self) -> list[RpmPackageInput]:
+        """Get the rpm packages specified for this request."""
+        return self._packages_by_type(RpmPackageInput)
 
     @property
     def yarn_packages(self) -> list[YarnPackageInput]:

--- a/cachi2/core/package_managers/rpm/__init__.py
+++ b/cachi2/core/package_managers/rpm/__init__.py
@@ -1,0 +1,3 @@
+from cachi2.core.package_managers.rpm.main import fetch_rpm_source
+
+__all__ = ["fetch_rpm_source"]

--- a/cachi2/core/package_managers/rpm/__init__.py
+++ b/cachi2/core/package_managers/rpm/__init__.py
@@ -1,3 +1,3 @@
-from cachi2.core.package_managers.rpm.main import fetch_rpm_source
+from cachi2.core.package_managers.rpm.main import fetch_rpm_source, inject_files_post
 
-__all__ = ["fetch_rpm_source"]
+__all__ = ["fetch_rpm_source", "inject_files_post"]

--- a/cachi2/core/package_managers/rpm/main.py
+++ b/cachi2/core/package_managers/rpm/main.py
@@ -1,20 +1,80 @@
 import logging
 
+import yaml
+from pydantic import ValidationError
+
+from cachi2.core.errors import PackageManagerError, PackageRejected
 from cachi2.core.models.input import Request
 from cachi2.core.models.output import RequestOutput
 from cachi2.core.models.sbom import Component
+from cachi2.core.package_managers.rpm.redhat import RedhatRpmsLock
+from cachi2.core.rooted_path import RootedPath
 
 log = logging.getLogger(__name__)
+
+
+DEFAULT_LOCKFILE_NAME = "rpms.lock.yaml"
+DEFAULT_PACKAGE_DIR = "deps/rpm"
+
+# during the computing of file checksum read chunk of size 1 MB
+READ_CHUNK = 1048576
 
 
 def fetch_rpm_source(request: Request) -> RequestOutput:
     """Process all the rpm source directories in a request."""
     components: list[Component] = []
     for package in request.rpm_packages:
-        _ = request.source_dir.join_within_root(package.path)
+        path = request.source_dir.join_within_root(package.path)
+        components.extend(_resolve_rpm_project(path, request.output_dir))
 
     return RequestOutput.from_obj_list(
         components=components,
         environment_variables=[],
         project_files=[],
     )
+
+
+def _resolve_rpm_project(source_dir: RootedPath, output_dir: RootedPath) -> list[Component]:
+    """
+    Process a request for a single RPM source directory.
+
+    Process the input lockfile, fetch packages and generate SBOM.
+    """
+    # Check the availability of the input lockfile.
+    if not source_dir.join_within_root(DEFAULT_LOCKFILE_NAME).path.exists():
+        raise PackageRejected(
+            f"RPM lockfile '{DEFAULT_LOCKFILE_NAME}' missing, refusing to continue.",
+            solution=(
+                "Make sure your repository has RPM lockfile '{DEFAULT_LOCKFILE_NAME}' checked in "
+                "to the repository."
+            ),
+        )
+
+    lockfile_name = source_dir.join_within_root(DEFAULT_LOCKFILE_NAME)
+    log.info(f"Reading RPM lockfile: {lockfile_name}")
+    with open(lockfile_name) as f:
+        try:
+            yaml_content = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            log.error(str(e))
+            raise PackageRejected(
+                f"RPM lockfile '{DEFAULT_LOCKFILE_NAME}' yaml format is not correct.",
+                solution=("Check correct 'yaml' syntax in the lockfile."),
+            )
+
+        log.debug("Validating lockfile.")
+        try:
+            _ = RedhatRpmsLock.model_validate(yaml_content)
+        except ValidationError as e:
+            loc = e.errors()[0]["loc"]
+            msg = e.errors()[0]["msg"]
+            raise PackageManagerError(
+                f"RPM lockfile '{DEFAULT_LOCKFILE_NAME}' format is not valid: '{loc}: {msg}'",
+                solution=(
+                    "Check the correct format and whether any keys are missing in the lockfile."
+                ),
+            )
+
+        _ = output_dir.join_within_root(DEFAULT_PACKAGE_DIR)
+        components: list[Component] = []
+        return components

--- a/cachi2/core/package_managers/rpm/main.py
+++ b/cachi2/core/package_managers/rpm/main.py
@@ -1,0 +1,20 @@
+import logging
+
+from cachi2.core.models.input import Request
+from cachi2.core.models.output import RequestOutput
+from cachi2.core.models.sbom import Component
+
+log = logging.getLogger(__name__)
+
+
+def fetch_rpm_source(request: Request) -> RequestOutput:
+    """Process all the rpm source directories in a request."""
+    components: list[Component] = []
+    for package in request.rpm_packages:
+        _ = request.source_dir.join_within_root(package.path)
+
+    return RequestOutput.from_obj_list(
+        components=components,
+        environment_variables=[],
+        project_files=[],
+    )

--- a/cachi2/core/package_managers/rpm/redhat.py
+++ b/cachi2/core/package_managers/rpm/redhat.py
@@ -1,0 +1,79 @@
+import logging
+import uuid
+from functools import cached_property
+from typing import Optional
+
+from pydantic import BaseModel, PositiveInt, field_validator, model_validator
+
+log = logging.getLogger(__name__)
+
+
+class Package(BaseModel):
+    """Package item; represents RPM or SRPM file."""
+
+    repoid: Optional[str] = None
+    url: str
+    checksum: Optional[str] = None
+    size: Optional[int] = None
+
+
+class Arch(BaseModel):
+    """Architecture structure."""
+
+    arch: str
+    packages: list[Package] = []
+    source: list[Package] = []
+
+    @model_validator(mode="after")
+    def _arch_empty(self) -> "Arch":
+        """Validate arch."""
+        if self.packages == [] and self.source == []:
+            raise ValueError("At least one field ('packages', 'source') must be set in every arch.")
+        return self
+
+
+class RedhatRpmsLock(BaseModel):
+    """
+    The class implements basic operations with specific lockfile format.
+
+    Input data comes from raw yaml stored as a dictionary.
+    """
+
+    # Top of the structure of the lockfile. Model is used for parsing the lockfile.
+    lockfileVersion: PositiveInt
+    lockfileVendor: str
+    arches: list[Arch]
+
+    @cached_property
+    def _uuid(self) -> str:
+        """
+        Generate short random string for internal repoid.
+
+        'repoid' key is not mandatory in the lockfile format. When not present,
+        fallback is set as (partly) random string containing _uuid.
+        """
+        return uuid.uuid4().hex[:6]
+
+    @property
+    def internal_repoid(self) -> str:
+        """Internal_repoid getter."""
+        return f"cachi2-{self._uuid}"
+
+    @property
+    def internal_source_repoid(self) -> str:
+        """Internal_source_repoid getter."""
+        return f"cachi2-{self._uuid}-source"
+
+    @field_validator("lockfileVersion")
+    def _version_redhat(cls, version: PositiveInt) -> PositiveInt:
+        """Evaluate whether the lockfile header matches the format specification."""
+        if version != 1:
+            raise ValueError(f"Unexpected value for 'lockfileVersion': '{version}'.")
+        return version
+
+    @field_validator("lockfileVendor")
+    def _vendor_redhat(cls, vendor: str) -> str:
+        """Evaluate whether the lockfile header matches the format specification."""
+        if vendor != "redhat":
+            raise ValueError(f"Unexpected value for 'lockfileVendor': '{vendor}'.")
+        return vendor

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -1,7 +1,7 @@
 from collections.abc import Iterable
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Callable
+from typing import Any, Callable
 
 from cachi2.core.errors import UnsupportedFeature
 from cachi2.core.models.input import PackageManagerType, Request
@@ -84,3 +84,11 @@ def _merge_outputs(outputs: Iterable[RequestOutput]) -> RequestOutput:
         environment_variables=env_vars,
         project_files=project_files,
     )
+
+
+def inject_files_post(*args: Any, **kwargs: Any) -> None:
+    """Do extra steps for package manager."""
+    # if there is a callback method defined within the particular package manager, run it
+    if hasattr(rpm, "inject_files_post"):
+        callback_method = getattr(rpm, "inject_files_post")
+        callback_method(*args, **kwargs)

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -6,7 +6,7 @@ from typing import Callable
 from cachi2.core.errors import UnsupportedFeature
 from cachi2.core.models.input import PackageManagerType, Request
 from cachi2.core.models.output import RequestOutput
-from cachi2.core.package_managers import gomod, npm, pip, yarn
+from cachi2.core.package_managers import gomod, npm, pip, rpm, yarn
 from cachi2.core.rooted_path import RootedPath
 from cachi2.core.utils import copy_directory
 
@@ -21,7 +21,9 @@ _package_managers: dict[PackageManagerType, Handler] = {
 
 # This is where we put package managers currently under development in order to
 # invoke them via CLI
-_dev_package_managers: dict[PackageManagerType, Handler] = {}
+_dev_package_managers: dict[PackageManagerType, Handler] = {
+    "rpm": rpm.fetch_rpm_source,
+}
 
 # This is *only* used to provide a list for `cachi2 --version`
 supported_package_managers = list(_package_managers)

--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -15,7 +15,7 @@ from cachi2.core.errors import Cachi2Error, InvalidInput
 from cachi2.core.extras.envfile import EnvFormat, generate_envfile
 from cachi2.core.models.input import Flag, PackageInput, Request, parse_user_input
 from cachi2.core.models.output import BuildConfig
-from cachi2.core.resolver import resolve_packages, supported_package_managers
+from cachi2.core.resolver import inject_files_post, resolve_packages, supported_package_managers
 from cachi2.core.rooted_path import RootedPath
 from cachi2.interface.logging import LogLevel, setup_logging
 
@@ -338,6 +338,8 @@ def inject_files(
 
         content = project_file.resolve_content(output_dir=for_output_dir)
         project_file.abspath.write_text(content)
+
+    inject_files_post(from_output_dir=from_output_dir, for_output_dir=for_output_dir)
 
 
 def _get_build_config(output_dir: Path) -> BuildConfig:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "aiohttp-retry",
   "backoff",
   "beautifulsoup4",
+  "createrepo_c",
   "gitpython",
   "packageurl-python",
   "packaging",

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -76,7 +76,7 @@ class TestPackageInput:
             ),
             (
                 {"type": "go-package"},
-                r"Input tag 'go-package' found using 'type' does not match any of the expected tags: 'gomod', 'npm', 'pip', 'yarn'",
+                r"Input tag 'go-package' found using 'type' does not match any of the expected tags: 'gomod', 'npm', 'pip', 'rpm', 'yarn'",
             ),
             (
                 {"type": "gomod", "path": "/absolute"},

--- a/tests/unit/package_managers/test_rpm.py
+++ b/tests/unit/package_managers/test_rpm.py
@@ -1,0 +1,30 @@
+from unittest import mock
+
+import pytest
+
+from cachi2.core.package_managers.rpm.redhat import RedhatRpmsLock
+
+
+class TestRedhatRpmsLock:
+    @pytest.fixture
+    def raw_content(self) -> dict:
+        return {"lockfileVendor": "redhat", "lockfileVersion": 1, "arches": []}
+
+    @mock.patch("cachi2.core.package_managers.rpm.redhat.uuid")
+    def test_internal_repoid(self, mock_uuid: mock.Mock, raw_content: dict) -> None:
+        mock_uuid.uuid4.return_value.hex = "abcdefghijklmn"
+        lock = RedhatRpmsLock.model_validate(raw_content)
+        assert lock._uuid == "abcdef"
+        assert lock.internal_repoid == "cachi2-abcdef"
+
+    @mock.patch("cachi2.core.package_managers.rpm.redhat.uuid")
+    def test_internal_source_repoid(self, mock_uuid: mock.Mock, raw_content: dict) -> None:
+        mock_uuid.uuid4.return_value.hex = "abcdefghijklmn"
+        lock = RedhatRpmsLock.model_validate(raw_content)
+        assert lock._uuid == "abcdef"
+        assert lock.internal_source_repoid == "cachi2-abcdef-source"
+
+    def test_uuid(self, raw_content: dict) -> None:
+        lock = RedhatRpmsLock.model_validate(raw_content)
+        uuid = lock._uuid
+        assert len(uuid) == 6

--- a/tests/unit/package_managers/test_rpm.py
+++ b/tests/unit/package_managers/test_rpm.py
@@ -1,8 +1,233 @@
 from unittest import mock
 
 import pytest
+import yaml
 
+from cachi2.core.errors import PackageManagerError, PackageRejected
+from cachi2.core.package_managers.rpm import fetch_rpm_source
+from cachi2.core.package_managers.rpm.main import DEFAULT_LOCKFILE_NAME, _resolve_rpm_project
 from cachi2.core.package_managers.rpm.redhat import RedhatRpmsLock
+from cachi2.core.rooted_path import RootedPath
+
+
+@mock.patch("cachi2.core.package_managers.rpm.main.RequestOutput.from_obj_list")
+@mock.patch("cachi2.core.package_managers.rpm.main._resolve_rpm_project")
+def test_fetch_rpm_source(
+    mock_resolve_rpm_project: mock.Mock,
+    mock_from_obj_list: mock.Mock,
+) -> None:
+    mock_component = mock.Mock()
+    mock_resolve_rpm_project.return_value = [mock_component]
+    mock_request = mock.Mock()
+    mock_request.rpm_packages = [mock.Mock()]
+    fetch_rpm_source(mock_request)
+    mock_resolve_rpm_project.assert_called_once()
+    mock_from_obj_list.assert_called_once_with(
+        components=[mock_component], environment_variables=[], project_files=[]
+    )
+
+
+def test_resolve_rpm_project_no_lockfile(rooted_tmp_path: RootedPath) -> None:
+    with pytest.raises(PackageRejected) as exc_info:
+        mock_source_dir = mock.Mock()
+        mock_source_dir.join_within_root.return_value.path.exists.return_value = False
+        _resolve_rpm_project(mock_source_dir, mock.Mock())
+    assert f"RPM lockfile '{DEFAULT_LOCKFILE_NAME}' missing, refusing to continue" in str(
+        exc_info.value
+    )
+
+
+def test_resolve_rpm_project_invalid_yaml_format(rooted_tmp_path: RootedPath) -> None:
+    with open(rooted_tmp_path.join_within_root("rpms.lock.yaml"), "w") as f:
+        # colon is missing at the end
+        f.write("lockfileVendor: redhat\nlockfileVersion: 1\narches\n")
+    with pytest.raises(PackageRejected) as exc_info:
+        _resolve_rpm_project(rooted_tmp_path, rooted_tmp_path)
+
+    with open(rooted_tmp_path.join_within_root("rpms.lock.yaml"), "w") as f:
+        # end of line is missing between items
+        f.write("lockfileVendor: redhat lockfileVersion: 1\narches:\n")
+    with pytest.raises(PackageRejected) as exc_info:
+        _resolve_rpm_project(rooted_tmp_path, rooted_tmp_path)
+    assert f"RPM lockfile '{DEFAULT_LOCKFILE_NAME}' yaml format is not correct" in str(
+        exc_info.value
+    )
+
+
+def test_resolve_rpm_project_invalid_lockfile_format(rooted_tmp_path: RootedPath) -> None:
+    with open(rooted_tmp_path.join_within_root("rpms.lock.yaml"), "w") as f:
+        yaml.safe_dump(
+            {
+                "lockfileVendor": "unknown",
+                "lockfileVersion": 1,
+                "arches": [],
+            },
+            f,
+        )
+    with pytest.raises(PackageManagerError) as exc_info:
+        _resolve_rpm_project(rooted_tmp_path, rooted_tmp_path)
+
+    with open(rooted_tmp_path.join_within_root("rpms.lock.yaml"), "w") as f:
+        yaml.safe_dump(
+            {
+                "lockfileVendor": "redhat",
+                "lockfileVersion": 2,
+                "arches": [],
+            },
+            f,
+        )
+    with pytest.raises(PackageManagerError) as exc_info:
+        _resolve_rpm_project(rooted_tmp_path, rooted_tmp_path)
+
+    with open(rooted_tmp_path.join_within_root("rpms.lock.yaml"), "w") as f:
+        yaml.safe_dump(
+            {
+                "lockfileVendor": "redhat",
+                "lockfileVersion": "zz",
+                "arches": [],
+            },
+            f,
+        )
+    with pytest.raises(PackageManagerError) as exc_info:
+        _resolve_rpm_project(rooted_tmp_path, rooted_tmp_path)
+
+    with open(rooted_tmp_path.join_within_root("rpms.lock.yaml"), "w") as f:
+        yaml.safe_dump(
+            {
+                "vendor": "redhat",
+                "lockfileVersion": 1,
+                "arches": [],
+            },
+            f,
+        )
+    with pytest.raises(PackageManagerError) as exc_info:
+        _resolve_rpm_project(rooted_tmp_path, rooted_tmp_path)
+
+    with open(rooted_tmp_path.join_within_root("rpms.lock.yaml"), "w") as f:
+        yaml.safe_dump(
+            {
+                "lockfileVendor": "redhat",
+                "lockfileVersion": 1,
+                "arches": "everything",
+            },
+            f,
+        )
+    with pytest.raises(PackageManagerError) as exc_info:
+        _resolve_rpm_project(rooted_tmp_path, rooted_tmp_path)
+
+    with open(rooted_tmp_path.join_within_root("rpms.lock.yaml"), "w") as f:
+        yaml.safe_dump(
+            {
+                "lockfileVendor": "redhat",
+                "lockfileVersion": "zz",
+                "arches": [
+                    {
+                        "arch": "x86_64",
+                        "packages": [
+                            {
+                                "address": "SOME_ADDRESS",
+                                "size": 1111,
+                            },
+                        ],
+                    },
+                ],
+            },
+            f,
+        )
+    with pytest.raises(PackageManagerError) as exc_info:
+        _resolve_rpm_project(rooted_tmp_path, rooted_tmp_path)
+    assert f"RPM lockfile '{DEFAULT_LOCKFILE_NAME}' format is not valid" in str(exc_info.value)
+
+
+def test_resolve_rpm_project_arch_empty(rooted_tmp_path: RootedPath) -> None:
+    with open(rooted_tmp_path.join_within_root("rpms.lock.yaml"), "w") as f:
+        yaml.safe_dump(
+            {
+                "lockfileVendor": "redhat",
+                "lockfileVersion": 1,
+                "arches": [
+                    {
+                        "arch": "x86_64",
+                    },
+                ],
+            },
+            f,
+        )
+    with pytest.raises(PackageManagerError) as exc_info:
+        _resolve_rpm_project(rooted_tmp_path, rooted_tmp_path)
+
+    with open(rooted_tmp_path.join_within_root("rpms.lock.yaml"), "w") as f:
+        yaml.safe_dump(
+            {
+                "lockfileVendor": "redhat",
+                "lockfileVersion": 1,
+                "arches": [
+                    {
+                        "arch": "aarch64",
+                        "packages": [],
+                    },
+                ],
+            },
+            f,
+        )
+    with pytest.raises(PackageManagerError) as exc_info:
+        _resolve_rpm_project(rooted_tmp_path, rooted_tmp_path)
+
+    with open(rooted_tmp_path.join_within_root("rpms.lock.yaml"), "w") as f:
+        yaml.safe_dump(
+            {
+                "lockfileVendor": "redhat",
+                "lockfileVersion": 1,
+                "arches": [
+                    {
+                        "arch": "i686",
+                        "packages": [],
+                        "source": [],
+                    },
+                    {
+                        "arch": "x86_64",
+                        "packages": [
+                            {
+                                "url": "SOME_URL",
+                            },
+                        ],
+                    },
+                ],
+            },
+            f,
+        )
+    with pytest.raises(PackageManagerError) as exc_info:
+        _resolve_rpm_project(rooted_tmp_path, rooted_tmp_path)
+    assert "At least one field ('packages', 'source') must be set in every arch." in str(
+        exc_info.value
+    )
+
+
+def test_resolve_rpm_project_correct_format(rooted_tmp_path: RootedPath) -> None:
+    with open(rooted_tmp_path.join_within_root("rpms.lock.yaml"), "w") as f:
+        yaml.safe_dump(
+            {
+                "lockfileVendor": "redhat",
+                "lockfileVersion": 1,
+                "arches": [
+                    {
+                        "arch": "x86_64",
+                        "packages": [
+                            {
+                                "url": "SOME_URL",
+                            },
+                        ],
+                        "source": [
+                            {
+                                "url": "SOME_URL",
+                            },
+                        ],
+                    },
+                ],
+            },
+            f,
+        )
+    _resolve_rpm_project(rooted_tmp_path, rooted_tmp_path)
 
 
 class TestRedhatRpmsLock:

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -357,7 +357,7 @@ class TestFetchDeps:
                 [
                     "Error: InvalidInput: 1 validation error for user input",
                     "packages -> 0",
-                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'gomod', 'npm', 'pip', 'yarn'",
+                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'gomod', 'npm', 'pip', 'rpm', 'yarn'",
                 ],
             ),
             (
@@ -365,7 +365,7 @@ class TestFetchDeps:
                 [
                     "Error: InvalidInput: 1 validation error for user input",
                     "packages -> 0",
-                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'gomod', 'npm', 'pip', 'yarn'",
+                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'gomod', 'npm', 'pip', 'rpm', 'yarn'",
                 ],
             ),
             (
@@ -373,7 +373,7 @@ class TestFetchDeps:
                 [
                     "Error: InvalidInput: 1 validation error for user input",
                     "packages -> 0",
-                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'gomod', 'npm', 'pip', 'yarn'",
+                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'gomod', 'npm', 'pip', 'rpm', 'yarn'",
                 ],
             ),
             # Missing package type


### PR DESCRIPTION
This is the proof of concept of RPM prefetching functionality.
Design concept: https://github.com/containerbuildsystem/cachi2/discussions/465

A new rpm package manager was added as a development version so `--dev-package-managers` flag needs to be activated.
* `fetch-deps` command will read the rpms lockfile and download listed packages and sources into the output directory structure. Also SBOM file will be generated (bom.json).
* `inject-files` command will create repofile for each arch and create repository metadata out of its RPMs for every repoid dir.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
