### PR TITLE
Adding a new merge-sboms sub-command

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,6 +8,7 @@ The second section goes through each of these steps for the supported package ma
   * [pre-fetch dependencies](#pre-fetch-dependencies)
   * [generate environment variables](#generate-environment-variables)
   * [inject project files](#inject-project-files)
+  * [merge SBOMs](#merge-sboms)
   * [building the artifact](#Building-the-artifact-with-the-pre-fetched-dependencies)
     * set the environment variables ([Containerfile example](#write-the-dockerfile-or-containerfile))
     * run the build ([container build example](#build-the-container))
@@ -105,6 +106,26 @@ lose) when calling inject-files.*
 it was previously clean. If any scripting depends on the cleanliness of a git repository and you do not want to commit
 the changes, the scripting should either be changed to handle the dirty status or the changes should be temporarily
 stashed by wrapping in `git stash && <command> && git stash pop` according to the suitability of the context.*
+
+### Merge SBOMs
+
+Sometimes it might be necessary to merge two or more SBOMs. This could be done with `cachi2 merge-sboms`:
+
+```shell
+cachi2 merge-sboms <cachi2_sbom_1.json> ... <cachi2_sbom_n.json>
+```
+
+The subcommand expects at least two SBOMs, all produced by Cachi2, and will exit with error
+otherwise. The reason for this is that Cachi2 supports a
+[limited set](https://github.com/containerbuildsystem/cachi2/blob/main/cachi2/core/models/sbom.py#L7-L13)
+of component [properties](https://cyclonedx.org/docs/1.4/json/#components_items_properties),
+and it validates that no other properties exist in the SBOM. By default the result of a merge
+will be printed to stdout. To save it to a file use `-o` option:
+
+```shell
+cachi2 merge-sboms <cachi2_sbom_1.json> ... <cachi2_sbom_n.json> -o <merged_sbom.json>
+```
+
 
 ### Building the Artifact with the Pre-fetched dependencies
 

--- a/tests/unit/data/sboms/cachito_gomod.bom.json
+++ b/tests/unit/data/sboms/cachito_gomod.bom.json
@@ -1,0 +1,596 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "bytes",
+      "purl": "pkg:golang/bytes?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "errors",
+      "purl": "pkg:golang/errors?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "fmt",
+      "purl": "pkg:golang/fmt?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "github.com/akhmanova/cachito-gomod-test",
+      "purl": "pkg:golang/github.com/cachito-testing/cachito-gomod-test@v0.0.0-20200825151551-1827221d787c?type=module",
+      "version": "v0.0.0-20200825151551-1827221d787c",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "github.com/akhmanova/cachito-gomod-test",
+      "purl": "pkg:golang/github.com/cachito-testing/cachito-gomod-test@v0.0.0-20200825151551-1827221d787c?type=package",
+      "version": "v0.0.0-20200825151551-1827221d787c",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "golang.org/x/text/internal/tag",
+      "purl": "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
+      "version": "v0.0.0-20170915032832-14c0d48ead0c",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "golang.org/x/text/language",
+      "purl": "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
+      "version": "v0.0.0-20170915032832-14c0d48ead0c",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "golang.org/x/text",
+      "purl": "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
+      "version": "v0.0.0-20170915032832-14c0d48ead0c",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/abi",
+      "purl": "pkg:golang/internal/abi?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/bytealg",
+      "purl": "pkg:golang/internal/bytealg?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/coverage/rtcov",
+      "purl": "pkg:golang/internal/coverage/rtcov?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/cpu",
+      "purl": "pkg:golang/internal/cpu?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/fmtsort",
+      "purl": "pkg:golang/internal/fmtsort?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/goarch",
+      "purl": "pkg:golang/internal/goarch?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/goexperiment",
+      "purl": "pkg:golang/internal/goexperiment?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/goos",
+      "purl": "pkg:golang/internal/goos?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/itoa",
+      "purl": "pkg:golang/internal/itoa?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/oserror",
+      "purl": "pkg:golang/internal/oserror?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/poll",
+      "purl": "pkg:golang/internal/poll?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/race",
+      "purl": "pkg:golang/internal/race?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/reflectlite",
+      "purl": "pkg:golang/internal/reflectlite?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/safefilepath",
+      "purl": "pkg:golang/internal/safefilepath?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/syscall/execenv",
+      "purl": "pkg:golang/internal/syscall/execenv?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/syscall/unix",
+      "purl": "pkg:golang/internal/syscall/unix?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/testlog",
+      "purl": "pkg:golang/internal/testlog?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "internal/unsafeheader",
+      "purl": "pkg:golang/internal/unsafeheader?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "io/fs",
+      "purl": "pkg:golang/io/fs?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "io",
+      "purl": "pkg:golang/io?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "math/bits",
+      "purl": "pkg:golang/math/bits?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "math",
+      "purl": "pkg:golang/math?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "os",
+      "purl": "pkg:golang/os?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "path",
+      "purl": "pkg:golang/path?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "reflect",
+      "purl": "pkg:golang/reflect?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "rsc.io/quote",
+      "purl": "pkg:golang/rsc.io/quote@v1.5.2?type=module",
+      "version": "v1.5.2",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "rsc.io/quote",
+      "purl": "pkg:golang/rsc.io/quote@v1.5.2?type=package",
+      "version": "v1.5.2",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "rsc.io/sampler",
+      "purl": "pkg:golang/rsc.io/sampler@v1.3.0?type=module",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "rsc.io/sampler",
+      "purl": "pkg:golang/rsc.io/sampler@v1.3.0?type=package",
+      "version": "v1.3.0",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "runtime/internal/atomic",
+      "purl": "pkg:golang/runtime/internal/atomic?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "runtime/internal/math",
+      "purl": "pkg:golang/runtime/internal/math?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "runtime/internal/sys",
+      "purl": "pkg:golang/runtime/internal/sys?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "runtime/internal/syscall",
+      "purl": "pkg:golang/runtime/internal/syscall?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "runtime",
+      "purl": "pkg:golang/runtime?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "sort",
+      "purl": "pkg:golang/sort?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "strconv",
+      "purl": "pkg:golang/strconv?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "strings",
+      "purl": "pkg:golang/strings?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "sync/atomic",
+      "purl": "pkg:golang/sync/atomic?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "sync",
+      "purl": "pkg:golang/sync?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "syscall",
+      "purl": "pkg:golang/syscall?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "time",
+      "purl": "pkg:golang/time?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "unicode/utf8",
+      "purl": "pkg:golang/unicode/utf8?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "unicode",
+      "purl": "pkg:golang/unicode?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "unsafe",
+      "purl": "pkg:golang/unsafe?type=package",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "vendor": "red hat",
+        "name": "cachi2"
+      }
+    ]
+  },
+  "specVersion": "1.4",
+  "version": 1
+}

--- a/tests/unit/data/sboms/cachito_gomod_nodeps.bom.json
+++ b/tests/unit/data/sboms/cachito_gomod_nodeps.bom.json
@@ -1,0 +1,39 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "github.com/cachito-testing/cachito-gomod-without-deps",
+      "purl": "pkg:golang/github.com/cachito-testing/cachito-gomod-without-deps@v0.0.0-20200925115855-a888f7261b9a?type=module",
+      "version": "v0.0.0-20200925115855-a888f7261b9a",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    },
+    {
+      "name": "github.com/cachito-testing/cachito-gomod-without-deps",
+      "purl": "pkg:golang/github.com/cachito-testing/cachito-gomod-without-deps@v0.0.0-20200925115855-a888f7261b9a?type=package",
+      "version": "v0.0.0-20200925115855-a888f7261b9a",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "vendor": "red hat",
+        "name": "cachi2"
+      }
+    ]
+  },
+  "specVersion": "1.4",
+  "version": 1
+}


### PR DESCRIPTION
Functionality for merging SBOMs was already present in the codebase, this commit exposes it to a user.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Docs updated (if applicable)
- [-] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
