### PR TITLE
indent JSON files generated by fetch-deps command

### DIFF
--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -254,13 +254,13 @@ def fetch_deps(
 
     request.output_dir.path.mkdir(parents=True, exist_ok=True)
     request.output_dir.join_within_root(".build-config.json").path.write_text(
-        request_output.build_config.model_dump_json()
+        request_output.build_config.model_dump_json(indent=2)
     )
 
     sbom = request_output.generate_sbom()
     request.output_dir.join_within_root("bom.json").path.write_text(
         # the Sbom model has camelCase aliases in some fields
-        sbom.model_dump_json(by_alias=True, exclude_none=True)
+        sbom.model_dump_json(indent=2, by_alias=True, exclude_none=True)
     )
 
     log.info(r"All dependencies fetched successfully \o/")


### PR DESCRIPTION
within user request, we write out json files
(bom.json, .build-config.json) by `model_dump_json()`method, but with no indentation so the output is a huge one-line file

unlike generating data in integration tests:
https://github.com/containerbuildsystem/cachi2/blob/main/tests/integration/utils.py#L228

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
