### PR TITLE
Fix extra options model for rpm

### DIFF
--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -144,14 +144,9 @@ class TestPackageInput:
                 id="pip_no_requirements_build_files",
             ),
             pytest.param(
-                {"type": "rpm", "options": "bad_type"},
-                r"Unexpected data type for 'options.bad_type' in input JSON",
-                id="rpm_bad_options_type",
-            ),
-            pytest.param(
-                {"type": "rpm", "options": {"unknown": "foo"}},
-                r"Missing required namespace attribute in '{\'unknown\': \'foo\'}': 'dnf'",
-                id="rpm_missing_required_namespace_dnf",
+                {"type": "rpm", "options": {"extra": "foo"}},
+                r".*Extra inputs are not permitted \[type=extra_forbidden, input_value='foo'.*",
+                id="rpm_extra_unknown_options",
             ),
             pytest.param(
                 {"type": "rpm", "options": {"dnf": "bad_type"}},

--- a/tests/unit/package_managers/test_rpm.py
+++ b/tests/unit/package_managers/test_rpm.py
@@ -8,7 +8,7 @@ import yaml
 from _pytest.logging import LogCaptureFixture
 
 from cachi2.core.errors import PackageManagerError, PackageRejected
-from cachi2.core.models.input import RpmPackageInput, _DNFOptions
+from cachi2.core.models.input import RpmPackageInput, _ExtraOptions
 from cachi2.core.models.sbom import Component, Property
 from cachi2.core.package_managers.rpm import fetch_rpm_source, inject_files_post
 from cachi2.core.package_managers.rpm.main import (
@@ -56,7 +56,7 @@ arches:
         pytest.param(
             RpmPackageInput.model_construct(
                 type="rpm",
-                options=_DNFOptions.model_construct(dnf={"foorepo": {"foo": 1, "bar": False}}),
+                options=_ExtraOptions.model_construct(dnf={"foorepo": {"foo": 1, "bar": False}}),
             ),
             {"rpm": {"dnf": {"foorepo": {"foo": 1, "bar": False}}}},
             id="fetch_with_dnf_options",
@@ -65,11 +65,13 @@ arches:
             [
                 RpmPackageInput.model_construct(
                     type="rpm",
-                    options=_DNFOptions.model_construct(dnf={"foorepo": {"foo": 1, "bar": False}}),
+                    options=_ExtraOptions.model_construct(
+                        dnf={"foorepo": {"foo": 1, "bar": False}}
+                    ),
                 ),
                 RpmPackageInput.model_construct(
                     type="rpm",
-                    options=_DNFOptions.model_construct(dnf={"bazrepo": {"baz": 0}}),
+                    options=_ExtraOptions.model_construct(dnf={"bazrepo": {"baz": 0}}),
                 ),
             ],
             {"rpm": {"dnf": {"bazrepo": {"baz": 0}}}},


### PR DESCRIPTION
This PR is a direct result of #580, more specifically to tackle:
- https://github.com/containerbuildsystem/cachi2/blob/848c8075caa6cde72a2b9338793786b14f1f2cae/cachi2/core/models/input.py#L109
- https://github.com/containerbuildsystem/cachi2/blob/848c8075caa6cde72a2b9338793786b14f1f2cae/cachi2/core/models/input.py#L214

The goal of this PR is make additions of new options models easier than it is today compared to what is needed in #580.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
