### PR TITLE
cachi2 output image

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -3,9 +3,6 @@ kind: PipelineRun
 metadata:
   name: cachi2-on-pull-request
   annotations:
-    build.appstudio.redhat.com/commit_sha: "{{revision}}"
-    build.appstudio.redhat.com/pull_request_number: "{{pull_request_number}}"
-    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-event: "[pull_request]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
@@ -16,7 +13,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: "quay.io/redhat-appstudio/pull-request-builds:rhtap-build-cachi2-{{revision}}"
+      value: "quay.io/konflux-ci/pull-request-builds:cachi2-build-{{revision}}"
     - name: dockerfile
       value: Containerfile
   pipelineRef:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -3,8 +3,6 @@ kind: PipelineRun
 metadata:
   name: cachi2-on-push
   annotations:
-    build.appstudio.redhat.com/commit_sha: "{{revision}}"
-    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
@@ -15,7 +13,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: "quay.io/redhat-appstudio/cachi2:{{revision}}"
+      value: "quay.io/konflux-ci/cachi2:{{revision}}"
     - name: dockerfile
       value: Containerfile
     - name: slack-webhook-notification-team

--- a/.tekton/release.yaml
+++ b/.tekton/release.yaml
@@ -82,8 +82,8 @@ spec:
                 set -eufx
 
                 version=$(cat $(results.version.path)) 
-                skopeo copy docker://quay.io/redhat-appstudio/cachi2:$PARAM_REVISION \
-                  docker://quay.io/redhat-appstudio/cachi2:$version
+                skopeo copy docker://quay.io/konflux-ci/cachi2:$PARAM_REVISION \
+                  docker://quay.io/konflux-ci/cachi2:$version
 
     finally:
       - name: slack-webhook-notification

--- a/.tekton/release.yaml
+++ b/.tekton/release.yaml
@@ -104,7 +104,7 @@ spec:
         - name: message
           value: |-
             Tekton pipelineRun $(context.pipelineRun.name) failed.
-            See https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/k8s/ns/tekton-ci/tekton.dev~v1beta1~PipelineRun/$(context.pipelineRun.name)
+            See https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/k8s/ns/konflux-ci/tekton.dev~v1~PipelineRun/$(context.pipelineRun.name)
             (Quick! It may disappear soon!)
         - name: key-name
           value: $(params.slack-webhook-notification-team)

--- a/.tekton/tag-latest.yaml
+++ b/.tekton/tag-latest.yaml
@@ -64,7 +64,7 @@ spec:
         - name: message
           value: |-
             Tekton pipelineRun $(context.pipelineRun.name) failed.
-            See https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/k8s/ns/tekton-ci/tekton.dev~v1beta1~PipelineRun/$(context.pipelineRun.name)
+            See https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/k8s/ns/konflux-ci/tekton.dev~v1~PipelineRun/$(context.pipelineRun.name)
             (Quick! It may disappear soon!)
         - name: key-name
           value: $(params.slack-webhook-notification-team)

--- a/.tekton/tag-latest.yaml
+++ b/.tekton/tag-latest.yaml
@@ -4,8 +4,6 @@ kind: PipelineRun
 metadata:
   name: cachi2-on-tag-latest
   annotations:
-    build.appstudio.redhat.com/commit_sha: "{{revision}}"
-    build.appstudio.redhat.com/target_branch: "{{target_branch}}"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-event: "[push]"
     pipelinesascode.tekton.dev/on-target-branch: "[main]"
@@ -32,8 +30,8 @@ spec:
               image: registry.access.redhat.com/ubi9/skopeo:latest@sha256:23c9ed4af1f42614bdc56309452568b2110a67f23102f42f6a6582a63b63dcdb
               script: |
                 #!/usr/bin/env bash
-                SRC_REF="quay.io/redhat-appstudio/cachi2:$(params.revision)"
-                TARGET_REF="quay.io/redhat-appstudio/cachi2:latest"
+                SRC_REF="quay.io/konflux-ci/cachi2:$(params.revision)"
+                TARGET_REF="quay.io/konflux-ci/cachi2:latest"
 
                 echo "Waiting until ${SRC_REF} is pushed"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,7 +216,7 @@ Note: while developing, you can run the PyPI server with `tests/pypiserver/start
 To run integration-tests with custom image, specify the CACHI2\_IMAGE environment variable. Examples:
 
 ```shell
