### PR TITLE
Improve the integration tests to cover Go workspace version tags

### DIFF
--- a/tests/integration/test_data/gomod_workspaces/bom.json
+++ b/tests/integration/test_data/gomod_workspaces/bom.json
@@ -31,9 +31,9 @@
           "value": "cachi2"
         }
       ],
-      "purl": "pkg:golang/github.com/cachito-testing/cachi2-gomod/workspace_modules/echo@v4.0.0-20240522074442-449f904ecf26?type=module",
+      "purl": "pkg:golang/github.com/cachito-testing/cachi2-gomod/workspace_modules/echo@v4.2.0?type=module",
       "type": "library",
-      "version": "v4.0.0-20240522074442-449f904ecf26"
+      "version": "v4.2.0"
     },
     {
       "name": "example.com/hello",
@@ -43,9 +43,9 @@
           "value": "cachi2"
         }
       ],
-      "purl": "pkg:golang/github.com/cachito-testing/cachi2-gomod/workspace_modules/hello@v0.0.0-20240522074442-449f904ecf26?type=module",
+      "purl": "pkg:golang/github.com/cachito-testing/cachi2-gomod/workspace_modules/hello@v1.1.0?type=module",
       "type": "library",
-      "version": "v0.0.0-20240522074442-449f904ecf26"
+      "version": "v1.1.0"
     },
     {
       "name": "example.com/hello",
@@ -55,9 +55,9 @@
           "value": "cachi2"
         }
       ],
-      "purl": "pkg:golang/github.com/cachito-testing/cachi2-gomod/workspace_modules/hello@v0.0.0-20240522074442-449f904ecf26?type=package",
+      "purl": "pkg:golang/github.com/cachito-testing/cachi2-gomod/workspace_modules/hello@v1.1.0?type=package",
       "type": "library",
-      "version": "v0.0.0-20240522074442-449f904ecf26"
+      "version": "v1.1.0"
     },
     {
       "name": "example.com/hiii",
@@ -67,9 +67,9 @@
           "value": "cachi2"
         }
       ],
-      "purl": "pkg:golang/github.com/cachito-testing/cachi2-gomod/workspace_modules/hi/hiii@v0.0.0-20240522074442-449f904ecf26?type=module",
+      "purl": "pkg:golang/github.com/cachito-testing/cachi2-gomod/workspace_modules/hi/hiii@v1.2.0?type=module",
       "type": "library",
-      "version": "v0.0.0-20240522074442-449f904ecf26"
+      "version": "v1.2.0"
     },
     {
       "name": "github.com/davecgh/go-spew",


### PR DESCRIPTION
In Golang, the tags applied to the repository are used to determine the module's version, and they can be applied individually for submodules (or workspaces).

This commit changes the expected data for the existing gomod workspaces integration test to match the newly pushed tags to the [test repository](https://github.com/cachito-testing/cachi2-gomod/tree/go_workspaces):

```
workspace_modules/echo/v4.2.0
workspace_modules/hello/v1.1.0
workspace_modules/hi/hiii/v1.2.0
```

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)