### PR TITLE
interface: cli: Remove the top-level output directory before fetching

### DIFF
--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -2,6 +2,7 @@ import functools
 import importlib.metadata
 import json
 import logging
+import shutil
 import sys
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -249,6 +250,11 @@ def fetch_deps(
             "flags": combine_option_and_json_flags(input.flags),
         },
     )
+
+    deps_dir = output / "deps"
+    if deps_dir.exists():
+        log.debug(f"Removing existing deps directory '{deps_dir}'")
+        shutil.rmtree(deps_dir, ignore_errors=True)
 
     request_output = resolve_packages(request)
 


### PR DESCRIPTION
We keep reusing the old output directory hierarchy with repeated fetch runs, overwriting all relevant files. Right now it's all fine because all the files have predictable (pretty much fixed) names, however if we create files/directories with any randomness in their names, we'll be just creating more and more noise with repeated runs. Since we're rewriting all files for the processed package managers anyway (for now), i.e. not reusing data in between runs, it would be better if we first cleaned up the destination if it exists and only then proceed with the fetch.

Note that failing to process a request would be the preferred approach if the output directory existed, because we can't be sure that the existing directory we're being pointed to was indeed created by us so we may end up deleting other legitimate data, however, given that such logic would lead to regressive behaviour since we already happily overwrite anything the user points us at, so the new behaviour isn't any worse than it already is.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
