### PR TITLE
Making bundler respect hermetic requirement

### DIFF
--- a/cachi2/core/package_managers/bundler/main.py
+++ b/cachi2/core/package_managers/bundler/main.py
@@ -177,6 +177,8 @@ def _prepare_for_hermetic_build(
         BUNDLE_CACHE_PATH: "${output_dir}/deps/bundler"
         BUNDLE_DEPLOYMENT: "true"
         BUNDLE_NO_PRUNE: "true"
+        BUNDLE_ALLOW_OFFLINE_INSTALL: "true"
+        BUNDLE_DISABLE_VERSION_CHECK: "true"
         BUNDLE_VERSION: "system"
     """
     )

--- a/docs/bundler.md
+++ b/docs/bundler.md
@@ -71,6 +71,9 @@ works correctly:
 - BUNDLE_DEPLOYMENT: "true"
 - BUNDLE_NO_PRUNE: "true"
 - BUNDLE_VERSION: "system"
+- BUNDLE_ALLOW_OFFLINE_INSTALL: "true"
+- BUNDLE_DISABLE_VERSION_CHECK: "true"
+
 
 ### BUNDLE_CACHE_PATH
 
@@ -88,6 +91,14 @@ Leave outdated gems unpruned.
 ### BUNDLE_VERSION
 
 The version of Bundler to use when running under the Bundler environment.
+
+### BUNDLE_ALLOW_OFFLINE_INSTALL
+
+Allow Bundler to use cached data when installing without network access.
+
+### BUNDLE_DISABLE_VERSION_CHECK
+
+Stop Bundler from checking if a newer Bundler version is available on rubygems.org.
 
 **Note**: _A prefetch could fail when Bundler versions differ between the build
 system and lockfile and when the former is outdated. Therefore we do not recommend

--- a/tests/integration/test_bundler.py
+++ b/tests/integration/test_bundler.py
@@ -132,8 +132,6 @@ def test_bundler_packages(
         ),
     ],
 )
-# FIXME: Re-enable the test once we have a proper fix or at least a workaround in place
-@pytest.mark.skip(reason="E2E tests currently broken due to bundler refusing to work offline")
 def test_e2e_bundler(
     test_params: utils.TestParameters,
     check_cmd: list[str],

--- a/tests/integration/test_data/bundler_everything_present/.build-config.yaml
+++ b/tests/integration/test_data/bundler_everything_present/.build-config.yaml
@@ -9,3 +9,6 @@ project_files:
     BUNDLE_DEPLOYMENT: "true"
     BUNDLE_NO_PRUNE: "true"
     BUNDLE_VERSION: "system"
+    BUNDLE_DISABLE_LOCAL_BRANCH_CHECK: "true"
+    BUNDLE_DISABLE_LOCAL_REVISION_CHECK: "true"
+    BUNDLE_LOCAL.JSON___SCHEMA: "${output_dir}/deps/bundler/json-schema-26487618a684"

--- a/tests/integration/test_data/bundler_everything_present/.build-config.yaml
+++ b/tests/integration/test_data/bundler_everything_present/.build-config.yaml
@@ -8,6 +8,8 @@ project_files:
     BUNDLE_CACHE_PATH: "${output_dir}/deps/bundler"
     BUNDLE_DEPLOYMENT: "true"
     BUNDLE_NO_PRUNE: "true"
+    BUNDLE_ALLOW_OFFLINE_INSTALL: "true"
+    BUNDLE_DISABLE_VERSION_CHECK: "true"
     BUNDLE_VERSION: "system"
     BUNDLE_DISABLE_LOCAL_BRANCH_CHECK: "true"
     BUNDLE_DISABLE_LOCAL_REVISION_CHECK: "true"

--- a/tests/integration/test_data/bundler_everything_present_except_gemspec/.build-config.yaml
+++ b/tests/integration/test_data/bundler_everything_present_except_gemspec/.build-config.yaml
@@ -9,3 +9,6 @@ project_files:
     BUNDLE_DEPLOYMENT: "true"
     BUNDLE_NO_PRUNE: "true"
     BUNDLE_VERSION: "system"
+    BUNDLE_DISABLE_LOCAL_BRANCH_CHECK: "true"
+    BUNDLE_DISABLE_LOCAL_REVISION_CHECK: "true"
+    BUNDLE_LOCAL.JSON___SCHEMA: "${output_dir}/deps/bundler/json-schema-26487618a684"

--- a/tests/integration/test_data/bundler_everything_present_except_gemspec/.build-config.yaml
+++ b/tests/integration/test_data/bundler_everything_present_except_gemspec/.build-config.yaml
@@ -8,6 +8,8 @@ project_files:
     BUNDLE_CACHE_PATH: "${output_dir}/deps/bundler"
     BUNDLE_DEPLOYMENT: "true"
     BUNDLE_NO_PRUNE: "true"
+    BUNDLE_ALLOW_OFFLINE_INSTALL: "true"
+    BUNDLE_DISABLE_VERSION_CHECK: "true"
     BUNDLE_VERSION: "system"
     BUNDLE_DISABLE_LOCAL_BRANCH_CHECK: "true"
     BUNDLE_DISABLE_LOCAL_REVISION_CHECK: "true"

--- a/tests/unit/package_managers/bundler/test_main.py
+++ b/tests/unit/package_managers/bundler/test_main.py
@@ -128,6 +128,8 @@ def test__prepare_for_hermetic_build_injects_necessary_variable_into_empty_confi
         BUNDLE_CACHE_PATH: "${output_dir}/deps/bundler"
         BUNDLE_DEPLOYMENT: "true"
         BUNDLE_NO_PRUNE: "true"
+        BUNDLE_ALLOW_OFFLINE_INSTALL: "true"
+        BUNDLE_DISABLE_VERSION_CHECK: "true"
         BUNDLE_VERSION: "system"
         """
     )
