### PR TITLE
generic fetcher: Official support with ADR

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,6 @@ Supported:
 * [npm](#npm)
 * [yarn](#yarn)
 * [bundler](#bundler)
-
-Experimental:
-
 * [generic fetcher](#generic-fetcher)
 
 Planned:
@@ -248,8 +245,7 @@ With the generic fetcher, you can easily fetch those files with Cachi2 along wit
 satisfy the hermetic build condition and have them recorded in the SBOM.
 
 Cachi2 uses a simple custom lockfile named `generic_lockfile.yaml` that is expected to be present in the repository. The
-lockfile describes the urls, checksums and target locations for the downloaded files. The generic fetcher is currently an
-experimental feature, so cachi2 has to be run with `--dev-package-managers` flag. 
+lockfile describes the urls, checksums and target locations for the downloaded files.
 
 See [docs/usage.md](docs/usage.md#pre-fetch-dependencies-generic-fetcher) for more details.
 

--- a/cachi2/core/models/input.py
+++ b/cachi2/core/models/input.py
@@ -122,6 +122,7 @@ class GenericPackageInput(_PackageInputBase):
     """Accepted input for generic package."""
 
     type: Literal["generic"]
+    lockfile: Optional[Path] = None
 
 
 class GomodPackageInput(_PackageInputBase):

--- a/cachi2/core/package_managers/generic/main.py
+++ b/cachi2/core/package_managers/generic/main.py
@@ -62,14 +62,14 @@ def _resolve_generic_lockfile(source_dir: RootedPath, output_dir: RootedPath) ->
 
     for artifact in lockfile.artifacts:
         # create the parent directory for the artifact
-        Path.mkdir(Path(artifact.target).parent, parents=True, exist_ok=True)
-        to_download[str(artifact.download_url)] = artifact.target
+        Path.mkdir(Path(artifact.filename).parent, parents=True, exist_ok=True)
+        to_download[str(artifact.download_url)] = artifact.filename
 
     asyncio.run(async_download_files(to_download, get_config().concurrency_limit))
 
     # verify checksums
     for artifact in lockfile.artifacts:
-        must_match_any_checksum(artifact.target, artifact.formatted_checksums)
+        must_match_any_checksum(artifact.filename, artifact.formatted_checksums)
     return _generate_sbom_components(lockfile)
 
 
@@ -110,7 +110,7 @@ def _generate_sbom_components(lockfile: GenericLockfileV1) -> list[Component]:
     components: list[Component] = []
 
     for artifact in lockfile.artifacts:
-        name = Path(artifact.target).name
+        name = Path(artifact.filename).name
         url = str(artifact.download_url)
         checksums = ",".join([f"{algo}:{digest}" for algo, digest in artifact.checksums.items()])
         component = Component(

--- a/cachi2/core/package_managers/generic/main.py
+++ b/cachi2/core/package_managers/generic/main.py
@@ -19,7 +19,7 @@ from cachi2.core.package_managers.generic.models import GenericLockfileV1
 from cachi2.core.rooted_path import RootedPath
 
 log = logging.getLogger(__name__)
-DEFAULT_LOCKFILE_NAME = "generic_lockfile.yaml"
+DEFAULT_LOCKFILE_NAME = "artifacts.lock.yaml"
 DEFAULT_DEPS_DIR = "deps/generic"
 
 

--- a/cachi2/core/package_managers/generic/main.py
+++ b/cachi2/core/package_managers/generic/main.py
@@ -69,7 +69,7 @@ def _resolve_generic_lockfile(source_dir: RootedPath, output_dir: RootedPath) ->
 
     # verify checksums
     for artifact in lockfile.artifacts:
-        must_match_any_checksum(artifact.filename, artifact.formatted_checksums)
+        must_match_any_checksum(artifact.filename, [artifact.formatted_checksum])
     return _generate_sbom_components(lockfile)
 
 
@@ -112,7 +112,6 @@ def _generate_sbom_components(lockfile: GenericLockfileV1) -> list[Component]:
     for artifact in lockfile.artifacts:
         name = Path(artifact.filename).name
         url = str(artifact.download_url)
-        checksums = ",".join([f"{algo}:{digest}" for algo, digest in artifact.checksums.items()])
         component = Component(
             name=name,
             purl=PackageURL(
@@ -120,7 +119,7 @@ def _generate_sbom_components(lockfile: GenericLockfileV1) -> list[Component]:
                 name=name,
                 qualifiers={
                     "download_url": url,
-                    "checksums": checksums,
+                    "checksum": artifact.checksum,
                 },
             ).to_string(),
             type="file",

--- a/cachi2/core/package_managers/generic/models.py
+++ b/cachi2/core/package_managers/generic/models.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Literal
 from urllib.parse import urlparse
 
-from pydantic import AnyUrl, BaseModel, field_validator, model_validator
+from pydantic import AnyUrl, BaseModel, ConfigDict, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 
 from cachi2.core.checksum import ChecksumInfo
@@ -18,6 +18,7 @@ class LockfileMetadata(BaseModel):
     """Defines format of the metadata section in the lockfile."""
 
     version: Literal["1.0"]
+    model_config = ConfigDict(extra="forbid")
 
 
 class LockfileArtifact(BaseModel):
@@ -32,6 +33,7 @@ class LockfileArtifact(BaseModel):
     download_url: AnyUrl
     filename: str = ""
     checksum: str
+    model_config = ConfigDict(extra="forbid")
 
     @field_validator("checksum")
     @classmethod
@@ -76,6 +78,7 @@ class GenericLockfileV1(BaseModel):
 
     metadata: LockfileMetadata
     artifacts: list[LockfileArtifact]
+    model_config = ConfigDict(extra="forbid")
 
     @model_validator(mode="after")
     def no_artifact_conflicts(self) -> "GenericLockfileV1":

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -18,6 +18,7 @@ _package_managers: dict[PackageManagerType, Handler] = {
     "npm": npm.fetch_npm_source,
     "pip": pip.fetch_pip_source,
     "yarn": yarn.fetch_yarn_source,
+    "generic": generic.fetch_generic_source,
 }
 
 # This is where we put package managers currently under development in order to
@@ -25,7 +26,6 @@ _package_managers: dict[PackageManagerType, Handler] = {
 _dev_package_managers: dict[PackageManagerType, Handler] = {
     "rpm": rpm.fetch_rpm_source,
     "yarn-classic": yarn_classic.fetch_yarn_source,
-    "generic": generic.fetch_generic_source,
 }
 
 # This is *only* used to provide a list for `cachi2 --version`

--- a/docs/adr/0001-add-generic-fetcher.md
+++ b/docs/adr/0001-add-generic-fetcher.md
@@ -1,0 +1,102 @@
+# Add generic fetcher
+
+## Context
+
+Some users need to download arbitrary files that don't fit within an established package ecosystem cachi2 could
+potentially otherwise support. The target audience is users that want to use cachi2 to achieve hermetic builds
+and also want an easy way to include these arbitrary files, that cachi2 will account for in the SBOM it produces.
+
+## Decision
+
+A new package manager for generic artifacts must be introduced. This package manager utilizes a custom
+lockfile based on which it will download files, save them into a requested location, and verify checksums.
+Below is a more detailed overview of the implementation.
+
+### Lockfile format
+
+Cachi2 expects the lockfile to be named `artifacts.lock.yaml`.
+In order to account for possible future breaking changes, the lockfile will contain a `metadata` section with a `version`
+field that will indicate the version of the lockfile format. It will also contain a list of artifacts (files) to download,
+each of the artifacts to having a URL, a checksum, and optionally output filename specified.
+
+```yaml
+metadata:
+  # uses X.Y semantic versioning
+  version: "1.0"
+artifacts:
+  - download_url: https://huggingface.co/instructlab/granite-7b-lab/resolve/main/model-00001-of-00003.safetensors?download=true
+    filename: granite-model-1.safetensors
+    checksum: sha256:d16bf783cb6670f7f692ad7d6885ab957c63cfc1b9649bc4a3ba1cfbdfd5230c
+```
+
+#### Lockfile properties
+
+Below is an explanation of individual properties of the lockfile.
+
+##### download_url (required)
+
+Specified as a string containing the download url of the artifact.
+
+##### checksum (required)
+
+Specified as string in the format of "algorithm:hash". Must be provided to ensure the identity of the artifact.
+
+#### filename (optional)
+
+This key is provided mainly for the users convenience, so the files end up in expected locations. It is optional and if
+not specified, it will be derived from the download_url. Filename here is a path inside cachi2's output directory for
+the generic fetcher (`{cachi2-output-dir}/deps/generic`). Cachi2 will verify that the resulting filenames, including those
+derived from download urls do not overlap.
+
+### SBOM components
+
+Artifacts fetched with the generic fetcher will all be recorded in the SBOM cachi2 produces. Given the inability to derive
+any extra information about these files beyond a download location and a filename, these files will always be recorded
+as SBOM components with purl of type generic.
+
+Additionally, the SBOM component will contain [externalReferences] of type `distribution` to indicate the url used to download
+the file to allow for easier handling for tools that might process the SBOM.
+
+Here's an example SBOM generated for above file.
+
+```json
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "granite-model-1.safetensors",
+      "purl": "pkg:generic/granite-model-1.safetensors?checksum=sha256:d16bf783cb6670f7f692ad7d6885ab957c63cfc1b9649bc4a3ba1cfbdfd5230c&download_url=https://huggingface.co/instructlab/granite-7b-lab/resolve/main/model-00001-of-00003.safetensors",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "file",
+      "externalReferences": [
+        {
+          "url": "https://huggingface.co/instructlab/granite-7b-lab/resolve/main/model-00001-of-00003.safetensors",
+          "type": "distribution"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "vendor": "red hat",
+        "name": "cachi2"
+      }
+    ]
+  },
+  "specVersion": "1.4",
+  "version": 1
+}
+```
+
+## Consequences
+
+As mentioned before, this package manager enables users to fetch arbitrary files with cachi2 and have them accounted for
+in the SBOM.
+
+[externalReferences]: https://cyclonedx.org/docs/1.6/json/#components_items_externalReferences

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -612,8 +612,9 @@ git clone -b sample-app https://github.com/cachito-testing/cachi2-generic.git
 ```
 
 #### Pre-fetch dependencies (generic fetcher)
-In order to retrieve the archive with the tool, a `artifacts.lock.yaml` needs to be in the repository. You can find a
-sample lockfile below. It is identical to one found in the [sample repository](https://github.com/cachito-testing/cachi2-generic/tree/sample-app).
+In order to retrieve the archive with the tool, either a `artifacts.lock.yaml` needs to be in the repository, or an absolute
+path needs to be supplied in the JSON input, pointing to a lockfile. You can find a sample lockfile below. It is identical
+to the one found in the [sample repository](https://github.com/cachito-testing/cachi2-generic/tree/sample-app).
 A lockfile for the generic fetcher must contain a `metadata` header and a list of artifacts, where each artifact is
 represented as a pair of URL and a checksum string in the format of `"algorithm:checksum"`:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -634,7 +634,7 @@ is assumed to be `.`. Since generic fetcher is still an experimental feature, it
 enabled with the `--dev-package-managers` flag.
 
 ```
-cachi2 fetch-deps --source ./cachi2-generic --output ./cachi2-output generic --dev-package-managers
+cachi2 fetch-deps --source ./cachi2-generic --output ./cachi2-output generic
 ```
 
 #### Build the application image (generic fetcher)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -616,7 +616,8 @@ In order to retrieve the archive with the tool, either a `artifacts.lock.yaml` n
 path needs to be supplied in the JSON input, pointing to a lockfile. You can find a sample lockfile below. It is identical
 to the one found in the [sample repository](https://github.com/cachito-testing/cachi2-generic/tree/sample-app).
 A lockfile for the generic fetcher must contain a `metadata` header and a list of artifacts, where each artifact is
-represented as a pair of URL and a checksum string in the format of `"algorithm:checksum"`:
+represented as a pair of URL and a checksum string in the format of `"algorithm:checksum"`. Optionally, you can also specify
+an output `filename` for the artifact. If not specified, it will be derived from the url. 
 
 ```
 ---
@@ -625,6 +626,7 @@ metadata:
 artifacts:
   - download_url: "https://github.com/jeremylong/DependencyCheck/releases/download/v11.1.0/dependency-check-11.1.0-release.zip"
     checksum: "sha256:c5b5b9e592682b700e17c28f489fe50644ef54370edeb2c53d18b70824de1e22"
+    filename: "dependency-check.zip"
 ```
 
 As with other examples, the command to fetch dependencies is very similar. The default path
@@ -645,7 +647,7 @@ FROM ibmjava:11-jdk
 WORKDIR /tmp
 
 # use jar to unzip file in order to avoid having to install more depependencies
-RUN jar -xvf cachi2-output/deps/generic/dependency-check-11.1.0-release.zip
+RUN jar -xvf cachi2-output/deps/generic/dependency-check.zip
 
 RUN chmod +x dependency-check/bin/dependency-check.sh
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -612,7 +612,7 @@ git clone -b sample-app https://github.com/cachito-testing/cachi2-generic.git
 ```
 
 #### Pre-fetch dependencies (generic fetcher)
-In order to retrieve the archive with the tool, a `generic_lockfile.yaml` needs to be in the repository. You can find a
+In order to retrieve the archive with the tool, a `artifacts.lock.yaml` needs to be in the repository. You can find a
 sample lockfile below. It is identical to one found in the [sample repository](https://github.com/cachito-testing/cachi2-generic/tree/sample-app).
 A lockfile for the generic fetcher must contain a `metadata` header and a list of artifacts, where each artifact is
 represented as a pair of URL and a checksum string in the format of `"algorithm:checksum"`:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -615,7 +615,7 @@ git clone -b sample-app https://github.com/cachito-testing/cachi2-generic.git
 In order to retrieve the archive with the tool, a `generic_lockfile.yaml` needs to be in the repository. You can find a
 sample lockfile below. It is identical to one found in the [sample repository](https://github.com/cachito-testing/cachi2-generic/tree/sample-app).
 A lockfile for the generic fetcher must contain a `metadata` header and a list of artifacts, where each artifact is
-represented as a pair of URL and a map containing one or more items in the shape of `"hashing algorithm": "checksum"`:
+represented as a pair of URL and a checksum string in the format of `"algorithm:checksum"`:
 
 ```
 ---
@@ -623,9 +623,7 @@ metadata:
   version: "1.0"
 artifacts:
   - download_url: "https://github.com/jeremylong/DependencyCheck/releases/download/v11.1.0/dependency-check-11.1.0-release.zip"
-    checksums:
-      sha256: "c5b5b9e592682b700e17c28f489fe50644ef54370edeb2c53d18b70824de1e22"
-
+    checksum: "sha256:c5b5b9e592682b700e17c28f489fe50644ef54370edeb2c53d18b70824de1e22"
 ```
 
 As with other examples, the command to fetch dependencies is very similar. The default path

--- a/tests/integration/test_data/generic_e2e/bom.json
+++ b/tests/integration/test_data/generic_e2e/bom.json
@@ -15,7 +15,7 @@
           "value": "cachi2"
         }
       ],
-      "purl": "pkg:generic/archive.zip?checksums=sha256:386428a82f37345fa24b74068e0e79f4c1f2ff38d4f5c106ea14de4a2926e584&download_url=https://github.com/cachito-testing/cachi2-generic/archive/refs/tags/v2.0.0.zip",
+      "purl": "pkg:generic/archive.zip?checksum=sha256:386428a82f37345fa24b74068e0e79f4c1f2ff38d4f5c106ea14de4a2926e584&download_url=https://github.com/cachito-testing/cachi2-generic/archive/refs/tags/v2.0.0.zip",
       "type": "file"
     },
     {
@@ -32,7 +32,7 @@
           "value": "cachi2"
         }
       ],
-      "purl": "pkg:generic/v1.0.0.zip?checksums=sha256:4fbcaa2a8d17c1f8042578627c122361ab18b7973311e7e9c598696732902f87&download_url=https://github.com/cachito-testing/cachi2-generic/archive/refs/tags/v1.0.0.zip",
+      "purl": "pkg:generic/v1.0.0.zip?checksum=sha256:4fbcaa2a8d17c1f8042578627c122361ab18b7973311e7e9c598696732902f87&download_url=https://github.com/cachito-testing/cachi2-generic/archive/refs/tags/v1.0.0.zip",
       "type": "file"
     }
   ],

--- a/tests/integration/test_generic.py
+++ b/tests/integration/test_generic.py
@@ -14,7 +14,6 @@ from . import utils
                 repo="https://github.com/cachito-testing/cachi2-generic",
                 ref="test-file-not-reachable",
                 packages=({"path": ".", "type": "generic"},),
-                flags=["--dev-package-managers"],
                 check_output=False,
                 check_deps_checksums=False,
                 check_vendor_checksums=False,

--- a/tests/unit/package_managers/test_generic.py
+++ b/tests/unit/package_managers/test_generic.py
@@ -22,8 +22,7 @@ metadata:
     version: '0.42'
 artifacts:
     - download_url: https://example.com/artifact
-      checksums:
-        md5: 3a18656e1cea70504b905836dee14db0
+      checksum: md5:3a18656e1cea70504b905836dee14db0
 """
 
 LOCKFILE_CHECKSUM_MISSING = """
@@ -33,25 +32,15 @@ artifacts:
     - download_url: https://example.com/artifact
 """
 
-LOCKFILE_CHECKSUM_EMPTY = """
-metadata:
-    version: '1.0'
-artifacts:
-    - download_url: https://example.com/artifact
-      checksums: {}
-"""
-
 LOCKFILE_VALID = """
 metadata:
     version: '1.0'
 artifacts:
     - download_url: https://example.com/artifact
       filename: archive.zip
-      checksums:
-        md5: 3a18656e1cea70504b905836dee14db0
+      checksum: md5:3a18656e1cea70504b905836dee14db0
     - download_url: https://example.com/more/complex/path/file.tar.gz?foo=bar#fragment
-      checksums:
-        md5: 32112bed1914cfe3799600f962750b1d
+      checksum: md5:32112bed1914cfe3799600f962750b1d
 """
 
 LOCKFILE_INVALID_FILENAME = """
@@ -60,8 +49,7 @@ metadata:
 artifacts:
     - download_url: https://example.com/artifact
       filename: ./../../../archive.zip
-      checksums:
-        md5: 3a18656e1cea70504b905836dee14db0
+      checksum: md5:3a18656e1cea70504b905836dee14db0
 """
 
 LOCKFILE_FILENAME_OVERLAP = """
@@ -70,12 +58,10 @@ metadata:
 artifacts:
     - download_url: https://example.com/artifact
       filename: archive.zip
-      checksums:
-        md5: 3a18656e1cea70504b905836dee14db0
+      checksum: md5:3a18656e1cea70504b905836dee14db0
     - download_url: https://example.com/artifact2
       filename: archive.zip
-      checksums:
-        md5: 3a18656e1cea70504b905836dee14db0
+      checksum: md5:3a18656e1cea70504b905836dee14db0
 """
 
 LOCKFILE_URL_OVERLAP = """
@@ -83,12 +69,10 @@ metadata:
     version: '1.0'
 artifacts:
     - download_url: https://example.com/artifact
-      checksums:
-        md5: 3a18656e1cea70504b905836dee14db0
+      checksum: md5:3a18656e1cea70504b905836dee14db0
     - download_url: https://example.com/artifact
       filename: archive.zip
-      checksums:
-        md5: 3a18656e1cea70504b905836dee14db0
+      checksum: md5:3a18656e1cea70504b905836dee14db0
 """
 
 LOCKFILE_WRONG_CHECKSUM = """
@@ -97,8 +81,7 @@ metadata:
 artifacts:
     - download_url: https://example.com/artifact
       filename: archive.zip
-      checksums:
-        md5: 32112bed1914cfe3799600f962750b1d
+      checksum: md5:32112bed1914cfe3799600f962750b1d
 """
 
 
@@ -148,12 +131,6 @@ def test_resolve_generic_no_lockfile(mock_load: mock.Mock, rooted_tmp_path: Root
         ),
         pytest.param(
             LOCKFILE_CHECKSUM_MISSING, PackageRejected, "Field required", id="checksum_missing"
-        ),
-        pytest.param(
-            LOCKFILE_CHECKSUM_EMPTY,
-            PackageRejected,
-            "At least one checksum must be provided",
-            id="checksum_empty",
         ),
         pytest.param(
             LOCKFILE_INVALID_FILENAME,
@@ -219,7 +196,7 @@ def test_resolve_generic_lockfile_invalid(
                     ],
                     "name": "archive.zip",
                     "properties": [{"name": "cachi2:found_by", "value": "cachi2"}],
-                    "purl": "pkg:generic/archive.zip?checksums=md5:3a18656e1cea70504b905836dee14db0&download_url=https://example.com/artifact",
+                    "purl": "pkg:generic/archive.zip?checksum=md5:3a18656e1cea70504b905836dee14db0&download_url=https://example.com/artifact",
                     "type": "file",
                     "version": None,
                 },
@@ -232,7 +209,7 @@ def test_resolve_generic_lockfile_invalid(
                     ],
                     "name": "file.tar.gz",
                     "properties": [{"name": "cachi2:found_by", "value": "cachi2"}],
-                    "purl": "pkg:generic/file.tar.gz?checksums=md5:32112bed1914cfe3799600f962750b1d&download_url=https://example.com/more/complex/path/file.tar.gz%3Ffoo%3Dbar%23fragment",
+                    "purl": "pkg:generic/file.tar.gz?checksum=md5:32112bed1914cfe3799600f962750b1d&download_url=https://example.com/more/complex/path/file.tar.gz%3Ffoo%3Dbar%23fragment",
                     "type": "file",
                     "version": None,
                 },
@@ -269,10 +246,10 @@ def test_load_generic_lockfile_valid(rooted_tmp_path: RootedPath) -> None:
             {
                 "download_url": Url("https://example.com/artifact"),
                 "filename": str(rooted_tmp_path.join_within_root("archive.zip")),
-                "checksums": {"md5": "3a18656e1cea70504b905836dee14db0"},
+                "checksum": "md5:3a18656e1cea70504b905836dee14db0",
             },
             {
-                "checksums": {"md5": "32112bed1914cfe3799600f962750b1d"},
+                "checksum": "md5:32112bed1914cfe3799600f962750b1d",
                 "download_url": Url(
                     "https://example.com/more/complex/path/file.tar.gz?foo=bar#fragment"
                 ),

--- a/tests/unit/package_managers/test_generic.py
+++ b/tests/unit/package_managers/test_generic.py
@@ -46,7 +46,7 @@ metadata:
     version: '1.0'
 artifacts:
     - download_url: https://example.com/artifact
-      target: archive.zip
+      filename: archive.zip
       checksums:
         md5: 3a18656e1cea70504b905836dee14db0
     - download_url: https://example.com/more/complex/path/file.tar.gz?foo=bar#fragment
@@ -54,26 +54,26 @@ artifacts:
         md5: 32112bed1914cfe3799600f962750b1d
 """
 
-LOCKFILE_INVALID_TARGET = """
+LOCKFILE_INVALID_FILENAME = """
 metadata:
     version: '1.0'
 artifacts:
     - download_url: https://example.com/artifact
-      target: ./../../../archive.zip
+      filename: ./../../../archive.zip
       checksums:
         md5: 3a18656e1cea70504b905836dee14db0
 """
 
-LOCKFILE_TARGET_OVERLAP = """
+LOCKFILE_FILENAME_OVERLAP = """
 metadata:
     version: '1.0'
 artifacts:
     - download_url: https://example.com/artifact
-      target: archive.zip
+      filename: archive.zip
       checksums:
         md5: 3a18656e1cea70504b905836dee14db0
     - download_url: https://example.com/artifact2
-      target: archive.zip
+      filename: archive.zip
       checksums:
         md5: 3a18656e1cea70504b905836dee14db0
 """
@@ -86,7 +86,7 @@ artifacts:
       checksums:
         md5: 3a18656e1cea70504b905836dee14db0
     - download_url: https://example.com/artifact
-      target: archive.zip
+      filename: archive.zip
       checksums:
         md5: 3a18656e1cea70504b905836dee14db0
 """
@@ -96,7 +96,7 @@ metadata:
     version: '1.0'
 artifacts:
     - download_url: https://example.com/artifact
-      target: archive.zip
+      filename: archive.zip
       checksums:
         md5: 32112bed1914cfe3799600f962750b1d
 """
@@ -156,16 +156,16 @@ def test_resolve_generic_no_lockfile(mock_load: mock.Mock, rooted_tmp_path: Root
             id="checksum_empty",
         ),
         pytest.param(
-            LOCKFILE_INVALID_TARGET,
+            LOCKFILE_INVALID_FILENAME,
             PathOutsideRoot,
             "target is outside",
-            id="invalid_target",
+            id="invalid_filename",
         ),
         pytest.param(
-            LOCKFILE_TARGET_OVERLAP,
+            LOCKFILE_FILENAME_OVERLAP,
             PackageRejected,
-            "Duplicate targets",
-            id="conflicting_targets",
+            "Duplicate filenames",
+            id="conflicting_filenames",
         ),
         pytest.param(
             LOCKFILE_URL_OVERLAP,
@@ -268,7 +268,7 @@ def test_load_generic_lockfile_valid(rooted_tmp_path: RootedPath) -> None:
         "artifacts": [
             {
                 "download_url": Url("https://example.com/artifact"),
-                "target": str(rooted_tmp_path.join_within_root("archive.zip")),
+                "filename": str(rooted_tmp_path.join_within_root("archive.zip")),
                 "checksums": {"md5": "3a18656e1cea70504b905836dee14db0"},
             },
             {
@@ -276,7 +276,7 @@ def test_load_generic_lockfile_valid(rooted_tmp_path: RootedPath) -> None:
                 "download_url": Url(
                     "https://example.com/more/complex/path/file.tar.gz?foo=bar#fragment"
                 ),
-                "target": str(rooted_tmp_path.join_within_root("file.tar.gz")),
+                "filename": str(rooted_tmp_path.join_within_root("file.tar.gz")),
             },
         ],
     }


### PR DESCRIPTION
This change includes the generic fetcher ADR which is a necessary step for the feature to be officially supported. Split from #718 

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
