### PR TITLE
tests: Replace "localhost" domain name with the equivalent IPv4 address

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -9,6 +9,8 @@ from typing import Iterator
 import pytest
 import requests
 
+from tests.integration.utils import TEST_SERVER_LOCALHOST
+
 from . import utils
 
 log = logging.getLogger(__name__)
@@ -59,7 +61,7 @@ def local_pypiserver() -> Iterator[None]:
         for _ in range(60):
             time.sleep(1)
             try:
-                resp = requests.get(f"http://localhost:{pypiserver_port}")
+                resp = requests.get(f"http://{TEST_SERVER_LOCALHOST}:{pypiserver_port}")
                 resp.raise_for_status()
                 log.debug(resp.text)
                 break

--- a/tests/integration/test_data/pip_custom_index/bom.json
+++ b/tests/integration/test_data/pip_custom_index/bom.json
@@ -9,7 +9,7 @@
           "value": "cachi2"
         }
       ],
-      "purl": "pkg:pypi/cachi2-pip-custom-index?vcs_url=git%2Bhttps://github.com/cachito-testing/cachi2-pip-custom-index.git%404d6fe87e62b984cf420e6c8377821a76895b72a8",
+      "purl": "pkg:pypi/cachi2-pip-custom-index?vcs_url=git%2Bhttps://github.com/cachito-testing/cachi2-pip-custom-index.git%4055376bc13904c2f450aac6ee89969d539c8d9f05",
       "type": "library"
     },
     {
@@ -24,7 +24,7 @@
           "value": "true"
         }
       ],
-      "purl": "pkg:pypi/requests@2.32.3?repository_url=http://localhost:8080/simple/",
+      "purl": "pkg:pypi/requests@2.32.3?repository_url=http://127.0.0.1:8080/simple/",
       "type": "library",
       "version": "2.32.3"
     }

--- a/tests/integration/test_pip.py
+++ b/tests/integration/test_pip.py
@@ -136,7 +136,7 @@ log = logging.getLogger(__name__)
         pytest.param(
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-pip-custom-index.git",
-                ref="4d6fe87e62b984cf420e6c8377821a76895b72a8",
+                ref="55376bc13904c2f450aac6ee89969d539c8d9f05",
                 packages=({"path": ".", "type": "pip", "allow_binary": True},),
                 check_vendor_checksums=False,
                 expected_exit_code=0,

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -19,6 +19,9 @@ from git import Repo
 
 from cachi2.core import resolver
 
+# force IPv4 localhost as 'localhost' can resolve with IPv6 as well
+TEST_SERVER_LOCALHOST = "127.0.0.1"
+
 # Individual files could be added to the set as well.
 PATHS_TO_CODE = frozenset((Path("cachi2"), Path("tests/integration")))
 SUPPORTED_PMS: frozenset[str] = frozenset(

--- a/tests/pypiserver/start.sh
+++ b/tests/pypiserver/start.sh
@@ -45,7 +45,7 @@ setup() {
     ls -lA "$WORKDIR/auth"
     tar cf - -C "$WORKDIR/auth" . | podman volume import cachi2-pypiserver-auth -
 
-    echo -e "\n--- Starting pypiserver on http://localhost:${PYPISERVER_PORT:-8080} ---\n"
+    echo -e "\n--- Starting pypiserver on http://127.0.0.1:${PYPISERVER_PORT:-8080} ---\n"
 }
 
 setup >&2

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ passenv =
     PYPISERVER_IMAGE
     PYPISERVER_PORT
 setenv =
-    CACHI2_TEST_NETRC_CONTENT={env:CACHI2_TEST_NETRC_CONTENT:machine localhost login cachi2-user password cachi2-pass}
+    CACHI2_TEST_NETRC_CONTENT={env:CACHI2_TEST_NETRC_CONTENT:machine 127.0.0.1 login cachi2-user password cachi2-pass}
 basepython = python3
 skip_install = true
 commands =


### PR DESCRIPTION
It's common that "localhost" translates with both IPv4 and IPv6. The simple containerized test PyPI server we use in our CI doesn't listen on IPv6 which may cause unpredictable issues on hosts where IPv6 is enabled and IPv6 would get prioritized by the low level network stack connection primitives. Therefore, use an IP explicitly to avoid any potential issues during pytest run, e.g.:

    DEBUG Starting new HTTP connection (1): localhost:8080
    DEBUG ('Connection aborted.',
           ConnectionResetError(104, 'Connection reset by peer'))


**PR depends on:** https://github.com/cachito-testing/cachi2-pip-custom-index/pull/1
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Docs updated (if applicable)
- [x] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
