### PR TITLE
bundler: parse Gemfile.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ RUN dnf -y install \
     --nodocs \
     git-core \
     python3 \
+    rubygem-bundler \
+    rubygem-json \
     subscription-manager && \
     dnf clean all
 

--- a/cachi2/core/models/input.py
+++ b/cachi2/core/models/input.py
@@ -241,7 +241,7 @@ class Request(pydantic.BaseModel):
 
     @property
     def bundler_packages(self) -> list[BundlerPackageInput]:
-        """Get the rubygems packages specified for this request."""
+        """Get the bundler packages specified for this request."""
         return self._packages_by_type(BundlerPackageInput)
 
     @property

--- a/cachi2/core/package_managers/bundler/main.py
+++ b/cachi2/core/package_managers/bundler/main.py
@@ -1,6 +1,8 @@
 from cachi2.core.models.input import Request
 from cachi2.core.models.output import EnvironmentVariable, ProjectFile, RequestOutput
 from cachi2.core.models.sbom import Component
+from cachi2.core.package_managers.bundler.parser import parse_lockfile
+from cachi2.core.rooted_path import RootedPath
 
 
 def fetch_bundler_source(request: Request) -> RequestOutput:
@@ -9,8 +11,18 @@ def fetch_bundler_source(request: Request) -> RequestOutput:
     environment_variables: list[EnvironmentVariable] = []
     project_files: list[ProjectFile] = []
 
+    for package in request.packages:
+        path_within_root = request.source_dir.join_within_root(package.path)
+        _resolve_bundler_package(package_dir=path_within_root, output_dir=request.output_dir)
+
     return RequestOutput.from_obj_list(
         components=components,
         environment_variables=environment_variables,
         project_files=project_files,
     )
+
+
+def _resolve_bundler_package(package_dir: RootedPath, output_dir: RootedPath) -> list[Component]:
+    """Process a request for a single bundler package."""
+    parse_lockfile(package_dir)
+    return []

--- a/cachi2/core/package_managers/bundler/parser.py
+++ b/cachi2/core/package_managers/bundler/parser.py
@@ -1,0 +1,127 @@
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import Annotated, Optional, Union
+
+import pydantic
+
+from cachi2.core.errors import PackageManagerError, PackageRejected, UnexpectedFormat
+from cachi2.core.rooted_path import PathOutsideRoot, RootedPath
+from cachi2.core.utils import run_cmd
+
+log = logging.getLogger(__name__)
+
+GEMFILE = "Gemfile"
+GEMFILE_LOCK = "Gemfile.lock"
+
+AcceptedUrl = Annotated[
+    pydantic.HttpUrl,
+    pydantic.UrlConstraints(allowed_schemes=["https"]),
+]
+
+AcceptedGitRef = Annotated[
+    pydantic.StrictStr,
+    pydantic.StringConstraints(pattern=r"^[a-fA-F0-9]{40}$"),
+]
+
+
+class _GemMetadata(pydantic.BaseModel):
+    """
+    Base class for gem metadata.
+
+    Attributes:
+        name:       The name of the gem.
+        version:    The version of the gem.
+    """
+
+    name: str
+    version: str
+
+
+class GemDependency(_GemMetadata):
+    """
+    Represents a gem dependency.
+
+    Attributes:
+        source:     The source URL of the gem.
+        checksum:   The checksum of the gem.
+    """
+
+    source: str
+    checksum: Optional[str] = None
+
+
+class GitDependency(_GemMetadata):
+    """
+    Represents a git dependency.
+
+    Attributes:
+        url:        The URL of the git repository.
+        ref:        Commit hash.
+    """
+
+    url: AcceptedUrl
+    ref: AcceptedGitRef
+
+
+class PathDependency(_GemMetadata):
+    """
+    Represents a path dependency.
+
+    Attributes:
+        path:       Subpath from package root.
+    """
+
+    path: str
+
+
+BundlerDependency = Union[GemDependency, GitDependency, PathDependency]
+ParseResult = list[BundlerDependency]
+
+
+def parse_lockfile(package_dir: RootedPath) -> ParseResult:
+    """Parse a Gemfile.lock file and return a list of dependencies."""
+    lockfile_path = package_dir.join_within_root(GEMFILE_LOCK)
+    gemfile_path = package_dir.join_within_root(GEMFILE)
+    if not lockfile_path.path.exists() or not gemfile_path.path.exists():
+        reason = "Gemfile and Gemfile.lock must be present in the package directory"
+        solution = (
+            "Run `bundle init` to generate the Gemfile.\n"
+            "Run `bundle lock` to generate the Gemfile.lock."
+        )
+        raise PackageRejected(reason=reason, solution=solution)
+
+    scripts_dir = Path(__file__).parent / "scripts"
+    lockfile_parser = scripts_dir / "lockfile_parser.rb"
+    try:
+        output = run_cmd(cmd=[str(lockfile_parser)], params={"cwd": package_dir.path})
+    except subprocess.CalledProcessError:
+        raise PackageManagerError(f"Failed to parse {lockfile_path}")
+
+    json_output = json.loads(output)
+
+    bundler_version: str = json_output["bundler_version"]
+    log.info("Package %s is bundled with version %s", package_dir.path.name, bundler_version)
+    dependencies: list[dict[str, str]] = json_output["dependencies"]
+
+    result: ParseResult = []
+    for dep in dependencies:
+        if dep["type"] == "rubygems":
+            result.append(GemDependency(**dep))
+        elif dep["type"] == "git":
+            result.append(GitDependency(**dep))
+        elif dep["type"] == "path":
+            _validate_path_dependency_subpath(package_dir, dep["path"])
+            result.append(PathDependency(**dep))
+
+    return result
+
+
+def _validate_path_dependency_subpath(package_dir: RootedPath, path: str) -> None:
+    """Validate that the path dependency is within the package root."""
+    try:
+        package_dir.join_within_root(path)
+    except PathOutsideRoot:
+        reason = "PATH dependencies should be within the package root"
+        raise UnexpectedFormat(reason=reason)

