### PR TITLE
Support configurable index urls for pip and private registry auth (not just) for pip

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -99,8 +99,11 @@ jobs:
     name: Build Cachi2 image and run integration tests on it
     runs-on: ubuntu-latest
     container:
-      image: registry.fedoraproject.org/fedora:37
+      image: registry.fedoraproject.org/fedora:40
       options: --privileged
+      volumes:
+      # https://github.com/containers/buildah/issues/3666
+      - /var/lib/containers:/var/lib/containers
 
     steps:
       - name: Install required packages
@@ -127,5 +130,6 @@ jobs:
       - name: Run integration tests on built image
         env:
           CACHI2_IMAGE: localhost/cachi2:${{ github.sha }}
+          CACHI2_TEST_LOCAL_PYPISERVER: 'true'
         run: |
-           tox -e integration
+          tox -e integration

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PYTHON_VERSION_VENV ?= python3
 TOX_ENVLIST ?= py39
 TOX_ARGS ?=
+GENERATE_TEST_DATA = false
 
 .PHONY: clean
 all: venv
@@ -29,13 +30,13 @@ test-unit: venv
 	venv/bin/tox -e $(TOX_ENVLIST) -- $(TOX_ARGS)
 
 test-integration: venv
-	venv/bin/tox -e integration
+	CACHI2_GENERATE_TEST_DATA=$(GENERATE_TEST_DATA) venv/bin/tox -e integration
 
 mock-unittest-data:
 	hack/mock-unittest-data/gomod.sh
 
-generate-test-data: venv
-	CACHI2_GENERATE_TEST_DATA=true venv/bin/tox -e integration
+generate-test-data: GENERATE_TEST_DATA = true
+generate-test-data: test-integration
 
 build-image:
 	podman build -t localhost/cachi2:latest .

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test-unit: venv
 test-integration: venv
 	CACHI2_GENERATE_TEST_DATA=$(GENERATE_TEST_DATA) \
 	CACHI2_TEST_LOCAL_PYPISERVER=$(TEST_LOCAL_PYPISERVER) \
-		venv/bin/tox -e integration
+		venv/bin/tox -e integration -- $(TOX_ARGS)
 
 mock-unittest-data:
 	hack/mock-unittest-data/gomod.sh

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PYTHON_VERSION_VENV ?= python3
 TOX_ENVLIST ?= py39
 TOX_ARGS ?=
 GENERATE_TEST_DATA = false
+TEST_LOCAL_PYPISERVER = false
 
 .PHONY: clean
 all: venv
@@ -30,7 +31,9 @@ test-unit: venv
 	venv/bin/tox -e $(TOX_ENVLIST) -- $(TOX_ARGS)
 
 test-integration: venv
-	CACHI2_GENERATE_TEST_DATA=$(GENERATE_TEST_DATA) venv/bin/tox -e integration
+	CACHI2_GENERATE_TEST_DATA=$(GENERATE_TEST_DATA) \
+	CACHI2_TEST_LOCAL_PYPISERVER=$(TEST_LOCAL_PYPISERVER) \
+		venv/bin/tox -e integration
 
 mock-unittest-data:
 	hack/mock-unittest-data/gomod.sh

--- a/README.md
+++ b/README.md
@@ -233,11 +233,19 @@ In short, tox passes all arguments to the right of `--` directly to pytest.
 
 ### Running integration tests
 
-Build Cachi2 image (localhost/cachi2:latest) and run all integration tests:
+Build Cachi2 image (localhost/cachi2:latest) and run most integration tests:
 
 ```shell
 make test-integration
 ```
+
+Run tests which requires a local PyPI server as well:
+
+```shell
+make test-integration TEST_LOCAL_PYPISERVER=true
+```
+
+Note: while developing, you can run the PyPI server with `tests/pypiserver/start.sh &`.
 
 To run integration-tests with custom image, specify the CACHI2\_IMAGE environment variable. Examples:
 

