### PR TITLE
dependabot: Exclude pydantic version updates from the bigger bunch and group it separately

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    commit-message:
+      prefix: "Dockerfile"
 
   - package-ecosystem: "pip"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,15 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        exclude_patterns:
+          - "pydantic*"
+
+      # pydantic is a known violator of version updates where they don't release the core backend
+      # with the API library at the same time which holds up other legitimate updates, so group
+      # pydantic deps together
+      pydantic:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "pydantic*"


### PR DESCRIPTION
See commit 2 for explanation and e.g. https://github.com/containerbuildsystem/cachi2/actions/runs/10655305260/job/29532650464 (one of many regular occurrences in our CI)

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
