### PR TITLE
feat(pkg-mgr:pip): add 'pip_package_binary' property...

### DIFF
--- a/cachi2/core/models/property_semantics.py
+++ b/cachi2/core/models/property_semantics.py
@@ -32,6 +32,7 @@ class PropertySet:
     missing_hash_in_file: frozenset[str] = field(default_factory=frozenset)
     npm_bundled: bool = False
     npm_development: bool = False
+    pip_package_binary: bool = False
 
     @classmethod
     def from_properties(cls, props: Iterable[Property]) -> "Self":
@@ -40,6 +41,7 @@ class PropertySet:
         missing_hash_in_file = []
         npm_bundled = False
         npm_development = False
+        pip_package_binary = False
 
         for prop in props:
             if prop.name == "cachi2:found_by":
@@ -50,10 +52,18 @@ class PropertySet:
                 npm_bundled = True
             elif prop.name == "cdx:npm:package:development":
                 npm_development = True
+            elif prop.name == "cachi2:pip:package:binary":
+                pip_package_binary = True
             else:
                 assert_never(prop.name)
 
-        return cls(found_by, frozenset(missing_hash_in_file), npm_bundled, npm_development)
+        return cls(
+            found_by,
+            frozenset(missing_hash_in_file),
+            npm_bundled,
+            npm_development,
+            pip_package_binary,
+        )
 
     def to_properties(self) -> list[Property]:
         """Convert a PropertySet to a list of SBOM component properties."""
@@ -68,6 +78,9 @@ class PropertySet:
             props.append(Property(name="cdx:npm:package:bundled", value="true"))
         if self.npm_development:
             props.append(Property(name="cdx:npm:package:development", value="true"))
+        if self.pip_package_binary:
+            props.append(Property(name="cachi2:pip:package:binary", value="true"))
+
         return sorted(props, key=lambda p: (p.name, p.value))
 
     def merge(self, other: "Self") -> "Self":
@@ -78,4 +91,5 @@ class PropertySet:
             missing_hash_in_file=self.missing_hash_in_file | other.missing_hash_in_file,
             npm_bundled=self.npm_bundled and other.npm_bundled,
             npm_development=self.npm_development and other.npm_development,
+            pip_package_binary=self.pip_package_binary or other.pip_package_binary,
         )

--- a/cachi2/core/models/sbom.py
+++ b/cachi2/core/models/sbom.py
@@ -7,6 +7,7 @@ from cachi2.core.models.validators import unique_sorted
 PropertyName = Literal[
     "cachi2:found_by",
     "cachi2:missing_hash:in_file",
+    "cachi2:pip:package:binary",
     "cdx:npm:package:bundled",
     "cdx:npm:package:development",
 ]

--- a/tests/unit/models/test_property_semantics.py
+++ b/tests/unit/models/test_property_semantics.py
@@ -103,6 +103,41 @@ from cachi2.core.models.sbom import Component, Property
                 ),
             ],
         ),
+        (
+            # validate that "wheel" property is merged correctly
+            [
+                # sdist
+                Component(
+                    name="foo",
+                    version="1.0.0",
+                    purl="pkg:pip/foo@1.0.0",
+                    properties=[
+                        Property(name="cachi2:found_by", value="cachi2"),
+                    ],
+                ),
+                # wheel
+                Component(
+                    name="foo",
+                    version="1.0.0",
+                    purl="pkg:pip/foo@1.0.0",
+                    properties=[
+                        Property(name="cachi2:found_by", value="cachi2"),
+                        Property(name="cachi2:pip:package:binary", value="true"),
+                    ],
+                ),
+            ],
+            [
+                Component(
+                    name="foo",
+                    version="1.0.0",
+                    purl="pkg:pip/foo@1.0.0",
+                    properties=[
+                        Property(name="cachi2:found_by", value="cachi2"),
+                        Property(name="cachi2:pip:package:binary", value="true"),
+                    ],
+                )
+            ],
+        ),
     ],
 )
 def test_merge_component_properties(
@@ -134,6 +169,10 @@ class TestPropertySet:
             (
                 [Property(name="cdx:npm:package:development", value="true")],
                 PropertySet(npm_development=True),
+            ),
+            (
+                [Property(name="cachi2:pip:package:binary", value="true")],
+                PropertySet(pip_package_binary=True),
             ),
             (
                 [
@@ -200,6 +239,11 @@ class TestPropertySet:
                 PropertySet(npm_development=True),
                 PropertySet(npm_development=True),
                 PropertySet(npm_development=True),
+            ),
+            (
+                PropertySet(),
+                PropertySet(pip_package_binary=True),
+                PropertySet(pip_package_binary=True),
             ),
         ],
     )

--- a/tests/unit/package_managers/test_pip.py
+++ b/tests/unit/package_managers/test_pip.py
@@ -2687,7 +2687,7 @@ class TestDownload:
         )
 
     @mock.patch.object(pypi_simple.PyPISimple, "get_project_page")
