### PR TITLE
stop exposing git credentials in SBOM

### DIFF
--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -24,6 +24,11 @@ class TestRepoID:
             # no-op
             ("ssh://user@git.host.com/some/path", "ssh://user@git.host.com/some/path"),
             ("https://git.host.com/some/path", "https://git.host.com/some/path"),
+            # credentials
+            (
+                "https://student:redhat@github.com/student/cachi2.git",
+                "https://github.com/student/cachi2.git",
+            ),
             # unsupported
             (
                 "./foo:bar",


### PR DESCRIPTION
if git origin url contains credentials for
auth, remove them from url so they will not
appear in PURL in SBOM

closes [#521](https://github.com/containerbuildsystem/cachi2/issues/521)

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
