### PR TITLE
Revert "Dockerfile: bump library/node from 22.9.0-bullseye to 23.0.0-bullseye"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi@sha256:b00d5990a00937bd1ef7f44547af6c7fd36e3fd410e2c89b5d2dfc1aff69fe99 as ubi
 FROM docker.io/library/golang:1.20.0-bullseye as golang_120
 FROM docker.io/library/golang:1.21.0-bullseye as golang_121
-FROM docker.io/library/node:23.0.0-bullseye as node
+FROM docker.io/library/node:22.9.0-bullseye as node
 
 ########################
 # PREPARE OUR BASE IMAGE


### PR DESCRIPTION
Reverts containerbuildsystem/cachi2#695

A breaking change slipped in and now yarn complains about package checksums when it is not supposed to (see https://github.com/containerbuildsystem/cachi2/actions/runs/11461916749/job/31900425880?pr=686 for an example). Let's revert the change until we figure out what exactly has to be done with e2e tests and merge https://github.com/containerbuildsystem/cachi2/pull/702 in the meantime.