-    def test_process_existing_package_without_source_distributions(
+    def test_process_existing_wheel_only_package(
         self,
         mock_get_project_page: mock.Mock,
         rooted_tmp_path: RootedPath,
@@ -3380,12 +3380,14 @@ class TestDownload:
             "package": "eggs",
             "path": vcs_download,
             "repo": "eggs",
+            "package_type": "",
             "hash_verified": use_hashes,
             "requirement_file": str(req_file.file_path.subpath_from_root),
             # etc., not important for this test
         }
         url_info = {
             "package": "bar",
+            "package_type": "",
             "original_url": plain_url,
             "url_with_hash": plain_url,
             "path": url_download,
@@ -3406,6 +3408,7 @@ class TestDownload:
             "kind": "pypi",
             "requirement_file": str(req_file.file_path.subpath_from_root),
             "hash_verified": True,
+            "package_type": "sdist",
         }
         pypi_downloads = [sdist_d_i]
         wheel_downloads = []
@@ -3433,6 +3436,7 @@ class TestDownload:
                         "kind": "pypi",
                         "requirement_file": str(req_file.file_path.subpath_from_root),
                         "hash_verified": hash_verified,
+                        "package_type": "wheel",
                     }
                 )
 
@@ -3602,12 +3606,14 @@ class TestDownload:
                 "kind": "pypi",
                 "hash_verified": False,
                 "requirement_file": str(req_file1.subpath_from_root),
+                "package_type": "sdist",
             },
             pypi_package2.download_info
             | {
                 "kind": "pypi",
                 "hash_verified": False,
                 "requirement_file": str(req_file2.subpath_from_root),
+                "package_type": "sdist",
             },
         ]
         _check_metadata_in_sdist.assert_has_calls(
@@ -3709,6 +3715,7 @@ def test_resolve_pip(
                 "version": "2.1",
                 "hash_verified": True,
                 "requirement_file": str(req_file.subpath_from_root),
+                "package_type": "sdist",
             }
         ],
         [
@@ -3719,6 +3726,7 @@ def test_resolve_pip(
                 "version": "0.0.5",
                 "hash_verified": True,
                 "requirement_file": str(build_req_file.subpath_from_root),
+                "package_type": "sdist",
             }
         ],
     ]
@@ -3743,6 +3751,7 @@ def test_resolve_pip(
                 "kind": "pypi",
                 "hash_verified": True,
                 "requirement_file": "req.txt" if custom_requirements else "requirements.txt",
+                "package_type": "sdist",
             },
             {
                 "name": "baz",
@@ -3752,6 +3761,7 @@ def test_resolve_pip(
                 "kind": "pypi",
                 "hash_verified": True,
                 "requirement_file": "breq.txt" if custom_requirements else "requirements-build.txt",
+                "package_type": "sdist",
             },
         ],
         "requirements": [req_file, build_req_file],
@@ -3943,6 +3953,7 @@ def test_fetch_pip_source(
             {
                 "name": "bar",
                 "version": "https://x.org/bar.zip#cachito_hash=sha256:aaaaaaaaaa",
+                "package_type": "",
                 "type": "pip",
                 "dev": False,
                 "kind": "url",
@@ -3952,6 +3963,7 @@ def test_fetch_pip_source(
             {
                 "name": "baz",
                 "version": "0.0.5",
+                "package_type": "wheel",
                 "type": "pip",
                 "dev": True,
                 "kind": "pypi",
@@ -3967,6 +3979,7 @@ def test_fetch_pip_source(
             {
                 "name": "ham",
                 "version": "3.2",
+                "package_type": "sdist",
                 "type": "pip",
                 "dev": False,
                 "kind": "pypi",
@@ -3976,6 +3989,7 @@ def test_fetch_pip_source(
             {
                 "name": "eggs",
                 "version": "https://x.org/eggs.zip#cachito_hash=sha256:aaaaaaaaaa",
+                "package_type": "",
                 "type": "pip",
                 "dev": False,
                 "kind": "url",
@@ -4015,7 +4029,12 @@ def test_fetch_pip_source(
             name="bar",
             purl="pkg:pypi/bar?checksum=sha256:aaaaaaaaaa&download_url=https://x.org/bar.zip",
         ),
-        Component(name="baz", version="0.0.5", purl="pkg:pypi/baz@0.0.5"),
+        Component(
+            name="baz",
+            version="0.0.5",
+            purl="pkg:pypi/baz@0.0.5",
+            properties=[Property(name="cachi2:pip:package:binary", value="true")],
+        ),
     ]
 
     expect_components_package_b = [


### PR DESCRIPTION
...to PropertySet and sbom::PropertyName so it can be processed

Signed-off-by: Ben Alkov <ben.alkov@redhat.com># Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
