### PR TITLE
Convert PipRequirement classmethods to staticmethods

### DIFF
--- a/cachi2/core/package_managers/pip.py
+++ b/cachi2/core/package_managers/pip.py
@@ -1164,27 +1164,6 @@ class PipRequirementsFile:
 class PipRequirement:
     """Parse a requirement and its options from a requirement line."""
 
-    URL_SCHEMES = {"http", "https", "ftp"}
-
-    VCS_SCHEMES = {
-        "bzr",
-        "bzr+ftp",
-        "bzr+http",
-        "bzr+https",
-        "git",
-        "git+ftp",
-        "git+http",
-        "git+https",
-        "hg",
-        "hg+ftp",
-        "hg+http",
-        "hg+https",
-        "svn",
-        "svn+ftp",
-        "svn+http",
-        "svn+https",
-    }
-
     # Regex used to determine if a direct access requirement specifies a
     # package name, e.g. "name @ https://..."
     HAS_NAME_IN_DIRECT_ACCESS_REQUIREMENT = re.compile(r"@.+://")
@@ -1355,6 +1334,25 @@ class PipRequirement:
             e.g. "vcs", and the second item is a bool indicating if the requirement is a
             direct access requirement
         """
+        URL_SCHEMES = {"http", "https", "ftp"}
+        VCS_SCHEMES = {
+            "bzr",
+            "bzr+ftp",
+            "bzr+http",
+            "bzr+https",
+            "git",
+            "git+ftp",
+            "git+http",
+            "git+https",
+            "hg",
+            "hg+ftp",
+            "hg+http",
+            "hg+https",
+            "svn",
+            "svn+ftp",
+            "svn+http",
+            "svn+https",
+        }
         direct_access_kind = None
 
         if ":" not in line:
@@ -1368,9 +1366,9 @@ class PipRequirement:
             )
         scheme = scheme_parts[-1].lower().strip()
 
-        if scheme in cls.URL_SCHEMES:
+        if scheme in URL_SCHEMES:
             direct_access_kind = "url"
-        elif scheme in cls.VCS_SCHEMES:
+        elif scheme in VCS_SCHEMES:
             direct_access_kind = "vcs"
         else:
             direct_access_kind = scheme


### PR DESCRIPTION
PipRequirement had three classmethods with no real connection to the class, so in this commit I'm converting them to staticmethods and passing the necessary data as arguments.

PipRequirement._assess_direct_access_requirement
PipRequirement._adjust_direct_access_requirement
PipRequirement._split_hashes_from_options

Resolves #488 

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
