### PR TITLE
RPM PoC: integration tests

### DIFF
--- a/tests/integration/test_data/rpm_missing_checksums/.build-config.yaml
+++ b/tests/integration/test_data/rpm_missing_checksums/.build-config.yaml
@@ -1,0 +1,2 @@
+environment_variables: []
+project_files: []

--- a/tests/integration/test_data/rpm_missing_checksums/bom.json
+++ b/tests/integration/test_data/rpm_missing_checksums/bom.json
@@ -1,0 +1,71 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "gpm-libs",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        },
+        {
+          "name": "cachi2:missing_hash:in_file",
+          "value": "rpms.lock.yaml"
+        }
+      ],
+      "purl": "pkg:rpm/fedora%20project/gpm-libs@1.20.7-46.fc40?arch=x86_64&download_url=http%3A//fedora.c3sl.ufpr.br/linux/releases/40/Everything/x86_64/os/Packages/g/gpm-libs-1.20.7-46.fc40.x86_64.rpm",
+      "type": "library",
+      "version": "1.20.7"
+    },
+    {
+      "name": "gpm",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        },
+        {
+          "name": "cachi2:missing_hash:in_file",
+          "value": "rpms.lock.yaml"
+        }
+      ],
+      "purl": "pkg:rpm/fedora%20project/gpm@1.20.7-46.fc40?arch=i686&download_url=http%3A//fedora.c3sl.ufpr.br/linux/releases/40/Everything/source/tree/Packages/g/gpm-1.20.7-46.fc40.src.rpm",
+      "type": "library",
+      "version": "1.20.7"
+    },
+    {
+      "name": "libsodium",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:rpm/fedora%20project/libsodium@1.0.19-4.fc40?arch=i686&download_url=http%3A//fedora.c3sl.ufpr.br/linux/releases/40/Everything/source/tree/Packages/l/libsodium-1.0.19-4.fc40.src.rpm",
+      "type": "library",
+      "version": "1.0.19"
+    },
+    {
+      "name": "libsodium",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:rpm/fedora%20project/libsodium@1.0.19-4.fc40?arch=x86_64&download_url=http%3A//fedora.c3sl.ufpr.br/linux/releases/40/Everything/x86_64/os/Packages/l/libsodium-1.0.19-4.fc40.x86_64.rpm",
+      "type": "library",
+      "version": "1.0.19"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "name": "cachi2",
+        "vendor": "red hat"
+      }
+    ]
+  },
+  "specVersion": "1.4",
+  "version": 1
+}

--- a/tests/integration/test_rpm.py
+++ b/tests/integration/test_rpm.py
@@ -22,6 +22,20 @@ from . import utils
             ),
             id="rpm_missing_checksums",
         ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-rpm",
+                ref="a214ee8db55418ea1d0734cd2a401c97ad896390",
+                packages=({"path": ".", "type": "rpm"},),
+                flags=["--dev-package-managers"],
+                check_output=False,
+                check_deps_checksums=False,
+                check_vendor_checksums=False,
+                expected_exit_code=2,
+                expected_output="Unmatched checksum",
+            ),
+            id="rpm_unmatched_checksum",
+        ),
     ],
 )
 def test_rpm_packages(

--- a/tests/integration/test_rpm.py
+++ b/tests/integration/test_rpm.py
@@ -36,6 +36,20 @@ from . import utils
             ),
             id="rpm_unmatched_checksum",
         ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-rpm",
+                ref="699bfad4030c97e3b62042ffc48149ef896164ec",
+                packages=({"path": ".", "type": "rpm"},),
+                flags=["--dev-package-managers"],
+                check_output=False,
+                check_deps_checksums=False,
+                check_vendor_checksums=False,
+                expected_exit_code=2,
+                expected_output="Unexpected file size",
+            ),
+            id="rpm_unexpected_size",
+        ),
     ],
 )
 def test_rpm_packages(

--- a/tests/integration/test_rpm.py
+++ b/tests/integration/test_rpm.py
@@ -7,6 +7,48 @@ from . import utils
 
 
 @pytest.mark.parametrize(
+    "test_params",
+    [
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-rpm",
+                ref="3956e4d095920b3f06b861dbc778a520fdb89fd2",
+                packages=({"path": ".", "type": "rpm"},),
+                flags=["--dev-package-managers"],
+                check_output=True,
+                check_deps_checksums=False,
+                check_vendor_checksums=False,
+                expected_exit_code=0,
+            ),
+            id="rpm_missing_checksums",
+        ),
+    ],
+)
+def test_rpm_packages(
+    test_params: utils.TestParameters,
+    cachi2_image: utils.ContainerImage,
+    tmp_path: Path,
+    test_data_dir: Path,
+    request: pytest.FixtureRequest,
+) -> None:
+    """
+    Test fetched dependencies for RPMs.
+
+    :param test_params: Test case arguments
+    :param tmp_path: Temp directory for pytest
+    """
+    test_case = request.node.callspec.id
+
+    source_folder = utils.clone_repository(
+        test_params.repo, test_params.ref, f"{test_case}-source", tmp_path
+    )
+
+    utils.fetch_deps_and_check_output(
+        tmp_path, test_case, test_params, source_folder, test_data_dir, cachi2_image
+    )
+
+
+@pytest.mark.parametrize(
     "test_params, check_cmd, expected_cmd_output",
     [
         # Test case that checks fetching RPM files, generating repos and repofiles, building an


### PR DESCRIPTION
This PR introduces 3 integration test scenarios to cover the RPM prefetch functionality:
- Missing checksums
- Invalid checksum
- Invalid file size

For more details on these scenarios, refer to the [design document](https://github.com/containerbuildsystem/cachi2/discussions/516).

The remaining scenarios will be added in a follow up PR.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)