### PR TITLE
rpm PoC: Allow specifying DNF options via CLI input JSON 

### DIFF
--- a/cachi2/core/models/input.py
+++ b/cachi2/core/models/input.py
@@ -1,5 +1,17 @@
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Callable, ClassVar, Literal, Optional, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    Optional,
+    TypeVar,
+    Union,
+)
 
 import pydantic
 
@@ -65,6 +77,60 @@ class _PackageInputBase(pydantic.BaseModel, extra="forbid"):
         return check_sane_relpath(path)
 
 
+class _DNFOptions(pydantic.BaseModel, extra="forbid"):
+    """DNF options model.
+
+    DNF options can be provided via 2 'streams':
+        1) global /etc/dnf/dnf.conf OR
+        2) /etc/yum.repos.d/.repo files
+
+    Config options are specified via INI format based on sections. There are 2 types of sections:
+        1) global 'main' - either global repo options or DNF control-only options
+            - NOTE: there must always ever be a single "main" section
+
+        2) <repoid> sections - options tied specifically to a given defined repo
+
+    [1] https://man7.org/linux/man-pages/man5/dnf.conf.5.html
+    """
+
+    # Don't model all known DNF options for validation purposes - it's user's responsibility!
+    dnf: Dict[Union[Literal["main"], str], Dict[str, Any]]
+
+    @pydantic.model_validator(mode="before")
+    def _validate_dnf_options(cls, data: Any, info: pydantic.ValidationInfo) -> Optional[Dict]:
+        """Fail if the user passes unexpected configuration options namespace."""
+
+        def _raise_unexpected_type(repr_: str, *prefixes: str) -> None:
+            loc = ".".join(prefixes + (repr_,))
+            raise ValueError(f"Unexpected data type for '{loc}' in input JSON: expected 'dict'")
+
+        prefixes: List[str] = ["options"]
+
+        if not data:
+            return None
+
+        if not isinstance(data, dict):
+            _raise_unexpected_type(data, *prefixes)
+
+        if "dnf" not in data:
+            raise ValueError(f"Missing required namespace attribute in '{data}': 'dnf'")
+
+        if diff := set(cls.model_fields) - set(data.keys()):
+            raise ValueError(f"Extra attributes passed in '{data}': {diff}")
+
+        prefixes.append("dnf")
+        options_scope = data["dnf"]
+        if not isinstance(options_scope, dict):
+            _raise_unexpected_type(options_scope, *prefixes)
+
+        for repo, repo_options in options_scope.items():
+            prefixes.append(repo)
+            if not isinstance(repo_options, dict):
+                _raise_unexpected_type(repo_options, *prefixes)
+
+        return data
+
+
 class GomodPackageInput(_PackageInputBase):
     """Accepted input for a gomod package."""
 
@@ -104,6 +170,7 @@ class RpmPackageInput(_PackageInputBase):
     """Accepted input for a rpm package."""
 
     type: Literal["rpm"]
+    options: Optional[Union[_DNFOptions]] = None
 
 
 class YarnPackageInput(_PackageInputBase):

--- a/cachi2/core/models/output.py
+++ b/cachi2/core/models/output.py
@@ -1,7 +1,7 @@
 import logging
 import string
 from pathlib import Path
-from typing import Dict, Literal, Optional, Set
+from typing import Any, Dict, Literal, Optional, Set
 
 import pydantic
 
@@ -133,6 +133,7 @@ class BuildConfig(pydantic.BaseModel):
 
     environment_variables: list[EnvironmentVariable] = []
     project_files: list[ProjectFile] = []
+    options: Optional[Dict[str, Any]] = None
 
     @pydantic.field_validator("environment_variables")
     def _unique_env_vars(cls, env_vars: list[EnvironmentVariable]) -> list[EnvironmentVariable]:
