### PR TITLE
Dockerfile: Inject merge_syft_sbom script to /usr/local/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ COPY --from=golang_121 /usr/local/go /usr/local/go/go1.21
 COPY --from=node_223 /usr/local/lib/node_modules/corepack /usr/local/lib/corepack
 COPY --from=node_223 /usr/local/bin/node /usr/local/bin/node
 COPY --from=builder /venv /venv
+COPY --from=builder /src/utils/merge_syft_sbom.py /usr/local/bin/merge_syft_sbom
 
 # link corepack, yarn, and go to standard PATH location
 RUN ln -s /usr/local/lib/corepack/dist/corepack.js /usr/local/bin/corepack && \


### PR DESCRIPTION
When commit 49ba69d0 converted the image build to multi-stage it forgot to install the merge_syft_sbom.py utility script that was previously installed as part of copying the whole repo into the image to /src/utils/merge_syft_sbom.py.
This patch takes a bit of a different path by installing the script as a utility binary to a more standardized location.

Fixes: 49ba69d0de05addbca966b683f75f8a71fcbd1c1
Resolves: https://github.com/containerbuildsystem/cachi2/issues/582

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
