### PR TITLE
yarn: Universal utility for Yarn version detection

### DIFF
--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -122,7 +122,7 @@ def _configure_yarn_version(project: Project) -> None:
     yarn_path_version = get_semver_from_yarn_path(project.yarn_rc.yarn_path)
     package_manager_version = get_semver_from_package_manager(project.package_json.package_manager)
 
-    if not yarn_path_version and not package_manager_version:
+    if yarn_path_version is None and package_manager_version is None:
         raise PackageRejected(
             "Unable to determine the yarn version to use to process the request",
             solution=(

--- a/cachi2/core/package_managers/yarn/main.py
+++ b/cachi2/core/package_managers/yarn/main.py
@@ -13,7 +13,11 @@ from cachi2.core.package_managers.yarn.project import (
     get_semver_from_yarn_path,
 )
 from cachi2.core.package_managers.yarn.resolver import create_components, resolve_packages
-from cachi2.core.package_managers.yarn.utils import extract_yarn_version_from_env, run_yarn_cmd
+from cachi2.core.package_managers.yarn.utils import (
+    VersionsRange,
+    extract_yarn_version_from_env,
+    run_yarn_cmd,
+)
 from cachi2.core.rooted_path import RootedPath
 
 log = logging.getLogger(__name__)
@@ -127,9 +131,9 @@ def _configure_yarn_version(project: Project) -> None:
             ),
         )
 
-    # Note (mypy): version cannot be None anymore after the next statement
     version = yarn_path_version if yarn_path_version else package_manager_version
