### PR TITLE
merge_syft_sbom: Handle missing components for the syft sbom

### DIFF
--- a/utils/merge_syft_sbom.py
+++ b/utils/merge_syft_sbom.py
@@ -163,7 +163,7 @@ def merge_sboms(cachi2_sbom_path: str, syft_sbom_path: str) -> str:
     is_duplicate_component = _get_syft_component_filter(cachi2_sbom["components"])
 
     filtered_syft_components = [
-        component for component in syft_sbom["components"] if not is_duplicate_component(component)
+        c for c in syft_sbom.get("components", []) if not is_duplicate_component(c)
     ]
 
     syft_sbom["components"] = filtered_syft_components + cachi2_sbom["components"]


### PR DESCRIPTION
When Syft scans an image and doesn't find any components, it generates a SBOM without a "components" property (this is valid according to the CycloneDX spec.)

Log file snippet:

```
[merge-cachi2-sbom] Merging contents of sbom-cachi2.json into sbom-cyclonedx.json
[merge-cachi2-sbom] Traceback (most recent call last):
[merge-cachi2-sbom]   File "/src/utils/merge_syft_sbom.py", line 184, in <module>
[merge-cachi2-sbom]     merged_sbom = merge_sboms(args.cachi2_sbom_path, args.syft_sbom_path)
[merge-cachi2-sbom]   File "/src/utils/merge_syft_sbom.py", line 166, in merge_sboms
[merge-cachi2-sbom]     component for component in syft_sbom["components"] if not is_duplicate_component(component)
[merge-cachi2-sbom] KeyError: 'components'
```

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
