### PR TITLE
Generic fetcher: Init package manager

### DIFF
--- a/cachi2/core/models/input.py
+++ b/cachi2/core/models/input.py
@@ -51,7 +51,9 @@ def _present_user_input_error(validation_error: pydantic.ValidationError) -> str
 
 
 # Supported package managers
-PackageManagerType = Literal["bundler", "gomod", "npm", "pip", "rpm", "yarn", "yarn-classic"]
+PackageManagerType = Literal[
+    "bundler", "generic", "gomod", "npm", "pip", "rpm", "yarn", "yarn-classic"
+]
 
 Flag = Literal[
     "cgo-disable", "dev-package-managers", "force-gomod-tidy", "gomod-vendor", "gomod-vendor-check"
@@ -73,6 +75,12 @@ class BundlerPackageInput(_PackageInputBase):
     """Accepted input for a bundler package."""
 
     type: Literal["bundler"]
+
+
+class GenericPackageInput(_PackageInputBase):
+    """Accepted input for generic package."""
+
+    type: Literal["generic"]
 
 
 class GomodPackageInput(_PackageInputBase):
@@ -183,6 +191,7 @@ class YarnClassicPackageInput(_PackageInputBase):
 PackageInput = Annotated[
     Union[
         BundlerPackageInput,
+        GenericPackageInput,
         GomodPackageInput,
         NpmPackageInput,
         PipPackageInput,
@@ -258,6 +267,11 @@ class Request(pydantic.BaseModel):
     def bundler_packages(self) -> list[BundlerPackageInput]:
         """Get the bundler packages specified for this request."""
         return self._packages_by_type(BundlerPackageInput)
+
+    @property
+    def generic_packages(self) -> list[GenericPackageInput]:
+        """Get the generic packages specified for this request."""
+        return self._packages_by_type(GenericPackageInput)
 
     @property
     def gomod_packages(self) -> list[GomodPackageInput]:

--- a/cachi2/core/package_managers/generic.py
+++ b/cachi2/core/package_managers/generic.py
@@ -1,0 +1,33 @@
+from cachi2.core.errors import PackageRejected
+from cachi2.core.models.input import Request
+from cachi2.core.models.output import RequestOutput
+from cachi2.core.models.sbom import Component
+from cachi2.core.rooted_path import RootedPath
+
+DEFAULT_LOCKFILE_NAME = "cachi2_generic.yaml"
+DEFAULT_DEPS_DIR = "deps/generic"
+
+
+def fetch_generic_source(request: Request) -> RequestOutput:
+    """
+    Resolve and fetch generic dependencies for a given request.
+
+    :param request: the request to process
+    """
+    components = []
+    for package in request.generic_packages:
+        path = request.source_dir.join_within_root(package.path)
+        components.extend(_resolve_generic_lockfile(path, request.output_dir))
+    return RequestOutput.from_obj_list(components=components)
+
+
+def _resolve_generic_lockfile(source_dir: RootedPath, output_dir: RootedPath) -> list[Component]:
+    if not source_dir.join_within_root(DEFAULT_LOCKFILE_NAME).path.exists():
+        raise PackageRejected(
+            f"Cachi2 generic lockfile '{DEFAULT_LOCKFILE_NAME}' missing, refusing to continue.",
+            solution=(
+                f"Make sure your repository has cachi2 generic lockfile '{DEFAULT_LOCKFILE_NAME}' checked in "
+                "to the repository."
+            ),
+        )
+    return []

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 from cachi2.core.errors import UnsupportedFeature
 from cachi2.core.models.input import PackageManagerType, Request
 from cachi2.core.models.output import RequestOutput
-from cachi2.core.package_managers import bundler, gomod, npm, pip, rpm, yarn, yarn_classic
+from cachi2.core.package_managers import bundler, generic, gomod, npm, pip, rpm, yarn, yarn_classic
 from cachi2.core.rooted_path import RootedPath
 from cachi2.core.utils import copy_directory
 
@@ -25,6 +25,7 @@ _dev_package_managers: dict[PackageManagerType, Handler] = {
     "bundler": bundler.fetch_bundler_source,
     "rpm": rpm.fetch_rpm_source,
     "yarn-classic": yarn_classic.fetch_yarn_source,
+    "generic": generic.fetch_generic_source,
 }
 
 # This is *only* used to provide a list for `cachi2 --version`

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -105,7 +105,7 @@ class TestPackageInput:
             ),
             pytest.param(
                 {"type": "go-package"},
-                r"Input tag 'go-package' found using 'type' does not match any of the expected tags: 'bundler', 'gomod', 'npm', 'pip', 'rpm', 'yarn-classic', 'yarn'",
+                r"Input tag 'go-package' found using 'type' does not match any of the expected tags: 'bundler', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn-classic', 'yarn'",
                 id="incorrect_type_tag",
             ),
             pytest.param(

--- a/tests/unit/package_managers/test_generic.py
+++ b/tests/unit/package_managers/test_generic.py
@@ -1,0 +1,48 @@
+from unittest import mock
+
+import pytest
+
+from cachi2.core.errors import PackageRejected
+from cachi2.core.models.input import GenericPackageInput
+from cachi2.core.models.sbom import Component
+from cachi2.core.package_managers.generic import (
+    DEFAULT_LOCKFILE_NAME,
+    _resolve_generic_lockfile,
+    fetch_generic_source,
+)
+from cachi2.core.rooted_path import RootedPath
+
+
+@pytest.mark.parametrize(
+    ["model_input", "components"],
+    [
+        pytest.param(GenericPackageInput.model_construct(type="generic"), [], id="single_input"),
+    ],
+)
+@mock.patch("cachi2.core.package_managers.rpm.main.RequestOutput.from_obj_list")
+@mock.patch("cachi2.core.package_managers.generic._resolve_generic_lockfile")
+def test_fetch_generic_source(
+    mock_resolve_generic_lockfile: mock.Mock,
+    mock_from_obj_list: mock.Mock,
+    model_input: GenericPackageInput,
+    components: list[Component],
+) -> None:
+
+    mock_resolve_generic_lockfile.return_value = components
+
+    mock_request = mock.Mock()
+    mock_request.generic_packages = [model_input]
+
+    fetch_generic_source(mock_request)
+
+    mock_resolve_generic_lockfile.assert_called()
+    mock_from_obj_list.assert_called_with(components=components)
+
+
+def test_resolve_generic_no_lockfile(rooted_tmp_path: RootedPath) -> None:
+    with pytest.raises(PackageRejected) as exc_info:
+        _resolve_generic_lockfile(rooted_tmp_path, rooted_tmp_path)
+    assert (
+        f"Cachi2 generic lockfile '{DEFAULT_LOCKFILE_NAME}' missing, refusing to continue"
+        in str(exc_info.value)
+    )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -358,7 +358,7 @@ class TestFetchDeps:
                 [
                     "Error: InvalidInput: 1 validation error for user input",
                     "packages -> 0",
-                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'bundler', 'gomod', 'npm', 'pip', 'rpm', 'yarn-classic', 'yarn'",
+                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'bundler', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn-classic', 'yarn'",
                 ],
             ),
             (
@@ -366,7 +366,7 @@ class TestFetchDeps:
                 [
                     "Error: InvalidInput: 1 validation error for user input",
                     "packages -> 0",
-                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'bundler', 'gomod', 'npm', 'pip', 'rpm', 'yarn-classic', 'yarn'",
+                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'bundler', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn-classic', 'yarn'",
                 ],
             ),
             (
@@ -374,7 +374,7 @@ class TestFetchDeps:
                 [
                     "Error: InvalidInput: 1 validation error for user input",
                     "packages -> 0",
-                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'bundler', 'gomod', 'npm', 'pip', 'rpm', 'yarn-classic', 'yarn'",
+                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'bundler', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn-classic', 'yarn'",
                 ],
             ),
             # Missing package type


### PR DESCRIPTION
This PR bootstraps the new generic fetcher, so it can be contributed to. Basic structure and tests added.  

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
