### PR TITLE
feat(yarnv1): generate build env vars

### DIFF
--- a/cachi2/core/package_managers/yarn_classic/main.py
+++ b/cachi2/core/package_managers/yarn_classic/main.py
@@ -1,0 +1,18 @@
+from cachi2.core.models.output import EnvironmentVariable
+
+
+def _generate_build_environment_variables() -> list[EnvironmentVariable]:
+    """Generate environment variables that will be used for building the project.
+
+    These ensure that yarnv1 will
+    - YARN_YARN_OFFLINE_MIRROR: Maintain offline copies of packages for repeatable and reliable
+        builds. Defines the cache location.
+    - YARN_YARN_OFFLINE_MIRROR_PRUNING: Control automatic pruning of the offline mirror. We
+        disable this, as we need to retain the cache.
+    """
+    env_vars = {
+        "YARN_YARN_OFFLINE_MIRROR": "${output_dir}/deps/yarn-classic",
+        "YARN_YARN_OFFLINE_MIRROR_PRUNING": "false",
+    }
+
+    return [EnvironmentVariable(name=key, value=value) for key, value in env_vars.items()]

--- a/tests/unit/package_managers/yarn_classic/test_main.py
+++ b/tests/unit/package_managers/yarn_classic/test_main.py
@@ -1,0 +1,21 @@
+import pytest
+
+from cachi2.core.models.output import EnvironmentVariable
+from cachi2.core.package_managers.yarn_classic.main import _generate_build_environment_variables
+
+
+@pytest.fixture(scope="module")
+def yarn_classic_env_variables() -> list[EnvironmentVariable]:
+    return [
+        EnvironmentVariable(
+            name="YARN_YARN_OFFLINE_MIRROR", value="${output_dir}/deps/yarn-classic"
+        ),
+        EnvironmentVariable(name="YARN_YARN_OFFLINE_MIRROR_PRUNING", value="false"),
+    ]
+
+
+def test_generate_build_environment_variables(
+    yarn_classic_env_variables: list[EnvironmentVariable],
+) -> None:
+    result = _generate_build_environment_variables()
+    assert result == yarn_classic_env_variables


### PR DESCRIPTION
Based on taylormadore/cachi2 [#f19ce5de](https://github.com/taylormadore/cachi2/commit/f19ce5de5ca12f73ce6cc837877d9f3d53edc81a)

- Implements and closes #625

- Adds unit test

Prefetching dependencies for Yarn in Cachi2 will be done using Yarn's offline
mirror feature. When a project is configured to use the offline mirror, Yarn
will store compressed archives in the mirror directory (specified by env var
`YARN_YARN_OFFLINE_MIRROR`) and can install cached project dependencies
from there later without network access.

The offline mirror also has a setting that controls whether it removes package
archives from the mirror directory when they are no longer needed. Cachi2 will
want to disable automatic pruning of the offline mirror (using env var
`YARN_YARN_OFFLINE_MIRROR_PRUNING=false`), since we support multiple
yarn projects in a single request.

reference:  https://classic.yarnpkg.com/en/docs/yarnrc

For acceptance criteria:

   I can hear Erik saying "Where's the unit test for generating a valid 'cachi2.env' file from a valid '.build-config.json' using the 'generate-env' command to `cachi2`?" - it's a trick question, because we do that in the integration tests :stuck_out_tongue:

   However, for completeness, I tested it by hand (by actually running `cachi2 generate-env ./cachi2-output -o ./cachi2.env --for-output-dir /tmp/cachi2-output`), using

   ```json
	{
	  "environment_variables": [
	    {
	      "name": "YARN_YARN_OFFLINE_MIRROR",
	      "value": "${output_dir}/deps/yarn-classic"
	    },
	    {
	      "name": "YARN_YARN_OFFLINE_MIRROR_PRUNING",
	      "value": "false"
	    }
	  ],
	  "project_files": []
	}
   ```

   for the .build-config.json.

   Result:

   ```bash
	export YARN_YARN_OFFLINE_MIRROR=/tmp/cachi2-output/deps/yarn-classic
	export YARN_YARN_OFFLINE_MIRROR_PRUNING=false
   ```

   as expected.




# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
