### PR TITLE
generic fetcher: Generate SBOM components

### DIFF
--- a/cachi2/core/models/sbom.py
+++ b/cachi2/core/models/sbom.py
@@ -21,6 +21,13 @@ class Property(pydantic.BaseModel):
     value: str
 
 
+class ExternalReference(pydantic.BaseModel):
+    """An ExternalReference inside an SBOM component."""
+
+    url: str
+    type: Literal["distribution"] = "distribution"
+
+
 FOUND_BY_CACHI2_PROPERTY: Property = Property(name="cachi2:found_by", value="cachi2")
 
 
@@ -35,7 +42,10 @@ class Component(pydantic.BaseModel):
     purl: str
     version: Optional[str] = None
     properties: list[Property] = pydantic.Field(default_factory=list, validate_default=True)
-    type: Literal["library"] = "library"
+    type: Literal["library", "file"] = "library"
+    external_references: Optional[list[ExternalReference]] = pydantic.Field(
+        serialization_alias="externalReferences", default=None
+    )
 
     def key(self) -> str:
         """Uniquely identifies a package.

--- a/tests/integration/test_data/generic_e2e/bom.json
+++ b/tests/integration/test_data/generic_e2e/bom.json
@@ -1,6 +1,41 @@
 {
   "bomFormat": "CycloneDX",
-  "components": [],
+  "components": [
+    {
+      "externalReferences": [
+        {
+          "type": "distribution",
+          "url": "https://github.com/cachito-testing/cachi2-generic/archive/refs/tags/v2.0.0.zip"
+        }
+      ],
+      "name": "archive.zip",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:generic/archive.zip?checksums=sha256:386428a82f37345fa24b74068e0e79f4c1f2ff38d4f5c106ea14de4a2926e584&download_url=https://github.com/cachito-testing/cachi2-generic/archive/refs/tags/v2.0.0.zip",
+      "type": "file"
+    },
+    {
+      "externalReferences": [
+        {
+          "type": "distribution",
+          "url": "https://github.com/cachito-testing/cachi2-generic/archive/refs/tags/v1.0.0.zip"
+        }
+      ],
+      "name": "v1.0.0.zip",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:generic/v1.0.0.zip?checksums=sha256:4fbcaa2a8d17c1f8042578627c122361ab18b7973311e7e9c598696732902f87&download_url=https://github.com/cachito-testing/cachi2-generic/archive/refs/tags/v1.0.0.zip",
+      "type": "file"
+    }
+  ],
   "metadata": {
     "tools": [
       {


### PR DESCRIPTION
Generic fetcher now generates SBOM components of purl type pkg:generic. It also produces externalReferences of type distribution for each generic component to allow for gating at later time.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