--- a/cachi2/core/package_managers/bundler/scripts/lockfile_parser.rb
+++ b/cachi2/core/package_managers/bundler/scripts/lockfile_parser.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+
+require 'bundler'
+require 'json'
+
+lockfile_content = File.read("Gemfile.lock")
+lockfile_parser = Bundler::LockfileParser.new(lockfile_content)
+
+parsed_specs = []
+
+lockfile_parser.specs.each do |spec|
+    parsed_spec = {
+      name: spec.name,
+      version: spec.version.to_s
+    }
+
+    case spec.source
+    when Bundler::Source::Rubygems
+      parsed_spec[:type] = 'rubygems'
+      parsed_spec[:source] = spec.source.remotes.map(&:to_s).first
+    when Bundler::Source::Git
+      parsed_spec[:type] = 'git'
+      parsed_spec[:url] = spec.source.uri
+      parsed_spec[:ref] = spec.source.revision
+    when Bundler::Source::Path
+      parsed_spec[:type] = 'path'
+      parsed_spec[:path] = spec.source.path.to_s
+    end
+
+    parsed_specs << parsed_spec
+  end
+
+puts JSON.pretty_generate({ bundler_version: lockfile_parser.bundler_version, dependencies: parsed_specs })
+
+# References:
+# https://github.com/rubygems/rubygems/blob/master/bundler/lib/bundler/lockfile_parser.rb

