### PR TITLE
allow downloading yanked sdists for pip dependencies

### DIFF
--- a/cachi2/core/package_managers/pip.py
+++ b/cachi2/core/package_managers/pip.py
@@ -1896,18 +1896,11 @@ def _process_package_distributions(
 
     if sdists:
         best_sdist = max(sdists, key=_sdist_preference)
+        processed_dpis.append(best_sdist)
         if best_sdist.is_yanked:
-            raise PackageRejected(
-                f"All sdists for package {name}=={version} are yanked",
-                solution=(
-                    f"Please update the {name} version in your requirements file.\n"
-                    "Usually, when a version gets yanked from PyPI, there will already "
-                    "be a fixed version available.\n"
-                    "Otherwise, you may need to pin to the previous version."
-                ),
+            log.warning(
+                "The version %s of package %s is yanked, use a different version", version, name
             )
-        if best_sdist:
-            processed_dpis.append(best_sdist)
     else:
         log.warning("No sdist found for package %s==%s", name, version)
 

--- a/tests/unit/package_managers/test_pip.py
+++ b/tests/unit/package_managers/test_pip.py
@@ -2762,6 +2762,7 @@ class TestDownload:
         self,
         mock_get_project_page: mock.Mock,
         rooted_tmp_path: RootedPath,
+        caplog: pytest.LogCaptureFixture,
     ) -> None:
         package_name = "aiowsgi"
         version = "0.1.0"
@@ -2775,10 +2776,12 @@ class TestDownload:
             None,
             None,
         )
-        with pytest.raises(PackageRejected) as exc_info:
-            pip._process_package_distributions(mock_requirement, rooted_tmp_path)
 
-        assert str(exc_info.value) == f"All sdists for package {package_name}=={version} are yanked"
+        pip._process_package_distributions(mock_requirement, rooted_tmp_path)
+        assert (
+            f"The version {version} of package {package_name} is yanked, use a different version"
+            in caplog.text
+        )
 
     @pytest.mark.parametrize("use_user_hashes", (True, False))
     @pytest.mark.parametrize("use_pypi_digests", (True, False))


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