@@ -148,6 +150,8 @@ def test__prepare_for_hermetic_build_injects_necessary_variable_into_existing_co
         BUNDLE_CACHE_PATH: "${output_dir}/deps/bundler"
         BUNDLE_DEPLOYMENT: "true"
         BUNDLE_NO_PRUNE: "true"
+        BUNDLE_ALLOW_OFFLINE_INSTALL: "true"
+        BUNDLE_DISABLE_VERSION_CHECK: "true"
         BUNDLE_VERSION: "system"
         """
     )
@@ -178,6 +182,8 @@ def test__prepare_for_hermetic_build_injects_necessary_variable_into_existing_al
         BUNDLE_CACHE_PATH: "${output_dir}/deps/bundler"
         BUNDLE_DEPLOYMENT: "true"
         BUNDLE_NO_PRUNE: "true"
+        BUNDLE_ALLOW_OFFLINE_INSTALL: "true"
+        BUNDLE_DISABLE_VERSION_CHECK: "true"
         BUNDLE_VERSION: "system"
         """
     )
@@ -213,6 +219,8 @@ def test__prepare_for_hermetic_build_ignores_a_directory_in_place_of_config(
         BUNDLE_CACHE_PATH: "${output_dir}/deps/bundler"
         BUNDLE_DEPLOYMENT: "true"
         BUNDLE_NO_PRUNE: "true"
+        BUNDLE_ALLOW_OFFLINE_INSTALL: "true"
+        BUNDLE_DISABLE_VERSION_CHECK: "true"
         BUNDLE_VERSION: "system"
         """
     )

--- a/tests/unit/package_managers/bundler/test_main.py
+++ b/tests/unit/package_managers/bundler/test_main.py
@@ -62,7 +62,7 @@ def test_resolve_bundler_package(
     mock_parse_lockfile.return_value = deps
     mock_get_main_package_name_and_version.return_value = ("name", None)
 
-    components = _resolve_bundler_package(package_dir=package_dir, output_dir=output_dir)
+    components, git_paths = _resolve_bundler_package(package_dir=package_dir, output_dir=output_dir)
 
     mock_parse_lockfile.assert_called_once_with(package_dir, False)
     mock_get_main_package_name_and_version.assert_called_once_with(package_dir, deps)
@@ -71,6 +71,7 @@ def test_resolve_bundler_package(
     mock_path_dep_download_to.assert_called_with(deps_dir)
 
     assert len(components) == len(deps) + 1  # + 1 for the "main" package
+    assert len(git_paths) == 1  # since there is exactly one git dependency
     assert deps_dir.path.exists()
 
 


### PR DESCRIPTION
It turned out that due to a yet unknown change somewhere
in the ecosystem bundler started ignoring instructions
to not access the web during a build when a git dependency
was present.

This change adds a workaround that explicitly forbids
consulting remotes for branches and references and also
pins a path to local repository in a config.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