--- a/cachi2/core/package_managers/general.py
+++ b/cachi2/core/package_managers/general.py
@@ -117,7 +117,10 @@ async def async_download_files(
     num_attempts: int = int(DEFAULT_RETRY_OPTIONS["total"])
     retry_options = aiohttp_retry.JitterRetry(attempts=num_attempts, retry_all_server_errors=True)
     retry_client = aiohttp_retry.RetryClient(
-        retry_options=retry_options, trace_configs=[trace_config]
+        retry_options=retry_options,
+        trace_configs=[trace_config],
+        # respect proxy settings and .netrc
+        trust_env=True,
     )
 
     async with retry_client as session:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,8 +1,13 @@
+import contextlib
 import logging
 import os
+import subprocess
+import time
 from pathlib import Path
+from typing import Iterator
 
 import pytest
+import requests
 
 from . import utils
 
@@ -16,7 +21,7 @@ def test_data_dir() -> Path:
 
 
 @pytest.fixture(scope="session")
-def cachi2_image() -> utils.ContainerImage:
+def cachi2_image() -> utils.Cachi2Image:
     cachi2_image_ref = os.environ.get("CACHI2_IMAGE")
     if not cachi2_image_ref:
         cachi2_image_ref = "localhost/cachi2:latest"
@@ -28,8 +33,39 @@ def cachi2_image() -> utils.ContainerImage:
         cachi2_repo_root = Path(__file__).parents[2]
         utils.build_image(cachi2_repo_root, tag=cachi2_image_ref)
 
-    cachi2 = utils.ContainerImage(cachi2_image_ref)
+    cachi2 = utils.Cachi2Image(cachi2_image_ref)
     if not cachi2_image_ref.startswith("localhost/"):
         cachi2.pull_image()
 
     return cachi2
+
+
+# autouse=True: It's nicer to see the pypiserver setup logs at the beginning of the test suite.
+# Otherwise, pypiserver would start once the pip tests need it and the logs would be buried between
+# test output.
+@pytest.fixture(autouse=True, scope="session")
+def local_pypiserver() -> Iterator[None]:
+    if os.getenv("CACHI2_TEST_LOCAL_PYPISERVER") != "true":
+        yield
+        return
+
+    pypiserver_dir = Path(__file__).parent.parent / "pypiserver"
+
+    with contextlib.ExitStack() as context:
+        proc = context.enter_context(subprocess.Popen([pypiserver_dir / "start.sh"]))
+        context.callback(proc.terminate)
+
+        pypiserver_port = os.getenv("PYPISERVER_PORT", "8080")
+        for _ in range(60):
+            time.sleep(1)
+            try:
+                resp = requests.get(f"http://localhost:{pypiserver_port}")
+                resp.raise_for_status()
+                log.debug(resp.text)
+                break
+            except requests.RequestException as e:
+                log.debug(e)
+        else:
+            raise RuntimeError("pypiserver didn't start fast enough")
+
+        yield

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,16 +19,17 @@ def test_data_dir() -> Path:
 def cachi2_image() -> utils.ContainerImage:
     cachi2_image_ref = os.environ.get("CACHI2_IMAGE")
     if not cachi2_image_ref:
+        cachi2_image_ref = "localhost/cachi2:latest"
         log.info("Building local cachi2:latest image")
         log.info("To skip this step, pass a CACHI2_IMAGE=<image-ref> environment variable, e.g.:")
         log.info("    CACHI2_IMAGE=localhost/cachi2:latest tox -e integration")
         # <arbitrary_path>/cachi2/tests/integration/conftest.py
         #                   [2] <- [1]  <-  [0]  <- parents
         cachi2_repo_root = Path(__file__).parents[2]
-        cachi2 = utils.build_image(cachi2_repo_root, tag="localhost/cachi2:latest")
-    else:
-        cachi2 = utils.ContainerImage(cachi2_image_ref)
-        if not cachi2_image_ref.startswith("localhost/"):
-            cachi2.pull_image()
+        utils.build_image(cachi2_repo_root, tag=cachi2_image_ref)
+
+    cachi2 = utils.ContainerImage(cachi2_image_ref)
+    if not cachi2_image_ref.startswith("localhost/"):
+        cachi2.pull_image()
 
     return cachi2

--- a/tests/integration/test_data/pip_custom_index/.build-config.yaml
+++ b/tests/integration/test_data/pip_custom_index/.build-config.yaml
@@ -1,0 +1,6 @@
+environment_variables:
+- name: PIP_FIND_LINKS
+  value: ${output_dir}/deps/pip
+- name: PIP_NO_INDEX
+  value: 'true'
+project_files: []

--- a/tests/integration/test_data/pip_custom_index/bom.json
+++ b/tests/integration/test_data/pip_custom_index/bom.json
@@ -1,0 +1,42 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "cachi2-pip-custom-index",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:pypi/cachi2-pip-custom-index?vcs_url=git%2Bhttps://github.com/cachito-testing/cachi2-pip-custom-index.git%404d6fe87e62b984cf420e6c8377821a76895b72a8",
+      "type": "library"
+    },
+    {
+      "name": "requests",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        },
+        {
+          "name": "cachi2:pip:package:binary",
+          "value": "true"
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.32.3?repository_url=http://localhost:8080/simple/",
+      "type": "library",
+      "version": "2.32.3"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "name": "cachi2",
+        "vendor": "red hat"
+      }
+    ]
+  },
+  "specVersion": "1.4",
+  "version": 1
+}

