### PR TITLE
generic fetcher: Add usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ Supported:
 * [yarn](#yarn)
 * [bundler](#bundler)
 
+Experimental:
+
+* [generic fetcher](#generic-fetcher)
+
 Planned:
 
 * dnf
@@ -236,6 +240,18 @@ on the dependencies specified in the [Gemfile](https://bundler.io/v2.5/man/gemfi
 Both files must be present in the source repository so you should check them into your git repository.
 
 See [docs/bundler.md](docs/bundler.md) for more details.
+
+### generic fetcher
+
+Generic fetcher is a way for Cachi2 to support prefetching arbitrary files that don't fit into other package managers.
+With the generic fetcher, you can easily fetch those files with Cachi2 along with your other language-specific dependencies,
+satisfy the hermetic build condition and have them recorded in the SBOM.
+
+Cachi2 uses a simple custom lockfile named `generic_lockfile.yaml` that is expected to be present in the repository. The
+lockfile describes the urls, checksums and target locations for the downloaded files. The generic fetcher is currently an
+experimental feature, so cachi2 has to be run with `--dev-package-managers` flag. 
+
+See [docs/usage.md](docs/usage.md#pre-fetch-dependencies-generic-fetcher) for more details.
 
 ## Project status
 


### PR DESCRIPTION
Add documentation on how to use the generic fetcher and also an ADR to help move out of the experimental phase.

I've tried to follow the CONTRIBUTING.md guidelines, but since I did not see any previous ADR, I just tried to come up with something. Feel free to give more direction on how you want the docs to look like. Thanks!

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
