### PR TITLE
Enable typing on pip

### DIFF
--- a/tests/unit/package_managers/test_pip.py
+++ b/tests/unit/package_managers/test_pip.py
@@ -2585,7 +2585,7 @@ class TestPipRequirementsFile:
         self,
         requirement_line: str,
         requirement_options: list[str],
-        new_values: dict[str, str],
+        new_values: Union[dict[str, str], dict[str, list[str]]],
         expected_changes: dict[str, str],
     ) -> None:
         """Test PipRequirement.copy method."""


### PR DESCRIPTION
Typing was disabled in PipRequirement due to several small issues left over time, so this PR addresses all of them and re-enables typing on the file .

Resolves #485 

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [-] Docs updated (if applicable)
- [-] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