-CACHI2_IMAGE=quay.io/redhat-appstudio/cachi2:{tag} tox -e integration
+CACHI2_IMAGE=quay.io/konflux-ci/cachi2:{tag} tox -e integration
 CACHI2_IMAGE=localhost/cachi2:latest tox -e integration
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -270,10 +270,6 @@ tag follows the expected format: `$major.$minor.$patch`, without a `v` prefix).
 should have built the image for that commit already. This is the "corresponding image" that receives
 the new version tag. If the image for the tagged commit does not exist, the release pipeline will fail.*
 
-You can watch the release pipeline in the [OpenShift console][ocp-cachi2-pipelines] in case it fails
-(the pipeline is not visible anywhere in GitHub UI). For intermittent failures, retrying should be
-possible from the OpenShift UI or by deleting and re-pushing the version tag.
-
 *⚠ The release pipeline runs as soon as you push a tag into the repository. Do not push the new version
 tag until you are ready to publish the release. You can use GitHub's ability to auto-create the tag
 upon publishment.*

--- a/README.md
+++ b/README.md
@@ -242,4 +242,3 @@ still in early development phase.
 [go118-changelog]: https://tip.golang.org/doc/go1.18#go-command
 [go119-changelog]: https://tip.golang.org/doc/go1.19#go-command
 [go121-changelog]: https://tip.golang.org/doc/go1.21
-[ocp-cachi2-pipelines]: https://console-openshift-console.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/pipelines/ns/tekton-ci/pipeline-runs?name=cachi2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cachi2
 
 [![coverage][cachi2-coverage-badge]][cachi2-coverage-status]
-[![container][cachi2-container-status]][cachi2-container]
+[![container][cachi2-container-badge]][cachi2-container-status]
 
 Cachi2 is a CLI tool that pre-fetches your project's dependencies to aid in making your build process
 [hermetic](https://slsa.dev/spec/v0.1/requirements#hermetic).
@@ -61,10 +61,10 @@ To install Cachi2 for local development, see the [development](#development) sec
 
 ### Container image
 
-[![container][cachi2-container-status]][cachi2-container]
+[![container][cachi2-container-badge]][cachi2-container-status]
 
 ```text
-quay.io/redhat-appstudio/cachi2:latest
+quay.io/konflux-ci/cachi2:latest
 ```
 
 The container is re-built automatically on every merge to the main branch.
@@ -72,7 +72,7 @@ The container is re-built automatically on every merge to the main branch.
 You may wish to set up an alias to make local usage more convenient:
 
 ```shell
-alias cachi2='podman run --rm -ti -v "$PWD:$PWD:z" -w "$PWD" quay.io/redhat-appstudio/cachi2:latest'
+alias cachi2='podman run --rm -ti -v "$PWD:$PWD:z" -w "$PWD" quay.io/konflux-ci/cachi2:latest'
 ```
 
 Note that the alias mounts the current working directory - the container will have access to files in that directory
@@ -230,8 +230,10 @@ still in early development phase.
 
 [cachi2-coverage-badge]: https://codecov.io/github/containerbuildsystem/cachi2/graph/badge.svg?token=VJKRTZQBMY
 [cachi2-coverage-status]: https://codecov.io/github/containerbuildsystem/cachi2
-[cachi2-container]: https://quay.io/repository/redhat-appstudio/cachi2
-[cachi2-container-status]: https://quay.io/repository/redhat-appstudio/cachi2/status
+
+[cachi2-container-badge]: https://img.shields.io/badge/container-latest-blue
+[cachi2-container-status]: https://quay.io/repository/konflux-ci/cachi2/tag/latest
+
 [cachi2-releases]: https://github.com/containerbuildsystem/cachi2/releases
 [sdist-spec]: https://packaging.python.org/en/latest/specifications/source-distribution-format/
 [wheel-spec]: https://packaging.python.org/en/latest/specifications/binary-distribution-format/


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
