### PR TITLE
tests: unit: package_managers: yarn: Fix mock assert called_once

### DIFF
--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -325,7 +325,7 @@ def test_set_yarnrc_configuration(
     }
 
     assert yarn_rc._data == expected_data
-    assert mock_write.called_once()
+    mock_write.assert_called_once()
 
 
 def test_verify_yarnrc_paths() -> None:


### PR DESCRIPTION
Python 3.12 (not officially supported by cachi2) fails on the
    test_main.py::test_set_yarnrc_configuration

unit tests with the following error:
    AttributeError: 'called_once' is not a valid assertion. Use a spec
    for the mock if 'called_once' is meant to be an attribute.

Indeed, the proper way of handling this assertion is:
    mock_obj.assert_called_once()

Relates to:  https://github.com/containerbuildsystem/cachi2/issues/536

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [n/a] Docs updated (if applicable)
- [n/a] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
