### PR TITLE
testing: Adding rules to run all ITs on dependencies changes

### DIFF
--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -24,7 +24,15 @@ TEST_SERVER_LOCALHOST = "127.0.0.1"
 
 # Individual files could be added to the set as well.
 PATHS_TO_CODE = frozenset(
-    (Path("cachi2"), Path("tests/integration"), Path("Dockerfile"), Path("Containerfile"))
+    (
+        Path("cachi2"),
+        Path("tests/integration"),
+        Path("Dockerfile"),
+        Path("Containerfile"),
+        Path("requirements.txt"),
+        Path("requirements-extras.txt"),
+        Path("pyproject.toml"),
+    )
 )
 SUPPORTED_PMS: frozenset[str] = frozenset(
     list(resolver._package_managers) + list(resolver._dev_package_managers)
@@ -584,8 +592,12 @@ def is_testable_code(c: Path) -> bool:
     True
     >>> is_testable_code(Path('README.md'))
     False
-    >>> is_testable_code(Path('reqruiements.txt'))
-    False
+    >>> is_testable_code(Path('requirements.txt'))
+    True
+    >>> is_testable_code(Path('pyproject.toml'))
+    True
+    >>> is_testable_code(Path('requirements-extras.txt'))
+    True
     >>> is_testable_code(Path('Dockerfile'))
     True
     >>> is_testable_code(Path('Containerfile'))


### PR DESCRIPTION
Adding rules to ensure that all integration tests are run when any file with project dependencies is modified.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
