### PR TITLE
.github: dependabot: Ignore pydantic-core

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,15 +24,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
-        exclude-patterns:
-          - "pydantic*"
-
-      # pydantic is a known violator of version updates where they don't release the core backend
-      # with the API library at the same time which holds up other legitimate updates, so group
-      # pydantic deps together
-      pydantic:
-        update-types:
-          - "minor"
-          - "patch"
-        patterns:
-          - "pydantic*"
+    ignore:
+      # pydantic is designed to be used with a single version of pydantic-core [1] which follows a
+      # different release cycle and is our nr.1 violator of version updates blocking other
+      # dependency version updates to be accepted
+      - dependency-name: "pydantic-core"


### PR DESCRIPTION
pydantic is designed to be used with a single version of pydantic-core [1] which follows a different release cycle and currently is our nr.1 violator of version updates blocking other dependency version updates to be accepted.

Dependabot, however, currently can't comply with transitive version range constraints, always happily bumping all pip-compile locked versions to the latest one possible anyway, potentially leading to unresolvable requirements.txt files for the pip ecosystem [2] and so even if pydantic adopted a '<=' version constraint it wouldn't help us at all. Therefore, put pydantic-core to the dependabot ignore set and let be freely installed via pip's pydantic resolution based on the ^above.

[1] https://github.com/pydantic/pydantic/discussions/10670
[2] https://github.com/dependabot/dependabot-core/issues/5140

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
