### PR TITLE
Introduce support for Go 1.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ original Cachito.*
 
 <https://go.dev/ref/mod>
 
-Current version: 1.21 [^go-version] [^go-compat]
+Current version: 1.23 [^go-version] [^go-compat] [^workspace-vendoring]
 
 The gomod package manager works by parsing the [go.mod](https://go.dev/ref/mod#go-mod-file) file present in the source
 repository to determine which dependencies to download. Cachi2 does not parse this file on its own - rather, we rely on
@@ -357,6 +357,10 @@ See [docs/gomod.md](docs/gomod.md) for more details.
   [go 1.19][go119-changelog]. Things are a bit more complicated with [Go 1.21][go121-changelog], if
   you are or have been experiencing issues with cachi2 related to Go 1.21+, please refer to
   [docs/gomod.md](docs/gomod.md#go-121-since-cachi2-v050).
+
+[^workspace-vendoring]: Although Cachi2 supports Go 1.23, support for workspace vendoring
+  introduced in Go 1.22 hasn't been added yet (still in development) and so if your project makes
+  use of the feature cachi2 will error out.
 
 ### pip
 

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -767,7 +767,7 @@ def _setup_go_toolchain(go_mod_file: RootedPath) -> Go:
     GO_121 = version.Version("1.21")
     go = Go()
     target_version = None
-    go_max_version = version.Version("1.22")
+    go_max_version = version.Version("1.23")
     go_base_version = go.version
     go_mod_version_msg = "go.mod reported versions: '%s'[go], '%s'[toolchain]"
 

--- a/cachi2/core/package_managers/gomod.py
+++ b/cachi2/core/package_managers/gomod.py
@@ -827,6 +827,13 @@ def _setup_go_toolchain(go_mod_file: RootedPath) -> Go:
     return go
 
 
+def _disable_telemetry(go: Go, run_params: dict[str, Any]) -> None:
+    telemetry = go(["env", "GOTELEMETRY"], run_params).rstrip()
+    if telemetry and telemetry != "off":
+        log.debug("Disabling Go telemetry")
+        go(["telemetry", "off"], run_params)
+
+
 def _resolve_gomod(
     app_dir: RootedPath,
     request: Request,
@@ -870,6 +877,9 @@ def _resolve_gomod(
     log.info(f"Using Go release: {go.release}")
 
     run_params = {"env": env, "cwd": app_dir}
+
+    # Explicitly disable toolchain telemetry for go >= 1.23
+    _disable_telemetry(go, run_params)
 
     if go_work_path:
         modules_in_go_sum = _parse_go_sum_from_workspaces(go_work_path, go, run_params)

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1993,8 +1993,8 @@ def test_setup_go_toolchain(
 @pytest.mark.parametrize(
     "unsupported_version",
     [
-        pytest.param(("1.23.0", None), id="go_version_higher_than_max"),
-        pytest.param((None, "1.23.0"), id="toolchain_version_higher_than_max"),
+        pytest.param(("99.99.0", None), id="go_version_higher_than_max"),
+        pytest.param((None, "99.99.0"), id="toolchain_version_higher_than_max"),
     ],
 )
 @mock.patch("cachi2.core.package_managers.gomod._get_gomod_version")


### PR DESCRIPTION
Go 1.23 was released last month [1]. The only notable change on the tooling with essentially no real impact is the introduction of telemetry data gathering which is documented to be opt-in. To stay on the safe side patch 2 disables telemetry explicitly on Go releases which support it.

[1] https://tip.golang.org/doc/go1.23

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Docs updated (if applicable)
- [x] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
