### PR TITLE
tests: integration: bundler: Temporarily disable E2E tests

### DIFF
--- a/tests/integration/test_bundler.py
+++ b/tests/integration/test_bundler.py
@@ -132,6 +132,8 @@ def test_bundler_packages(
         ),
     ],
 )
+# FIXME: Re-enable the test once we have a proper fix or at least a workaround in place
+@pytest.mark.skip(reason="E2E tests currently broken due to bundler refusing to work offline")
 def test_e2e_bundler(
     test_params: utils.TestParameters,
     check_cmd: list[str],


### PR DESCRIPTION
Unfortunately we've lately been experiencing failing bundler E2E tests due to bundler trying to access the internet during an offline project build despite having all dependencies cached locally. Investigation is going on, but the tests are blocking unrelated PRs from being merged.

Disable the failing E2E tests for the time being until we come up at least with a feasible workaround if not a proper fix. Revert this commit once a fix is in place.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