@@ -170,6 +171,7 @@ class RequestOutput(pydantic.BaseModel):
         components: list[Component],
         environment_variables: Optional[list[EnvironmentVariable]] = None,
         project_files: Optional[list[ProjectFile]] = None,
+        options: Optional[Dict[str, Any]] = None,
     ) -> "RequestOutput":
         """Create a RequestOutput from components, environment variables and project files."""
         if environment_variables is None:
@@ -183,5 +185,6 @@ class RequestOutput(pydantic.BaseModel):
             build_config=BuildConfig(
                 environment_variables=environment_variables,
                 project_files=project_files,
+                options=options,
             ),
         )

--- a/cachi2/core/package_managers/rpm/main.py
+++ b/cachi2/core/package_managers/rpm/main.py
@@ -314,7 +314,8 @@ def _generate_repofiles(from_output_dir: Path, for_output_dir: Path) -> None:
             continue
         log.debug(f"Preparing repofile content for arch '{arch.name}'")
         repofile = _Repofile(defaults={"gpgcheck": "1"})
-        for entry in sorted(arch.iterdir()):
+
+        for entry in arch.iterdir():
             if not entry.is_dir() or entry.name == "repos.d":
                 continue
             repoid = entry.name

--- a/cachi2/core/package_managers/rpm/main.py
+++ b/cachi2/core/package_managers/rpm/main.py
@@ -287,10 +287,8 @@ def _generate_repofiles(from_output_dir: Path, for_output_dir: Path) -> None:
             content += "gpgcheck=1\n"
             # repoid directory matches the internal repoid
             if repoid.startswith("cachi2-"):
-                content += (
-                    "name=Generated repository containing all packages unaffiliated "
-                    "with any official repository\n"
-                )
+                content += "name=Packages unaffiliated with an official repository\n"
+
         if content:
             repo_file_path = arch.joinpath("repos.d", "cachi2.repo")
             if repo_file_path.exists():

--- a/cachi2/core/package_managers/rpm/main.py
+++ b/cachi2/core/package_managers/rpm/main.py
@@ -227,15 +227,11 @@ def _generate_sbom_components(
     return components
 
 
-def inject_files_post(*args: Any, **kwargs: Any) -> None:
+def inject_files_post(from_output_dir: Path, for_output_dir: Path, **kwargs: Any) -> None:
     """Run extra tasks for the RPM package manager (callback method) within `inject-files` cmd."""
-    if "from_output_dir" in kwargs and "for_output_dir" in kwargs:
-        from_output_dir = kwargs["from_output_dir"]
-        for_output_dir = kwargs["for_output_dir"]
-
-        if Path.exists(from_output_dir.joinpath(DEFAULT_PACKAGE_DIR)):
-            _generate_repos(from_output_dir)
-            _generate_repofiles(from_output_dir, for_output_dir)
+    if Path.exists(from_output_dir.joinpath(DEFAULT_PACKAGE_DIR)):
+        _generate_repos(from_output_dir)
+        _generate_repofiles(from_output_dir, for_output_dir)
 
 
 def _generate_repos(from_output_dir: Path) -> None:

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -86,9 +86,9 @@ def _merge_outputs(outputs: Iterable[RequestOutput]) -> RequestOutput:
     )
 
 
-def inject_files_post(*args: Any, **kwargs: Any) -> None:
+def inject_files_post(from_output_dir: Path, for_output_dir: Path, **kwargs: Any) -> None:
     """Do extra steps for package manager."""
     # if there is a callback method defined within the particular package manager, run it
     if hasattr(rpm, "inject_files_post"):
         callback_method = getattr(rpm, "inject_files_post")
-        callback_method(*args, **kwargs)
+        callback_method(from_output_dir, for_output_dir, **kwargs)

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -83,6 +83,7 @@ def _merge_outputs(outputs: Iterable[RequestOutput]) -> RequestOutput:
         components=components,
         environment_variables=env_vars,
         project_files=project_files,
+        options=output.build_config.options if output.build_config.options else None,
     )
 
 

