### PR TITLE
[GH workflows] Execute the integration test suite directly on the VM runner & run the simple PyPI test server as a service

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -91,7 +91,10 @@ jobs:
 
   build-image:
     name: Build Cachi2 image and run integration tests on it
-    runs-on: ubuntu-latest
+
+    # TODO: Replace this with ubuntu-latest once GH completes the migration of the VM runners to
+    # ubuntu 24.04 and respect the YAML tag (revert the commit that added this)
+    runs-on: ubuntu-24.04
     container:
       image: registry.fedoraproject.org/fedora:40
       options: --privileged

--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -107,6 +107,20 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: PyPI test server start
+        run: |
+          tests/pypiserver/start.sh &
+
+          # Testing basic HTTP request
+          status=$(curl -sSI \
+                        --output /dev/null \
+                        --write-out %{http_code} \
+                        --retry-delay 1 \
+                        --retry 60 \
+                        --retry-all-errors \
+                        http://127.0.0.1:8080)
+          [[ ${status} == "200" ]] || exit 1
+
       - name: Build Cachi2 image
         run: |
           podman build -t cachi2:${{ github.sha }} .

--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -95,20 +95,12 @@ jobs:
     # TODO: Replace this with ubuntu-latest once GH completes the migration of the VM runners to
     # ubuntu 24.04 and respect the YAML tag (revert the commit that added this)
     runs-on: ubuntu-24.04
-    container:
-      image: registry.fedoraproject.org/fedora:40
-      options: --privileged
-      volumes:
-      # https://github.com/containers/buildah/issues/3666
-      - /var/lib/containers:/var/lib/containers
-
     steps:
       - name: Install required packages
         run: |
-          dnf distro-sync -y
-          dnf install -y python3 python3-devel python3-pip gcc git podman
-          pip3 install --upgrade pip
-          pip3 install tox tox-gh-actions
+          python3 -m venv /var/tmp/venv
+          /var/tmp/venv/bin/pip3 install --upgrade pip
+          /var/tmp/venv/bin/pip3 install tox
 
       - name: add checkout action...
         uses: actions/checkout@v4
@@ -130,4 +122,4 @@ jobs:
           CACHI2_TEST_LOCAL_PYPISERVER: 'true'
         run: |
           git config --global --add safe.directory "*"
-          tox -e integration
+          /var/tmp/venv/bin/tox -e integration

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -47,7 +47,11 @@ def cachi2_image() -> utils.Cachi2Image:
 # test output.
 @pytest.fixture(autouse=True, scope="session")
 def local_pypiserver() -> Iterator[None]:
-    if os.getenv("CACHI2_TEST_LOCAL_PYPISERVER") != "true":
+    if (
+        os.getenv("CI")
+        and os.getenv("GITHUB_ACTIONS")
+        or os.getenv("CACHI2_TEST_LOCAL_PYPISERVER") != "true"
+    ):
         yield
         return
 

--- a/tox.ini
+++ b/tox.ini
@@ -53,6 +53,10 @@ passenv =
     CACHI2_TEST_LOCAL_PYPISERVER
     PYPISERVER_IMAGE
     PYPISERVER_PORT
+
+    # Github actions variables
+    CI
+    GITHUB_ACTIONS
 setenv =
     CACHI2_TEST_NETRC_CONTENT={env:CACHI2_TEST_NETRC_CONTENT:machine 127.0.0.1 login cachi2-user password cachi2-pass}
 basepython = python3


### PR DESCRIPTION
This PR is effectively just a vol.1 in a series of small refactorings of our GH CI.
This one only takes care of how:
- we run the integration test suite
- we spin up helper services

This PR **does not** tweak how logs are captured from GH workflows, those remain messy and will handled as part of a different work.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
