### PR TITLE
Update GH actions to run unit tests in a Python container

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -16,24 +16,27 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
+    container:
+      image: python:${{ matrix.python-version }}-slim
+
     steps:
+    - name: Install dependencies
+      run: |
+        # We need to install git inside the container otherwise the checkout action will use Git
+        # REST API and the .git directory won't be present which fails due to setuptools-scm
+        apt-get update && apt-get install --no-install-recommends --no-install-suggests -y git
+        python3 -m pip install --upgrade pip
+        pip install tox
+
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
-        pip install tox-gh-actions
-
     - name: Test with tox
-      run: tox
+      run: |
+        # Disable Git's safe.directory mechanism as some unit tests do clone repositories
+        git config --global --add safe.directory '*'
+        tox -e py3
 
     - name: Upload coverage reports to Codecov
       if: matrix.python-version == '3.12'
@@ -43,6 +46,7 @@ jobs:
 
   linters:
     name: Linters
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -52,17 +56,23 @@ jobs:
           - isort
           - flake8
           - mypy
-    runs-on: ubuntu-latest
+
+    container:
+      image: python:3.9-slim
+
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.9"
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        # We need to install git inside the container otherwise the checkout action will use Git
+        # REST API and the .git directory won't be present which fails due to setuptools-scm
+        apt-get update && apt-get install --no-install-recommends --no-install-suggests -y git
+        python3 -m pip install --upgrade pip
         pip install tox
+
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
     - name: Test '${{ matrix.tox_env }}' with tox
       run: tox -e ${{ matrix.tox_env }}
 

--- a/tox.ini
+++ b/tox.ini
@@ -64,13 +64,6 @@ commands =
 allowlist_externals = rm
 skipsdist = true
 
-[gh-actions]
-python =
-    3.9: py39
-    3.10: py310
-    3.11: py311
-    3.12: py312
-
 [flake8]
 show-source = True
 exclude = venv,.git,.tox,dist,*egg,.env,hack

--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,6 @@ envlist =
     py3{9,10,11,12}
 
 [testenv]
-passenv =
-    TOX_ENV_DIR
-setenv =
-    CACHITO_TESTING = true
-    PROMETHEUS_MULTIPROC_DIR = {envtmpdir}/prometheus_metrics
 usedevelop = true
 deps =
     -rrequirements-extras.txt
@@ -24,12 +19,6 @@ commands =
       --cov-report=term \
       --cov-report=html \
       --cov-report=xml {posargs}
-allowlist_externals =
-    make
-    mkdir
-    rm
-commands_post =
-    rm -rf {envtmpdir}/prometheus_metrics
 
 [testenv:flake8]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,6 @@ commands =
     bandit -c pyproject.toml -r cachi2
 
 [testenv:black]
-description = black checks [Mandatory]
 skip_install = true
 commands =
     black --check --diff cachi2 tests


### PR DESCRIPTION
The Python container used is a Debian slim image because Alpine uses musl C library which resulted in our createrepo_c depedency to be built from tarball instead of installed from a wheel (those wheels are based on glibc) which naturally failed as the container doesn't have all the deps needed to build createrepo_c.
~~This PR has also been rebased on top of #633 (can be changed) for testing the tox changes in the GH gating CI environment.~~

See the last commit message for more information.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
