### PR TITLE
bug: Don't skip integration tests on Dockerfile change

### DIFF
--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -23,7 +23,9 @@ from cachi2.core import resolver
 TEST_SERVER_LOCALHOST = "127.0.0.1"
 
 # Individual files could be added to the set as well.
-PATHS_TO_CODE = frozenset((Path("cachi2"), Path("tests/integration")))
+PATHS_TO_CODE = frozenset(
+    (Path("cachi2"), Path("tests/integration"), Path("Dockerfile"), Path("Containerfile"))
+)
 SUPPORTED_PMS: frozenset[str] = frozenset(
     list(resolver._package_managers) + list(resolver._dev_package_managers)
 )
@@ -584,6 +586,10 @@ def is_testable_code(c: Path) -> bool:
     False
     >>> is_testable_code(Path('reqruiements.txt'))
     False
+    >>> is_testable_code(Path('Dockerfile'))
+    True
+    >>> is_testable_code(Path('Containerfile'))
+    True
     """
     return any(c.is_relative_to(p) for p in PATHS_TO_CODE)
 


### PR DESCRIPTION
The logic for skipping integration tests also skipped them when Dockerfile is changed. This commit adds Dockerfile (and Containerfile just in case) to the list of locations that must be tested.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
