### PR TITLE
bundler: download git dependencies

### DIFF
--- a/tests/common_utils/__init__.py
+++ b/tests/common_utils/__init__.py
@@ -3,6 +3,8 @@ import os
 from pathlib import Path
 from typing import Union
 
+GIT_REF = "f" * 40
+
 
 def assert_directories_equal(dir_a: str, dir_b: str) -> None:
     """

--- a/tests/unit/package_managers/bundler/test_parser.py
+++ b/tests/unit/package_managers/bundler/test_parser.py
@@ -18,6 +18,7 @@ from cachi2.core.package_managers.bundler.parser import (
     parse_lockfile,
 )
 from cachi2.core.rooted_path import RootedPath
+from tests.common_utils import GIT_REF
 
 
 @pytest.fixture
@@ -89,7 +90,7 @@ def test_parse_lockfile_invalid_format(
             {
                 "type": "git",
                 "url": "github",
-                "ref": "f" * 40,
+                "ref": GIT_REF,
             }
         )
     elif error == "LOCKFILE_INVALID_URL_SCHEME":
@@ -97,7 +98,7 @@ def test_parse_lockfile_invalid_format(
             {
                 "type": "git",
                 "url": "http://github.com/3scale/json-schema.git",
-                "ref": "f" * 40,
+                "ref": GIT_REF,
             }
         )
     elif error == "LOCKFILE_INVALID_REVISION":
@@ -136,7 +137,7 @@ def test_parse_gemlock(
         {
             "type": "git",
             "url": "https://github.com/3scale/json-schema.git",
-            "ref": "f" * 40,
+            "ref": GIT_REF,
             **base_dep,
         },
         {
@@ -159,7 +160,7 @@ def test_parse_gemlock(
             name="example",
             version="0.1.0",
             url="https://github.com/3scale/json-schema.git",
-            ref="f" * 40,
+            ref=GIT_REF,
         ),
         PathDependency(name="example", version="0.1.0", path="subpath/pathgem"),
         GemDependency(name="example", version="0.1.0", source="https://rubygems.org/"),

--- a/tests/unit/package_managers/test_general.py
+++ b/tests/unit/package_managers/test_general.py
@@ -22,8 +22,7 @@ from cachi2.core.package_managers.general import (
     download_binary_file,
     pkg_requests_session,
 )
-
-GIT_REF = "9a557920b2a6d4110f838506120904a6fda421a2"
+from tests.common_utils import GIT_REF
 
 
 @pytest.mark.parametrize("auth", [None, HTTPBasicAuth("user", "password")])

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -50,7 +50,7 @@ from cachi2.core.package_managers.gomod import (
     fetch_gomod_source,
 )
 from cachi2.core.rooted_path import PathOutsideRoot, RootedPath
-from tests.common_utils import write_file_tree
+from tests.common_utils import GIT_REF, write_file_tree
 
 GO_CMD_PATH = "/usr/bin/go"
 
@@ -1874,7 +1874,7 @@ def test_get_repository_name(mock_git_repo: Any, input_url: str) -> None:
 
     mocked_repo = mock.Mock()
     mocked_repo.remote.return_value.url = input_url
-    mocked_repo.head.commit.hexsha = "f" * 40
+    mocked_repo.head.commit.hexsha = GIT_REF
     mock_git_repo.return_value = mocked_repo
 
     resolved_url = _get_repository_name(RootedPath("/my-folder/cloned-repo"))

--- a/tests/unit/package_managers/test_npm.py
+++ b/tests/unit/package_managers/test_npm.py
@@ -33,6 +33,7 @@ from cachi2.core.package_managers.npm import (
 )
 from cachi2.core.rooted_path import RootedPath
 from cachi2.core.scm import RepoID
+from tests.common_utils import GIT_REF
 
 MOCK_REPO_ID = RepoID("https://github.com/foolish/bar.git", "abcdef1234")
 MOCK_REPO_VCS_URL = "git%2Bhttps://github.com/foolish/bar.git%40abcdef1234"
@@ -1458,12 +1459,10 @@ def test_resolve_npm_unsupported_lockfileversion(rooted_tmp_path: RootedPath) ->
     "vcs, expected",
     [
         (
-            (
-                "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps.git#9e164b97043a2d91bbeb992f6cc68a3d1015086a"
-            ),
+            (f"git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps.git#{GIT_REF}"),
             {
                 "url": "ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps.git",
-                "ref": "9e164b97043a2d91bbeb992f6cc68a3d1015086a",
+                "ref": GIT_REF,
                 "host": "bitbucket.org",
                 "namespace": "cachi-testing",
                 "repo": "cachi2-without-deps",

--- a/tests/unit/package_managers/test_pip.py
+++ b/tests/unit/package_managers/test_pip.py
@@ -25,10 +25,9 @@ from cachi2.core.models.sbom import Component, Property
 from cachi2.core.package_managers import pip
 from cachi2.core.rooted_path import PathOutsideRoot, RootedPath
 from cachi2.core.scm import RepoID
-from tests.common_utils import Symlink, write_file_tree
+from tests.common_utils import GIT_REF, Symlink, write_file_tree
 
 THIS_MODULE_DIR = Path(__file__).resolve().parent
-GIT_REF = "9a557920b2a6d4110f838506120904a6fda421a2"
 PKG_DIR = RootedPath("/foo/package_dir")
 PKG_DIR_SUBPATH = PKG_DIR.join_within_root("subpath")
 MOCK_REPO_ID = RepoID("https://github.com/foolish/bar.git", "abcdef1234")
@@ -4146,7 +4145,7 @@ def test_fetch_pip_source(
 
     mocked_repo = mock.Mock()
     mocked_repo.remote.return_value.url = "https://github.com/my-org/my-repo"
-    mocked_repo.head.commit.hexsha = "f" * 40
+    mocked_repo.head.commit.hexsha = GIT_REF
     mock_git_repo.return_value = mocked_repo
 
     output = pip.fetch_pip_source(request)
@@ -4321,7 +4320,7 @@ def test_generate_purl_main_package(
 
     mocked_repo = mock.Mock()
     mocked_repo.remote.return_value.url = "ssh://git@github.com/my-org/my-repo"
-    mocked_repo.head.commit.hexsha = "f" * 40
+    mocked_repo.head.commit.hexsha = GIT_REF
     mock_git_repo.return_value = mocked_repo
 
     purl = pip._generate_purl_main_package(package, rooted_tmp_path.join_within_root(subpath))


### PR DESCRIPTION
See the commit msg for details.

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Docs updated (if applicable)
- [x] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
