### PR TITLE
yarn: frozen-lockfile integration test

### DIFF
--- a/tests/integration/test_yarn_classic.py
+++ b/tests/integration/test_yarn_classic.py
@@ -56,6 +56,20 @@ log = logging.getLogger(__name__)
         pytest.param(
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
+                ref="invalid_frozen_lockfile_add_dependency",
+                packages=({"path": ".", "type": "yarn-classic"},),
+                flags=["--dev-package-managers"],
+                check_output=False,
+                check_deps_checksums=False,
+                check_vendor_checksums=False,
+                expected_exit_code=1,
+                expected_output="Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.",
+            ),
+            id="yarn_invalid_frozen_lockfile_add_dependency",
+        ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-yarn.git",
                 ref="200cc9423b1df173c12b61f951e463d8a18d9e19",
                 packages=({"path": ".", "type": "yarn-classic"},),
                 flags=["--dev-package-managers"],


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
