### PR TITLE
cachi2 coverage

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -25,37 +25,21 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions
+        pip install tox
+        pip install tox-gh-actions
+
     - name: Test with tox
       run: tox
-    - name: Run coveralls-python
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_FLAG_NAME: python-${{ matrix.python-version }}
-        COVERALLS_PARALLEL: true
-      run: |
-        pip3 install --upgrade pip
-        pip3 install --upgrade setuptools
-        pip3 install --upgrade coverage[toml]
-        pip3 install --upgrade coveralls
-        coveralls --service=github
 
-  coveralls-finish:
-    name: Finish coveralls-python
-    needs: tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Finished
-        run: |
-          pip3 install --upgrade pip
-          pip3 install --upgrade setuptools
-          pip3 install --upgrade coveralls
-          coveralls --finish --service=github
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Upload coverage reports to Codecov
+      if: matrix.python-version == '3.12'
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   linters:
     name: Linters

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cachi2
 
-[![coverage][cachi2-coveralls-badge]][cachi2-coveralls]
+[![coverage][cachi2-coverage-badge]][cachi2-coverage-status]
 [![container][cachi2-container-status]][cachi2-container]
 
 Cachi2 is a CLI tool that pre-fetches your project's dependencies to aid in making your build process
@@ -406,8 +406,8 @@ See [docs/yarn.md](docs/yarn.md) for more details.
 Cachi2 was derived (but is not a direct fork) from [Cachito](https://github.com/containerbuildsystem/cachito) and is
 still in early development phase.
 
-[cachi2-coveralls]: https://coveralls.io/github/containerbuildsystem/cachi2?branch=main
-[cachi2-coveralls-badge]: https://coveralls.io/repos/github/containerbuildsystem/cachi2/badge.svg?branch=main
+[cachi2-coverage-badge]: https://codecov.io/github/containerbuildsystem/cachi2/graph/badge.svg?token=VJKRTZQBMY
+[cachi2-coverage-status]: https://codecov.io/github/containerbuildsystem/cachi2
 [cachi2-container]: https://quay.io/repository/redhat-appstudio/cachi2
 [cachi2-container-status]: https://quay.io/repository/redhat-appstudio/cachi2/status
 [cachi2-releases]: https://github.com/containerbuildsystem/cachi2/releases

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,12 @@
+codecov:
+  notify:
+    wait_for_ci: no
+
+coverage:
+  status:
+    patch: off
+    project:
+      default:
+        target: 90%
+
+comment: off


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
