### PR TITLE
bundler: Provide the build configuration

### DIFF
--- a/tests/integration/test_bundler.py
+++ b/tests/integration/test_bundler.py
@@ -53,6 +53,34 @@ log = logging.getLogger(__name__)
             ),
             id="bundler_malformed_lockfile",
         ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-bundler.git",
+                ref="well_formed_ruby_all_features",
+                packages=({"path": ".", "type": "bundler"},),
+                flags=["--dev-package-managers"],
+                check_output=False,
+                check_deps_checksums=False,
+                check_vendor_checksums=False,
+                expected_exit_code=0,
+                expected_output="",
+            ),
+            id="bundler_everything_present",
+        ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-bundler.git",
+                ref="well_formed_ruby_without_gemspec",
+                packages=({"path": ".", "type": "bundler"},),
+                flags=["--dev-package-managers"],
+                check_output=False,
+                check_deps_checksums=False,
+                check_vendor_checksums=False,
+                expected_exit_code=0,
+                expected_output="",
+            ),
+            id="bundler_everything_present_except_gemspec",
+        ),
     ],
 )
 def test_bundler_packages(


### PR DESCRIPTION
In order for Bundler to build from the content prefetched by Cachi2, we need to set a few configuration parameters. There are several ways of doing this, but the most robust one is to place a local configuration file into processed repository (see docs/design/bundler.md for details).

This commit introduces a fetch step that presets configuraion parameters.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
