### PR TITLE
docs: gomod: Fix version of cachi2 that introduced full Go 1.21 support

### DIFF
--- a/docs/gomod.md
+++ b/docs/gomod.md
@@ -225,7 +225,7 @@ workflow.
   Many projects bump their required Go toolchain's micro release as soon as it becomes available
   upstream (i.e. not waiting for distributions to bundle them properly). This caused problems for
   *cachi2-v0.5.0* because the container image's version simply may not have been high enough to
-  process a given project's `go.mod` file. Therefore, *cachi2-v0.6.0* implemented a mechanism to
+  process a given project's `go.mod` file. Therefore, *cachi2-v0.7.0* implemented a mechanism to
   always rely on the origin 0th release of a toolchain (e.g. 1.21.0) and use the `GOTOOLCHAIN=auto`
   setting to instruct Go to fetch any toolchain as specified by the `go.mod` file automatically,
   hence allowing us to keep up with frequent micro version bumps. **Note that such a language


### PR DESCRIPTION
v0.6.0 is already out, so we need to document this for the next future release v0.7.0

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