-    if version.compare("3.0.0") < 0 or version.major == 4:  # type: ignore
+    # By this point version is not Optional anymore, but mypy does not think so.
+    if version not in VersionsRange("3.0.0", "4.0.0"):  # type: ignore
         raise PackageRejected(
             f"Unsupported Yarn version '{version}' detected",
             solution="Please pick a different version of Yarn (3.0.0<= Yarn version <4.0.0)",

--- a/cachi2/core/package_managers/yarn/utils.py
+++ b/cachi2/core/package_managers/yarn/utils.py
@@ -1,6 +1,6 @@
 import os
 import subprocess
-from typing import Optional
+from typing import Optional, Union
 
 from semver import Version
 
@@ -29,6 +29,60 @@ def run_yarn_cmd(
     except subprocess.CalledProcessError as e:
         # the yarn command writes the errors to stdout
         raise PackageManagerError(f"Yarn command failed: {' '.join(cmd)}", stderr=e.stdout)
+
+
+SemverLike = Union[Version, str]
+
+
+class VersionsRange:
+    """Represents a version range for cleaner version constrains checks.
+
+    Versions range is a right-open interval:
+    >>> Version.parse("1.2.3") in VersionsRange("3.0.0", "4.0.0")
+    False
+    >>> Version.parse("1.2.3") in VersionsRange("1.0.0", "2.0.0")
+    True
+    >>> Version.parse("1.0.0") in VersionsRange("1.0.0", "2.0.0")
+    True
+    >>> Version.parse("2.0.0") in VersionsRange("1.0.0", "2.0.0")
+    False
+
+    Release candidates are a special case, they are ignored within the
+    interval and cause immediate rejection on any of the boundaries:
+    >>> Version.parse("2.0.0-rc1") in VersionsRange("1.0.0", "2.0.0")
+    False
+    >>> Version.parse("1.0.0-rc1") in VersionsRange("1.0.0", "2.0.0")
+    False
+    >>> Version.parse("1.5.0-rc1") in VersionsRange("1.0.0", "2.0.0")
+    True
+    """
+
+    def __init__(self, min_ver: SemverLike, max_ver: SemverLike) -> None:
+        """Initialize a version range."""
+        self.min_ver = min_ver if isinstance(min_ver, Version) else Version.parse(min_ver)
+        self.max_ver = max_ver if isinstance(max_ver, Version) else Version.parse(max_ver)
+
+    def __contains__(self, other: Version) -> bool:
+        if not isinstance(other, self.min_ver.__class__):
+            return False
+        # The original version check logic (as captured in UTs) broke with direct
+        # version comparison rules, e.g. 4.0.0-rc1 would have been considered
+        # version 4 and would  have been rejected basing on major version
+        # only. Direct comparison of Version object would have resulted in 4.0.0-rc1
+        # being strictly within 4.0.0 interval (since rcN is not a version yet).
+        # The original implementation considered anything starting with
+        # a different major version an outlier. The logic below captures this
+        # with a special case for versions with prerelease field set.
+        if other.prerelease:
+            # Drop prerelease:
+            other_ver = Version(other.major, other.minor, other.patch)
+            # Treat boundaries separately:
+            if other_ver == self.min_ver or other_ver == self.max_ver:
+                return False
+            # Continue as usual otherwise:
+            return other_ver >= self.min_ver and other < self.max_ver
+        else:
+            return other >= self.min_ver and other < self.max_ver
 
 
 def extract_yarn_version_from_env(source_dir: RootedPath, env: Optional[dict] = None) -> Version:

--- a/cachi2/core/package_managers/yarn_classic/main.py
+++ b/cachi2/core/package_managers/yarn_classic/main.py
@@ -1,11 +1,13 @@
 import logging
 
-import semver
-
 from cachi2.core.errors import PackageManagerError
 from cachi2.core.models.input import Request
 from cachi2.core.models.output import Component, EnvironmentVariable, RequestOutput
-from cachi2.core.package_managers.yarn.utils import extract_yarn_version_from_env, run_yarn_cmd
+from cachi2.core.package_managers.yarn.utils import (
+    VersionsRange,
+    extract_yarn_version_from_env,
+    run_yarn_cmd,
+)
 from cachi2.core.package_managers.yarn_classic.workspaces import extract_workspace_metadata
 from cachi2.core.rooted_path import RootedPath
 
@@ -93,12 +95,7 @@ def _verify_corepack_yarn_version(source_dir: RootedPath, env: dict[str, str]) -
     """Verify that corepack installed the correct version of yarn by checking `yarn --version`."""
     installed_yarn_version = extract_yarn_version_from_env(source_dir, env)
 
-    min_version_inclusive = semver.version.Version(1, 22, 0)
-    max_version_exclusive = semver.version.Version(2, 0, 0)
-    if (
-        installed_yarn_version < min_version_inclusive
-        or installed_yarn_version >= max_version_exclusive
-    ):
+    if installed_yarn_version not in VersionsRange("1.22.0", "2.0.0"):
         raise PackageManagerError(
             "Cachi2 expected corepack to install yarn >=1.22.0,<2.0.0, but instead "
             f"found yarn@{installed_yarn_version}."

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -122,7 +122,7 @@ def test_configure_yarn_version(
         pytest.param("1.0.0\n", id="yarn_versions_match_with_whitespace"),
     ],
 )
-@mock.patch("cachi2.core.package_managers.yarn.main.run_yarn_cmd")
+@mock.patch("cachi2.core.package_managers.yarn.utils.run_yarn_cmd")
 def test_corepack_installed_correct_yarn_version(
     mock_run_yarn_cmd: mock.Mock,
     corepack_yarn_version: str,
@@ -144,7 +144,7 @@ def test_corepack_installed_correct_yarn_version(
         pytest.param("2", id="invalid_semver"),
     ],
 )
-@mock.patch("cachi2.core.package_managers.yarn.main.run_yarn_cmd")
+@mock.patch("cachi2.core.package_managers.yarn.utils.run_yarn_cmd")
 def test_corepack_installed_correct_yarn_version_fail(
     mock_run_yarn_cmd: mock.Mock,
     corepack_yarn_version: str,

--- a/tests/unit/package_managers/yarn_classic/test_main.py
+++ b/tests/unit/package_managers/yarn_classic/test_main.py
@@ -130,7 +130,7 @@ def test_get_prefetch_environment_variables(tmp_path: Path) -> None:
         pytest.param("1.22.0\n", id="valid_version_with_whitespace"),
     ],
 )
-@mock.patch("cachi2.core.package_managers.yarn_classic.main.run_yarn_cmd")
+@mock.patch("cachi2.core.package_managers.yarn.utils.run_yarn_cmd")
 def test_verify_corepack_yarn_version(
     mock_run_yarn_cmd: mock.Mock, yarn_version_output: str, tmp_path: Path
 ) -> None:
@@ -149,7 +149,7 @@ def test_verify_corepack_yarn_version(
         pytest.param("2.0.0", id="version_too_high"),
     ],
 )
-@mock.patch("cachi2.core.package_managers.yarn_classic.main.run_yarn_cmd")
+@mock.patch("cachi2.core.package_managers.yarn.utils.run_yarn_cmd")
 def test_verify_corepack_yarn_version_disallowed_version(
     mock_run_yarn_cmd: mock.Mock, yarn_version_output: str, tmp_path: Path
 ) -> None:
@@ -163,7 +163,7 @@ def test_verify_corepack_yarn_version_disallowed_version(
         _verify_corepack_yarn_version(RootedPath(tmp_path), env={"foo": "bar"})
 
 
-@mock.patch("cachi2.core.package_managers.yarn_classic.main.run_yarn_cmd")
+@mock.patch("cachi2.core.package_managers.yarn.utils.run_yarn_cmd")
 def test_verify_corepack_yarn_version_invalid_version(
     mock_run_yarn_cmd: mock.Mock, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
This commit unifies handling of version info for Yarn and Yarn Classic package managers.

Resolves: https://github.com/containerbuildsystem/cachi2/issues/660

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
