### PR TITLE
CONTRIBUTING: Update the release schedule: Increase cadence by a week

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -289,5 +289,8 @@ upon publishment.*
 
 ## Release schedule
 
-This project follows a two-week release cycle. Note that a release might be skipped if there's no
-significant changes to release.
+This project follows a weekly release schedule, with planned releases every Tuesday. If there is no
+significant content to ship on a given release day, we may skip it. Urgent bug and security fixes
+are released promptly as needed at the team’s discretion.
+Should we encounter any CI issues on the day of a release, we either release immediately after the
+issue is resolved or skip the release based on the nature of the changes (urgent vs regular).


### PR DESCRIPTION
2 weeks may be too slow for some ultra-agile, rapid development consumers of this project, often having led to breaking the scheduled pattern and resorting to releases on an ad-hoc basis. Let's shorten the schedule by a week, describing scenarios at which a given release may be at risk.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
