### PR TITLE
bandit security corrections

### DIFF
--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 import shutil
-import subprocess  # nosec
+import subprocess
 import tempfile
 from datetime import datetime
 from functools import cached_property

--- a/cachi2/core/package_managers/yarn/utils.py
+++ b/cachi2/core/package_managers/yarn/utils.py
@@ -1,5 +1,5 @@
 import os
-import subprocess  # nosec
+import subprocess
 from typing import Optional
 
 from cachi2.core.errors import PackageManagerError

--- a/cachi2/core/scm.py
+++ b/cachi2/core/scm.py
@@ -120,8 +120,6 @@ def clone_as_tarball(url: str, ref: str, to_path: Path) -> None:
             _reset_git_head(repo, ref)
 
             with tarfile.open(to_path, mode="w:gz") as archive:
-                # GitPython wrongly annotates working_dir as Optional, it cannot be None
-                assert repo.working_dir is not None  # nosec assert_used
                 archive.add(repo.working_dir, "app")
 
             return

--- a/cachi2/core/utils.py
+++ b/cachi2/core/utils.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import shutil
-import subprocess  # nosec
+import subprocess
 import sys
 from functools import cache
 from pathlib import Path
@@ -48,7 +48,7 @@ def run_cmd(cmd: Sequence[str], params: dict) -> str:
             ),
         )
 
-    response = subprocess.run([executable_path, *args], **params)  # nosec
+    response = subprocess.run([executable_path, *args], **params)
 
     try:
         response.check_returncode()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,3 +94,9 @@ exclude_lines = [
   "if TYPE_CHECKING:",
   "return NotImplemented",
 ]
+
+[tool.bandit]
+skips = [
+  "B404", # import subprocess
+  "B603", # subprocess_without_shell_equals_true
+]

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,7 @@ commands =
 [testenv:bandit]
 skip_install = true
 commands =
-    bandit -r cachi2
+    bandit -c pyproject.toml -r cachi2
 
 [testenv:black]
 description = black checks [Mandatory]


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
