### PR TITLE
Code QL fixes reported under the 'Security' tab

### DIFF
--- a/cachi2/core/package_managers/yarn/resolver.py
+++ b/cachi2/core/package_managers/yarn/resolver.py
@@ -285,6 +285,8 @@ class _ComponentResolver:
 
         locator = package.parsed_locator
         checksum = package.checksum
+        name = None
+        version = None
 
         if isinstance(locator, NpmLocator):
             # npm dependencies have reliable names and versions in yarn info output

--- a/tests/unit/package_managers/conftest.py
+++ b/tests/unit/package_managers/conftest.py
@@ -1,5 +1,4 @@
 import copy
-import os
 import tempfile
 from pathlib import Path
 from typing import Any, Generator, Optional, Union
@@ -195,10 +194,10 @@ def fake_repo() -> Generator[tuple[Union[str, bytes], Union[str, bytes]], Any, N
         r = git.Repo.init(repo_dir)
         r.git.config("user.name", "tester")
         r.git.config("user.email", "tester@localhost")
-        open(os.path.join(repo_dir, "readme.rst"), "w").close()
+        Path(repo_dir, "readme.rst").touch()
         r.index.add(["readme.rst"])
         r.index.commit("first commit", skip_hooks=True)
-        open(os.path.join(repo_dir, "main.py"), "w").close()
+        Path(repo_dir, "main.py").touch()
         r.index.add(["main.py"])
         r.index.commit("add main source", skip_hooks=True)
         yield repo_dir, repo_dir.lstrip("/")

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -6,7 +6,6 @@ import subprocess
 import textwrap
 from pathlib import Path
 from string import Template
-from textwrap import dedent
 from typing import Any, Iterator, Optional, Tuple, Union
 from unittest import mock
 
@@ -418,7 +417,7 @@ def test_resolve_gomod_no_deps(
 ) -> None:
     module_path = gomod_request.source_dir.join_within_root("path/to/module")
 
-    mock_pkg_deps_no_deps = dedent(
+    mock_pkg_deps_no_deps = textwrap.dedent(
         """
         {
             "ImportPath": "github.com/release-engineering/retrodep/v2",
@@ -528,7 +527,7 @@ def test_resolve_gomod_suspicious_symlinks(symlinked_file: str, gomod_request: R
         (None, set()),
         ("", set()),
         (
-            dedent(
+            textwrap.dedent(
                 """
                 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
 
@@ -565,7 +564,7 @@ def test_parse_go_sum(
 
 
 def test_parse_broken_go_sum(rooted_tmp_path: RootedPath, caplog: pytest.LogCaptureFixture) -> None:
-    go_sum_content = dedent(
+    go_sum_content = textwrap.dedent(
         """\
         github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
         github.com/davecgh/go-spew v1.1.0/go.mod
@@ -626,7 +625,7 @@ def test_parse_local_modules(go: mock.Mock, version_resolver: mock.Mock) -> None
     (
         pytest.param(
             "/home/my-projects/simple-project",
-            dedent(
+            textwrap.dedent(
                 """
                 {
                     "Path": "github.com/my-org/simple-project",
@@ -651,7 +650,7 @@ def test_parse_local_modules(go: mock.Mock, version_resolver: mock.Mock) -> None
         ),
         pytest.param(
             "/home/my-projects/project-with-workspaces",
-            dedent(
+            textwrap.dedent(
                 """
                 {
                     "Path": "github.com/my-org/project-with-workspaces",


### PR DESCRIPTION
This PR dabs at fixing the Code QL issues reported under the 'Security' tab. Most (if not all) are false positives anyway, but let's make Code QL happy for a while.
The reported problem with `tar.extractall` will remain even after this PR because Code QL doesn't see past the immediate context at the end of its nose and so it doesn't see that we kinda validated the TAR members before extraction. It probably wants to see us applying the new `filter=` argument, but that's Python 3.12 only material [1] and so we'll have to dismiss that alert manually, besides it's reported against the unit tests so the naive solution proposed here should be good enough to catch test issues early.

[1] https://docs.python.org/3.12/library/tarfile.html#tarfile.TarFile.extractall

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