--- a/tests/unit/package_managers/bundler/test_parser.py
+++ b/tests/unit/package_managers/bundler/test_parser.py
@@ -1,0 +1,182 @@
+import json
+import subprocess
+from copy import deepcopy
+from typing import Any
+from unittest import mock
+
+import pydantic
+import pytest
+
+from cachi2.core.errors import PackageManagerError, PackageRejected, UnexpectedFormat
+from cachi2.core.package_managers.bundler.parser import (
+    GEMFILE,
+    GEMFILE_LOCK,
+    GemDependency,
+    GitDependency,
+    PathDependency,
+    parse_lockfile,
+)
+from cachi2.core.rooted_path import RootedPath
+
+
+@pytest.fixture
+def empty_bundler_files(rooted_tmp_path: RootedPath) -> tuple[RootedPath, RootedPath]:
+    gemfile_path = rooted_tmp_path.join_within_root(GEMFILE)
+    gemfile_path.path.touch()
+
+    lockfile_path = rooted_tmp_path.join_within_root(GEMFILE_LOCK)
+    lockfile_path.path.touch()
+
+    return gemfile_path, lockfile_path
+
+
+SAMPLE_PARSER_OUTPUT = {
+    "bundler_version": "2.5.10",
+    "dependencies": [{"name": "example", "version": "0.1.0"}],
+}
+
+
+@pytest.fixture
+def sample_parser_output() -> dict[str, Any]:
+    return deepcopy(SAMPLE_PARSER_OUTPUT)
+
+
+def test_parse_lockfile_without_bundler_files(rooted_tmp_path: RootedPath) -> None:
+    with pytest.raises(PackageRejected) as exc_info:
+        parse_lockfile(rooted_tmp_path)
+
+    assert (
+        "Gemfile and Gemfile.lock must be present in the package directory"
+        in exc_info.value.friendly_msg()
+    )
+
+
+@mock.patch("cachi2.core.package_managers.bundler.parser.run_cmd")
+def test_parse_lockfile_os_error(
+    mock_run_cmd: mock.MagicMock,
+    empty_bundler_files: tuple[RootedPath, RootedPath],
+    rooted_tmp_path: RootedPath,
+) -> None:
+    mock_run_cmd.side_effect = subprocess.CalledProcessError(returncode=1, cmd="cmd")
+
+    with pytest.raises(PackageManagerError) as exc_info:
+        parse_lockfile(rooted_tmp_path)
+
+    assert f"Failed to parse {empty_bundler_files[1]}" in exc_info.value.friendly_msg()
+
+
+@mock.patch("cachi2.core.package_managers.bundler.parser.run_cmd")
+@pytest.mark.parametrize(
+    "error, expected_error_msg",
+    [
+        ("LOCKFILE_INVALID_URL", "Input should be a valid URL"),
+        ("LOCKFILE_INVALID_URL_SCHEME", "URL scheme should be 'https'"),
+        ("LOCKFILE_INVALID_REVISION", "String should match pattern '^[a-fA-F0-9]{40}$'"),
+        ("LOCKFILE_INVALID_PATH", "PATH dependencies should be within the package root"),
+    ],
+)
+def test_parse_lockfile_invalid_format(
+    mock_run_cmd: mock.MagicMock,
+    error: str,
+    expected_error_msg: str,
+    empty_bundler_files: tuple[RootedPath, RootedPath],
+    sample_parser_output: dict[str, Any],
+    rooted_tmp_path: RootedPath,
+) -> None:
+    if error == "LOCKFILE_INVALID_URL":
+        sample_parser_output["dependencies"][0].update(
+            {
+                "type": "git",
+                "url": "github",
+                "ref": "f" * 40,
+            }
+        )
+    elif error == "LOCKFILE_INVALID_URL_SCHEME":
+        sample_parser_output["dependencies"][0].update(
+            {
+                "type": "git",
+                "url": "http://github.com/3scale/json-schema.git",
+                "ref": "f" * 40,
+            }
+        )
+    elif error == "LOCKFILE_INVALID_REVISION":
+        sample_parser_output["dependencies"][0].update(
+            {
+                "type": "git",
+                "url": "https://github.com/3scale/json-schema.git",
+                "ref": "abcd",
+            }
+        )
+    elif error == "LOCKFILE_INVALID_PATH":
+        sample_parser_output["dependencies"][0].update(
+            {
+                "type": "path",
+                "path": "/root/pathgem",
+            }
+        )
+
+    mock_run_cmd.return_value = json.dumps(sample_parser_output)
+    with pytest.raises((pydantic.ValidationError, UnexpectedFormat)) as exc_info:
+        parse_lockfile(rooted_tmp_path)
+
+    assert expected_error_msg in str(exc_info.value)
+
+
+@mock.patch("cachi2.core.package_managers.bundler.parser.run_cmd")
+def test_parse_gemlock(
+    mock_run_cmd: mock.MagicMock,
+    empty_bundler_files: tuple[RootedPath, RootedPath],
+    sample_parser_output: dict[str, Any],
+    rooted_tmp_path: RootedPath,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    base_dep: dict[str, str] = sample_parser_output["dependencies"][0]
+    sample_parser_output["dependencies"] = [
+        {
+            "type": "git",
+            "url": "https://github.com/3scale/json-schema.git",
+            "ref": "f" * 40,
+            **base_dep,
+        },
+        {
+            "type": "path",
+            "path": "subpath/pathgem",
+            **base_dep,
+        },
+        {
+            "type": "rubygems",
+            "source": "https://rubygems.org/",
+            **base_dep,
+        },
+    ]
+
+    mock_run_cmd.return_value = json.dumps(sample_parser_output)
+    result = parse_lockfile(rooted_tmp_path)
+
+    expected_deps = [
+        GitDependency(
+            name="example",
+            version="0.1.0",
+            url="https://github.com/3scale/json-schema.git",
+            ref="f" * 40,
+        ),
+        PathDependency(name="example", version="0.1.0", path="subpath/pathgem"),
+        GemDependency(name="example", version="0.1.0", source="https://rubygems.org/"),
+    ]
+
+    assert f"Package {rooted_tmp_path.path.name} is bundled with version 2.5.10" in caplog.messages
+    assert result == expected_deps
+
+
+@mock.patch("cachi2.core.package_managers.bundler.parser.run_cmd")
+def test_parse_gemlock_empty(
+    mock_run_cmd: mock.MagicMock,
+    empty_bundler_files: tuple[RootedPath, RootedPath],
+    rooted_tmp_path: RootedPath,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    mock_run_cmd.return_value = '{"bundler_version": "2.5.10", "dependencies": []}'
+    result = parse_lockfile(rooted_tmp_path)
+
+    assert f"Package {rooted_tmp_path.path.name} is bundled with version 2.5.10" in caplog.messages
+    assert result == []


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