--- a/cachi2/interface/cli.py
+++ b/cachi2/interface/cli.py
@@ -260,7 +260,7 @@ def fetch_deps(
 
     request.output_dir.path.mkdir(parents=True, exist_ok=True)
     request.output_dir.join_within_root(".build-config.json").path.write_text(
-        request_output.build_config.model_dump_json(indent=2)
+        request_output.build_config.model_dump_json(indent=2, exclude_none=True)
     )
 
     sbom = request_output.generate_sbom()
@@ -339,7 +339,11 @@ def inject_files(
         content = project_file.resolve_content(output_dir=for_output_dir)
         project_file.abspath.write_text(content)
 
-    inject_files_post(from_output_dir=from_output_dir, for_output_dir=for_output_dir)
+    inject_files_post(
+        from_output_dir=from_output_dir,
+        for_output_dir=for_output_dir,
+        options=fetch_deps_output.options,
+    )
 
 
 def _get_build_config(output_dir: Path) -> BuildConfig:

--- a/tests/integration/test_data/rpm_test_repo_file/cachi2.repo
+++ b/tests/integration/test_data/rpm_test_repo_file/cachi2.repo
@@ -4,7 +4,7 @@ gpgcheck=1
 [cachi2-aaa000]
 baseurl=file:///tmp/rpm_test_repo_file-output/deps/rpm/x86_64/cachi2-aaa000
 gpgcheck=1
-name=Generated repository containing all packages unaffiliated with any official repository
+name=Packages unaffiliated with an official repository
 [releases]
 baseurl=file:///tmp/rpm_test_repo_file-output/deps/rpm/x86_64/releases
 gpgcheck=1

--- a/tests/integration/test_rpm.py
+++ b/tests/integration/test_rpm.py
@@ -1,5 +1,6 @@
 import os
 import re
+from configparser import ConfigParser
 from pathlib import Path
 from typing import List
 
@@ -174,8 +175,15 @@ def test_repo_files(
         with open(expected_repo_file_path, "w") as file:
             file.write(repo_file_content)
 
+    actual = ConfigParser()
+    expected = ConfigParser()
+
+    actual.read_string(repo_file_content)
+    with open(expected_repo_file_path) as f:
+        expected.read_file(f)
+
     # check if .repo file content matches the expected test data
-    assert repo_file_content == read_and_normalize_repofile(expected_repo_file_path)
+    assert actual == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -70,41 +70,48 @@ class TestPackageInput:
     @pytest.mark.parametrize(
         "input_data, expect_error",
         [
-            (
-                {},
-                r"Unable to extract tag using discriminator 'type'",
+            pytest.param(
+                {}, r"Unable to extract tag using discriminator 'type'", id="no_type_discrinator"
             ),
-            (
+            pytest.param(
                 {"type": "go-package"},
                 r"Input tag 'go-package' found using 'type' does not match any of the expected tags: 'gomod', 'npm', 'pip', 'rpm', 'yarn'",
+                id="incorrect_type_tag",
             ),
-            (
+            pytest.param(
                 {"type": "gomod", "path": "/absolute"},
                 r"Value error, path must be relative: /absolute",
+                id="path_not_relative",
             ),
-            (
+            pytest.param(
                 {"type": "gomod", "path": ".."},
                 r"Value error, path contains ..: ..",
+                id="gomod_path_references_parent_directory",
             ),
-            (
+            pytest.param(
                 {"type": "gomod", "path": "weird/../subpath"},
                 r"Value error, path contains ..: weird/../subpath",
+                id="gomod_path_references_parent_directory_2",
             ),
-            (
+            pytest.param(
                 {"type": "pip", "requirements_files": ["weird/../subpath"]},
                 r"pip.requirements_files\n  Value error, path contains ..: weird/../subpath",
+                id="pip_path_references_parent_directory",
             ),
-            (
+            pytest.param(
                 {"type": "pip", "requirements_build_files": ["weird/../subpath"]},
                 r"pip.requirements_build_files\n  Value error, path contains ..: weird/../subpath",
+                id="pip_path_references_parent_directory",
             ),
-            (
+            pytest.param(
                 {"type": "pip", "requirements_files": None},
                 r"none is not an allowed value",
+                id="pip_no_requirements_files",
             ),
-            (
+            pytest.param(
                 {"type": "pip", "requirements_build_files": None},
                 r"none is not an allowed value",
+                id="pip_no_requirements_build_files",
             ),
         ],
     )

--- a/tests/unit/package_managers/test_rpm.py
+++ b/tests/unit/package_managers/test_rpm.py
@@ -318,12 +318,10 @@ def test_generate_repofiles(rooted_tmp_path: RootedPath) -> None:
     arch_dir.joinpath("repos.d").mkdir(parents=True)
     repopath = arch_dir.joinpath("repos.d", "cachi2.repo")
     output_dir = f"{package_dir}/x86_64"
-    name = (
-        "name=Generated repository containing all packages unaffiliated "
-        "with any official repository"
-    )
+    name = "Packages unaffiliated with an official repository"
+
     # repo items need to be sorted to match with the repofile
-    template = f"[cachi2-repo2]\nbaseurl=file://{output_dir}/cachi2-repo2\ngpgcheck=1\n{name}\n[repo1]\nbaseurl=file://{output_dir}/repo1\ngpgcheck=1\n"
+    template = f"[cachi2-repo2]\nbaseurl=file://{output_dir}/cachi2-repo2\ngpgcheck=1\nname={name}\n[repo1]\nbaseurl=file://{output_dir}/repo1\ngpgcheck=1\n"
     _generate_repofiles(rooted_tmp_path.path, rooted_tmp_path.path)
     with open(repopath) as f:
         assert template == f.read()


### PR DESCRIPTION
Introduce a new input JSON attribute 'options' for the PoC rpm package
manager allowing consumers to pass arbitrary DNF repo configuration
options that would be applied later through the inject-files command.

The general schema for the input JSON is as follows:

```
{
    type: <package_manager>
    path: <relative_path>
    options: {
        <namespace>: {
            <key1>..<keyN>: Union[str, Any]<val1>
        }
    }
}
```

which translated to DNF repo options for RPM might then look like:

```
{
    type: rpm
    path: .
    options: {
        dnf: {
             repoid1: {gpgcheck: 0, deltarpm: 1},
             repoid2: {fastestmirro: 1, sslverify: 0}
        }
    }
}
```

which in turn would end up being dumped to the `.build-config.json` similarly to this:
```
{
  "environment_variables": [],
  "project_files": [],
  "options": {
    "rpm": {
      "dnf": {
        "releases": {
          "gpgcheck": 0,
          "enabled": 0,
          "type": "yum"
        }
      }
    }
  }
```
and finally the resulting generated `.repo` file might look like:
```
[releases]
gpgcheck = 0
enabled = 0
type = yum
baseurl = file:///etc/yum.repos.d/deps/rpm/x86_64/releases
```

_Notes:_
- worth mentioning is that the way this is currently designed is that `options` are only ever formatted in the build config if some were actually set on the CLI (rather than being formatted as `options: {}`) so that this would be transparent to other package manager for which we don't intend to support options at the moment; this was all achieved by setting `exclude_none=True` globally for `buildconfig.model_dump_json`
- the reason why there's an additional level of nesting in the `.build-config.json` namespaced by `"rpm"` is due to the fact that it's possible to specify more than one package with the input JSON on CLI, thus theoretically possible to provide various options for various package managers (if ever turned on) so we'd need to know which options relate to which package manager type which wouldn't otherwise be possible from current build config contents.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] ~Docs updated (if applicable)~
- [ ] ~Docs links in the code are still valid (if docs were updated)~

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
