### PR TITLE
bundler: Adding Gem downloader

### DIFF
--- a/cachi2/core/package_managers/general.py
+++ b/cachi2/core/package_managers/general.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 import types
 from os import PathLike
-from pathlib import Path
 from typing import Any, Dict, Optional, Set, Union
 from urllib.parse import urlparse
 
@@ -27,7 +26,7 @@ log = logging.getLogger(__name__)
 
 def download_binary_file(
     url: str,
-    download_path: Union[str, Path],
+    download_path: Union[str, PathLike[str]],
     auth: Optional[AuthBase] = None,
     insecure: bool = False,
     chunk_size: int = 8192,
@@ -36,7 +35,7 @@ def download_binary_file(
     Download a binary file (such as a TAR archive) from a URL.
 
     :param str url: URL for file download
-    :param (str | Path) download_path: Path to download file to
+    :param (str | PathLike) download_path: Path to download file to
     :param requests.auth.AuthBase auth: Authentication for the URL
     :param bool insecure: Do not verify SSL for the URL
     :param int chunk_size: Chunk size param for Response.iter_content()


### PR DESCRIPTION
This change extends GemDependencies with a method
that will download them from their source.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
