### PR TITLE
Revert "Dockerfile: bump library/node from 22.9.0-bullseye to 23.0.0-…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi@sha256:b00d5990a00937bd1ef7f44547af6c7fd36e3fd410e2c89b5d2dfc1aff69fe99 as ubi
 FROM docker.io/library/golang:1.20.0-bullseye as golang_120
 FROM docker.io/library/golang:1.21.0-bullseye as golang_121
-FROM docker.io/library/node:23.0.0-bullseye as node
+FROM docker.io/library/node:22.9.0-bullseye as node
 
 ########################
 # PREPARE OUR BASE IMAGE


### PR DESCRIPTION
…bullseye"

This reverts commit 5cd224a16321ae303ae0d17a2ac7edd8fc4704cd.

A breaking change slipped in and now yarn complains about package checksums when it is not supposed to (see https://github.com/containerbuildsystem/cachi2/actions/runs/11461916749/job/31900425880?pr=686 for an example). Let's revert the change until we figure out what exactly has to be done with e2e tests and merge https://github.com/containerbuildsystem/cachi2/pull/702 in the meantime.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
