### PR TITLE
chore: Update usage.md after flag deprecation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,7 +54,7 @@ The main parameter (PKG) can handle different types of definitions:
 * JSON object: `{"path": "subpath/to/other/module", "type": "<package manager>"}`
 * JSON array: `[{"path": ".", "type": "<package manager>"}, {"path": "subpath/to/other/module", "type": "<package manager>"}]`
 * JSON object with flags:
-`{"packages": [{"path": ".", "type": "<package manager>"}], "flags": ["gomod-vendor"]}`
+`{"packages": [{"path": ".", "type": "<package manager>"}], "flags": ["cgo-disable"]}`
 
 See also `cachi2 fetch-deps --help`.
 


### PR DESCRIPTION
gomod-vendor has recently been deprecated, however it was still used in usage.md. It was replaced with a not-deprecated flag.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
