### PR TITLE
Dependabot: Fix the 'exclude_patterns' config typo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
-        exclude_patterns:
+        exclude-patterns:
           - "pydantic*"
 
       # pydantic is a known violator of version updates where they don't release the core backend


### PR DESCRIPTION
s/exclude_patterns/exclude-patterns [1].

Since an official native validation solution doesn't exist yet [2] that would work reliably, @bugron/validate-dependabot-yaml was used to validate this typo fix.

fixes: 24f35ee970db9d3de00211e9caa283f765fd520a

[1] https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
[2] https://github.com/dependabot/dependabot-core/issues/4605
[3] https://www.npmjs.com/package/@bugron/validate-dependabot-yaml

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