--- a/tests/integration/test_data/pip_custom_index/fetch_deps_sha256sums.json
+++ b/tests/integration/test_data/pip_custom_index/fetch_deps_sha256sums.json
@@ -1,0 +1,4 @@
+{
+  "pip/requests-2.32.3-py3-none-any.whl": "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6",
+  "pip/requests-2.32.3.tar.gz": "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"
+}

--- a/tests/integration/test_pip.py
+++ b/tests/integration/test_pip.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from typing import List
 
@@ -119,6 +120,21 @@ log = logging.getLogger(__name__)
                 expected_output="Error: PackageRejected: No distributions found",
             ),
             id="pip_no_sdists",
+        ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-pip-custom-index.git",
+                ref="4d6fe87e62b984cf420e6c8377821a76895b72a8",
+                packages=({"path": ".", "type": "pip", "allow_binary": True},),
+                check_vendor_checksums=False,
+                expected_exit_code=0,
+                expected_output="All dependencies fetched successfully",
+            ),
+            id="pip_custom_index",
+            marks=pytest.mark.skipif(
+                os.getenv("CACHI2_TEST_LOCAL_PYPISERVER") != "true",
+                reason="CACHI2_TEST_LOCAL_PYPISERVER!=true",
+            ),
         ),
     ],
 )

--- a/tests/pypiserver/package-urls.txt
+++ b/tests/pypiserver/package-urls.txt
@@ -1,0 +1,3 @@
+# curl https://pypi.org/simple/requests/ | sed -nr 's/.*href="([^"]*requests-2\.32\.3[.-][^"]*)".*/\1/p'
+https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl#sha256=70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
+https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz#sha256=55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760

