### PR TITLE
Preliminary support for Go 1.22

### DIFF
--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -758,6 +758,7 @@ def _find_missing_gomod_files(source_path: RootedPath, subpaths: list[str]) -> l
 
 
 def _setup_go_toolchain(go_mod_file: RootedPath) -> Go:
+    GO_121 = version.Version("1.21")
     go = Go()
     target_version = None
     go_max_version = version.Version("1.21")
@@ -799,13 +800,13 @@ def _setup_go_toolchain(go_mod_file: RootedPath) -> Go:
             ),
         )
 
-    if target_version >= go_max_version:
+    if target_version >= GO_121:
         # Project makes use of Go >=1.21:
         # - always use the 'X.Y.0' toolchain to make sure GOTOOLCHAIN=auto fetches anything newer
         # - container environments need to have it pre-installed
         # - local environments will always install 1.21.0 SDK and then pull any newer toolchain
         go = Go(release="go1.21.0")
-    elif go_base_version >= go_max_version:
+    elif go_base_version >= GO_121:
         # Starting with Go 1.21, Go doesn't try to be semantically backwards compatible in that the
         # 'go X.Y' line now denotes the minimum required version of Go, no a "suggested" version.
         # What it means in practice is that a Go toolchain >= 1.21 enforces the biggest common

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -1011,7 +1011,7 @@ def _get_go_work_path(app_dir: RootedPath) -> Optional[RootedPath]:
     go = Go()
     go_work_file = go(["env", "GOWORK"], {"cwd": app_dir}).rstrip()
 
-    if not go_work_file:
+    if not go_work_file or go_work_file == "off":
         return None
 
     go_work_path = Path(go_work_file).parent

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -798,6 +798,7 @@ def test_get_go_sum_files(
     (
         pytest.param(Template("$tmp_path/project"), False, id="go_work_exists"),
         pytest.param(Template(""), True, id="go_work_does_not_exist"),
+        pytest.param(Template("off"), True, id="go_work_disabled"),
     ),
 )
 @mock.patch("cachi2.core.package_managers.gomod.Go.__call__")


### PR DESCRIPTION
This is just very basic support for 1.22 done by a simple version bump (note that the change comes without pre-installing a new version inside the container because that would require more code changes beyond just the Dockerfile).

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
