### PR TITLE
Fix our go.mod version string parser regex pattern

### DIFF
--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -692,13 +692,17 @@ def _get_gomod_version(go_mod_file: RootedPath) -> Tuple[Optional[str], Optional
     toolchain_pattern = re.compile(toolchain_version_regex)
 
     with open(go_mod_file) as f:
-        for line in f:
+        for i, line in enumerate(f):
             if not go_version and (match := re.match(go_pattern, line)):
                 go_version = match.group("ver")
+                log.debug("Matched Go version %s on go.mod line %d: '%s'", go_version, i, line)
                 continue
 
             if not toolchain_version and (match := re.match(toolchain_pattern, line)):
                 toolchain_version = match.group("ver")
+                log.debug(
+                    "Matched toolchain %s on go.mod line %d: '%s'", toolchain_version, i, line
+                )
                 continue
 
     return (go_version, toolchain_version)

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -678,9 +678,15 @@ def _get_gomod_version(go_mod_file: RootedPath) -> Tuple[Optional[str], Optional
     go_version = None
     toolchain_version = None
 
-    version_str_regex = r"(?P<ver>\d+\.\d+(:?\.\d+)?)"
-    go_version_regex = rf"^\s*go\s+{version_str_regex}\s*$"
-    toolchain_version_regex = rf"^\s*toolchain\s+go{version_str_regex}\s*$"
+    # this needs to be able to handle arbitrary pre-release version identifiers and commentaries
+    # as well, since Go itself can parse it
+    # - 'go 1.21.0'
+    # - '   go 1.21.0rc4'
+    # - 'go 1.21beta1//commentary'
+    version_str_regex = r"(?P<ver>\d+\.\d+(:?\.\d+)?(?:[a-zA-Z]+\d+)?)"
+    post_version_chars_regex = r"\s*(?:\/\/.*)?"
+    go_version_regex = rf"^\s*go\s+{version_str_regex}{post_version_chars_regex}$"
+    toolchain_version_regex = rf"^\s*toolchain\s+go{version_str_regex}{post_version_chars_regex}$"
 
     go_pattern = re.compile(go_version_regex)
     toolchain_pattern = re.compile(toolchain_version_regex)

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -750,22 +750,22 @@ def _setup_go_toolchain(go_mod_file: RootedPath) -> Go:
     target_version = None
     go_max_version = version.Version("1.21")
     go_base_version = go.version
-    go_mod_version_msg = "go.mod reported versions: '{}'[go], '{}'[toolchain]"
+    go_mod_version_msg = "go.mod reported versions: '%s'[go], '%s'[toolchain]"
 
     go_version_str, toolchain_version_str = _get_gomod_version(go_mod_file)
+    log.info(
+        go_mod_version_msg,
+        go_version_str if go_version_str else "-",
+        toolchain_version_str if toolchain_version_str else "-",
+    )
+
     if not go_version_str:
         # Go added the 'go' directive to go.mod in 1.12 [1]. If missing, 1.16 is assumed [2].
         # For our version comparison purposes we set the version explicitly to 1.20 if missing.
         # [1] https://go.dev/doc/go1.12#modules
         # [2] https://go.dev/ref/mod#go-mod-file-go
         go_version_str = "1.20"
-        go_mod_version_msg += " (cachi2 enforced)"
-
-    log.info(
-        go_mod_version_msg.format(
-            go_version_str, toolchain_version_str if toolchain_version_str else "-"
-        )
-    )
+        log.debug("Could not parse Go version from go.mod, using %s as fallback", go_version_str)
 
     if not toolchain_version_str:
         toolchain_version_str = go_version_str

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -664,6 +664,7 @@ def _get_repository_name(source_dir: RootedPath) -> str:
     return f"{url.hostname}{url.path.rstrip('/').removesuffix('.git')}"
 
 
+# NOTE: get rid of this go.mod parser once we can assume Go > 1.21 (1.20 can't parse micro release)
 def _get_gomod_version(go_mod_file: RootedPath) -> Tuple[Optional[str], Optional[str]]:
     """Return the required/recommended version of Go from go.mod.
 
@@ -677,8 +678,9 @@ def _get_gomod_version(go_mod_file: RootedPath) -> Tuple[Optional[str], Optional
     go_version = None
     toolchain_version = None
 
-    go_version_regex = r"^\s*go\s+(?P<ver>\d+\.\d+(:?\.\d+)?)\s*$"
-    toolchain_version_regex = r"^\s*toolchain\s+go(?P<ver>\d+\.\d+(:?\.\d+)?)\s*$"
+    version_str_regex = r"(?P<ver>\d+\.\d+(:?\.\d+)?)"
+    go_version_regex = rf"^\s*go\s+{version_str_regex}\s*$"
+    toolchain_version_regex = rf"^\s*toolchain\s+go{version_str_regex}\s*$"
 
     go_pattern = re.compile(go_version_regex)
     toolchain_pattern = re.compile(toolchain_version_regex)

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -677,8 +677,8 @@ def _get_gomod_version(go_mod_file: RootedPath) -> Tuple[Optional[str], Optional
     go_version = None
     toolchain_version = None
 
-    go_version_regex = r"^\s*go\s+(?P<ver>\d\.\d+(:?\.\d+)?)\s*$"
-    toolchain_version_regex = r"^\s*toolchain\s+go(?P<ver>\d\.\d+(:?\.\d+)?)\s*$"
+    go_version_regex = r"^\s*go\s+(?P<ver>\d+\.\d+(:?\.\d+)?)\s*$"
+    toolchain_version_regex = r"^\s*toolchain\s+go(?P<ver>\d+\.\d+(:?\.\d+)?)\s*$"
 
     go_pattern = re.compile(go_version_regex)
     toolchain_pattern = re.compile(toolchain_version_regex)

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1930,6 +1930,11 @@ def test_fetch_tags_fail(repo_remote_with_tag: tuple[RootedPath, RootedPath]) ->
         pytest.param("go 1.21", "1.21", None, id="go_minor"),
         pytest.param("go 1.21.0", "1.21.0", None, id="go_micro"),
         pytest.param("    go    1.21.4    ", "1.21.4", None, id="go_spaces"),
+        pytest.param("go 1.21rc4", "1.21rc4", None, id="go_minor_rc"),
+        pytest.param("go 1.21.0rc4", "1.21.0rc4", None, id="go_micro_rc"),
+        pytest.param("go 1.21.0  // comment", "1.21.0", None, id="go_commentary"),
+        pytest.param("go 1.21.0//commentary", "1.21.0", None, id="go_commentary_no_spaces"),
+        pytest.param("go 1.21.0beta2//comment", "1.21.0beta2", None, id="go_rc_commentary"),
         pytest.param("   toolchain   go1.21.4  ", None, "1.21.4", id="toolchain_spaces"),
         pytest.param("go 1.21\ntoolchain go1.21.6", "1.21", "1.21.6", id="go_and_toolchain"),
     ],
@@ -1949,6 +1954,8 @@ INVALID_VERSION_STRINGS = [
     "go 1.21.0.100",  # non-conforming to the X.Y(.Z)? versioning template
     "1.21",  # missing 'go' at the beginning
     "go 1.21 foo",  # extra characters after version string
+    "go 1.21prerelease",  # pre-release with no number
+    "go 1.21prerelease_4",  # pre-release with non-alphanum character
     "toolchain 1.21",  # missing 'go' prefix for the toolchain spec
 ]
 

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1930,7 +1930,6 @@ def test_fetch_tags_fail(repo_remote_with_tag: tuple[RootedPath, RootedPath]) ->
         pytest.param("go 1.21", "1.21", None, id="no_toolchain"),
         pytest.param("    go    1.21.4    ", "1.21.4", None, id="whitechars_no_toolchain"),
         pytest.param("   toolchain   go1.21.4  ", None, "1.21.4", id="whitechars_toolchain"),
-        pytest.param("toolchain go1.21", None, "1.21", id="toolchain_missing_micro_version"),
         pytest.param("go 1.21\ntoolchain go1.21.6", "1.21", "1.21.6", id="go_and_toolchain"),
     ],
     indirect=["go_mod_file"],

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1927,9 +1927,9 @@ def test_fetch_tags_fail(repo_remote_with_tag: tuple[RootedPath, RootedPath]) ->
 @pytest.mark.parametrize(
     "go_mod_file, go_mod_version, go_toolchain_version",
     [
-        pytest.param("go 1.21", "1.21", None, id="no_toolchain"),
-        pytest.param("    go    1.21.4    ", "1.21.4", None, id="whitechars_no_toolchain"),
-        pytest.param("   toolchain   go1.21.4  ", None, "1.21.4", id="whitechars_toolchain"),
+        pytest.param("go 1.21", "1.21", None, id="go_minor"),
+        pytest.param("    go    1.21.4    ", "1.21.4", None, id="go_spaces"),
+        pytest.param("   toolchain   go1.21.4  ", None, "1.21.4", id="toolchain_spaces"),
         pytest.param("go 1.21\ntoolchain go1.21.6", "1.21", "1.21.6", id="go_and_toolchain"),
     ],
     indirect=["go_mod_file"],

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1928,6 +1928,7 @@ def test_fetch_tags_fail(repo_remote_with_tag: tuple[RootedPath, RootedPath]) ->
     "go_mod_file, go_mod_version, go_toolchain_version",
     [
         pytest.param("go 1.21", "1.21", None, id="go_minor"),
+        pytest.param("go 1.21.0", "1.21.0", None, id="go_micro"),
         pytest.param("    go    1.21.4    ", "1.21.4", None, id="go_spaces"),
         pytest.param("   toolchain   go1.21.4  ", None, "1.21.4", id="toolchain_spaces"),
         pytest.param("go 1.21\ntoolchain go1.21.6", "1.21", "1.21.6", id="go_and_toolchain"),


### PR DESCRIPTION
We currently don't allow prerelease version identifiers (e.g. beta/rc, etc.) and commentaries on the version string line (e.g. `go 1.21.0//comment`.

This PR mainly fixes a nasty bug where we fell back to picking an older Go version because of ^this which resulted in a very strange error trying to build buildah from git:

```
2024-05-29 15:48:50,010 INFO Fetching the gomod dependencies at subpath buildah
2024-05-29 15:48:50,011 INFO Fetching the gomod dependencies at the "buildah" directory
2024-05-29 15:48:52,913 INFO go.mod reported versions: '1.20'[go], '-'[toolchain] (cachi2 enforced)
2024-05-29 15:48:52,927 INFO Using Go release: go1.20
2024-05-29 15:48:52,928 INFO Vendoring the gomod dependencies
2024-05-29 15:49:17,954 INFO Retrieving the list of packages
2024-05-29 15:49:23,014 ERROR RuntimeError: Package parent module was not found
Traceback (most recent call last):
```

even though buildah uses 1.21 already. This PR also updates some unit tests and adds debug logs to keep better track of dealing with version string parsing.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