--- a/tests/pypiserver/start.sh
+++ b/tests/pypiserver/start.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+
+DEFAULT_IMAGE=docker.io/pypiserver/pypiserver:v2.1.1@sha256:17198f668ef4f460ee81456f09fc65d352766fa9e49a81474304c5aa69b8be38
+DEFAULT_PORT=8080
+
+cleanup() {
+    rm -r "$WORKDIR" || true
+    podman volume rm -f --time 0 cachi2-pypiserver-packages >/dev/null || true
+    podman volume rm -f --time 0 cachi2-pypiserver-auth >/dev/null || true
+}
+
+WORKDIR=$(mktemp -d --tmpdir "cachi2-pypiserver.XXXXXX")
+trap cleanup EXIT
+
+setup() {
+    echo -e "\n--- Downloading $DIR/package-urls.txt ---\n"
+
+    mkdir "$WORKDIR/packages"
+    sed '/^#/d' "$DIR/package-urls.txt" |
+        xargs curl --fail --remote-name-all --output-dir "$WORKDIR/packages"
+
+    echo -e "\n--- Setting cachi2-user:cachi2-pass authentication ---\n"
+
+    mkdir "$WORKDIR/auth"
+    # Content based on htpasswd -b -c .htpasswd cachi2-user cachi2-pass; cat .htpasswd
+    # shellcheck disable=SC2016
+    echo 'cachi2-user:$apr1$ChHgbvcg$l1QSrRehMhD0XOjj9ruem/' > "$WORKDIR/auth/.htpasswd"
+
+    echo -e "\n--- Creating podman volumes ---\n"
+
+    # Note: it's not strictly necessary to create these volumes, we could mount the content
+    # straight from the $WORKDIR. But pypiserver chowns the packages, making it impossible
+    # for this script to fully clean up after itself. Using podman volumes avoids that.
+
+    echo "Importing content of $WORKDIR/packages: cachi2-pypiserver-packages"
+    podman volume create --ignore cachi2-pypiserver-packages >/dev/null
+    ls -lA "$WORKDIR/packages"
+    tar cf - -C "$WORKDIR/packages" . | podman volume import cachi2-pypiserver-packages -
+
+    echo "Importing content of $WORKDIR/auth: cachi2-pypiserver-auth"
+    podman volume create --ignore cachi2-pypiserver-auth >/dev/null
+    ls -lA "$WORKDIR/auth"
+    tar cf - -C "$WORKDIR/auth" . | podman volume import cachi2-pypiserver-auth -
+
+    echo -e "\n--- Starting pypiserver on http://localhost:${PYPISERVER_PORT:-8080} ---\n"
+}
+
+setup >&2
+
+podman run --rm --replace --name cachi2-pypiserver \
+    -v cachi2-pypiserver-packages:/data/packages \
+    -v cachi2-pypiserver-auth:/data/auth \
+    -p "${PYPISERVER_PORT:-$DEFAULT_PORT}":8080 \
+    "${PYPISERVER_IMAGE:-$DEFAULT_IMAGE}" \
+        run \
+        --passwords /data/auth/.htpasswd \
+        --authenticate update,download,list \
+        --disable-fallback \
+        /data/packages

--- a/tox.ini
+++ b/tox.ini
@@ -62,12 +62,18 @@ commands =
 passenv =
     CACHI2_GENERATE_TEST_DATA
     CACHI2_IMAGE
+    CACHI2_TEST_LOCAL_PYPISERVER
+    PYPISERVER_IMAGE
+    PYPISERVER_PORT
+setenv =
+    CACHI2_TEST_NETRC_CONTENT={env:CACHI2_TEST_NETRC_CONTENT:machine localhost login cachi2-user password cachi2-pass}
 basepython = python3
 skip_install = true
 commands =
     pytest -rA -vvvv \
       --confcutdir=tests/integration \
       --log-cli-level=DEBUG \
+      --capture=tee-sys \
       tests/integration \
       {posargs}
 allowlist_externals = rm


### PR DESCRIPTION
TLDR:

* `--index-url` in requirements.txt is no longer ignored
* If the index url is anything other than https://pypi.org/simple/, report it in the SBOM
* Tell aiohttp not to ignore `.netrc`
* Add way to run local PyPI server that requires auth, add integration test that uses it

Run new test with:

```shell
make test-integration TEST_LOCAL_PYPISERVER=true TOX_ARGS='-k custom_index'
```

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
