### PR TITLE
Generic fetcher maven support

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,8 +244,8 @@ Generic fetcher is a way for Cachi2 to support prefetching arbitrary files that 
 With the generic fetcher, you can easily fetch those files with Cachi2 along with your other language-specific dependencies,
 satisfy the hermetic build condition and have them recorded in the SBOM.
 
-Cachi2 uses a simple custom lockfile named `generic_lockfile.yaml` that is expected to be present in the repository. The
-lockfile describes the urls, checksums and target locations for the downloaded files.
+Cachi2 uses a simple custom lockfile named `artifacts.lock.yaml` that is expected to be present in the repository, or
+supplied in JSON input. The lockfile describes the urls, checksums and output filenames for the downloaded files.
 
 See [docs/usage.md](docs/usage.md#pre-fetch-dependencies-generic-fetcher) for more details.
 

--- a/README.md
+++ b/README.md
@@ -247,7 +247,11 @@ satisfy the hermetic build condition and have them recorded in the SBOM.
 Cachi2 uses a simple custom lockfile named `artifacts.lock.yaml` that is expected to be present in the repository, or
 supplied in JSON input. The lockfile describes the urls, checksums and output filenames for the downloaded files.
 
-See [docs/usage.md](docs/usage.md#pre-fetch-dependencies-generic-fetcher) for more details.
+Currently supported types of artifacts:
+- Arbitrary files
+- Maven artifacts
+
+See [docs/generic.md](docs/generic.md) for more details.
 
 ## Project status
 

--- a/cachi2/core/package_managers/generic/models.py
+++ b/cachi2/core/package_managers/generic/models.py
@@ -1,14 +1,18 @@
 import re
+from abc import ABC, abstractmethod
 from collections import Counter
+from functools import cached_property
 from pathlib import Path
-from typing import Literal
-from urllib.parse import urlparse
+from typing import Literal, Union
+from urllib.parse import urljoin, urlparse
 
+from packageurl import PackageURL
 from pydantic import AnyUrl, BaseModel, ConfigDict, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 
 from cachi2.core.checksum import ChecksumInfo
 from cachi2.core.errors import PackageManagerError
+from cachi2.core.models.sbom import Component, ExternalReference
 from cachi2.core.rooted_path import RootedPath
 
 CHECKSUM_FORMAT = re.compile(r"^[a-zA-Z0-9]+:[a-zA-Z0-9]+$")
@@ -21,16 +25,14 @@ class LockfileMetadata(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class LockfileArtifact(BaseModel):
+class LockfileArtifactBase(BaseModel, ABC):
     """
-    Defines format of a single artifact in the lockfile.
+    Base class for artifacts in the lockfile.
 
-    :param download_url: The URL to download the artifact from.
     :param filename: The target path to save the artifact to. Subpath of the deps/generic folder.
     :param checksum: Checksum of the artifact in the format "algorithm:hash"
     """
 
-    download_url: AnyUrl
     filename: str = ""
     checksum: str
     model_config = ConfigDict(extra="forbid")
@@ -48,12 +50,24 @@ class LockfileArtifact(BaseModel):
             raise ValueError("Checksum must be in the format 'algorithm:hash'")
         return value
 
+    @abstractmethod
+    def resolve_filename(self) -> str:
+        """Resolve the filename of the artifact."""
+
+    @abstractmethod
+    def get_sbom_component(self) -> Component:
+        """Return an SBOM component representation of the artifact."""
+
+    @property
+    def formatted_checksum(self) -> ChecksumInfo:
+        """Return the checksum as a ChecksumInfo object."""
+        algorithm, digest = self.checksum.split(":", 1)
+        return ChecksumInfo(algorithm, digest)
+
     @model_validator(mode="after")
-    def set_filename(self, info: ValidationInfo) -> "LockfileArtifact":
+    def set_filename(self, info: ValidationInfo) -> "LockfileArtifactBase":
         """Set the target path if not provided and resolve it into an absolute path."""
-        if not self.filename:
-            url_path = urlparse(str(self.download_url)).path
-            self.filename = Path(url_path).name
+        self.filename = self.resolve_filename()
 
         # needs to have output_dir context in order to be able to resolve the target path
         # and so that it can be used to check for conflicts with other artifacts
@@ -66,18 +80,140 @@ class LockfileArtifact(BaseModel):
 
         return self
 
-    @property
-    def formatted_checksum(self) -> ChecksumInfo:
-        """Return the checksum as a ChecksumInfo object."""
-        algorithm, digest = self.checksum.split(":", 1)
-        return ChecksumInfo(algorithm, digest)
+
+class LockfileArtifactUrl(LockfileArtifactBase):
+    """
+    Defines format of a single artifact in the lockfile.
+
+    :param download_url: The URL to download the artifact from.
+    """
+
+    download_url: AnyUrl
+
+    def resolve_filename(self) -> str:
+        """Resolve the filename of the artifact."""
+        if not self.filename:
+            url_path = urlparse(str(self.download_url)).path
+            return Path(url_path).name
+        return self.filename
+
+    def get_sbom_component(self) -> Component:
+        """Return an SBOM component representation of the artifact."""
+        name = Path(self.filename).name
+        url = str(self.download_url)
+        component = Component(
+            name=name,
+            purl=PackageURL(
+                type="generic",
+                name=name,
+                qualifiers={
+                    "download_url": url,
+                    "checksum": self.checksum,
+                },
+            ).to_string(),
+            type="file",
+            external_references=[ExternalReference(url=url, type="distribution")],
+        )
+        return component
+
+
+class LockfileArtifactMavenAttributes(BaseModel):
+    """Attributes for a Maven artifact in the lockfile."""
+
+    repository_url: AnyUrl
+    group_id: str
+    artifact_id: str
+    version: str
+    classifier: str = ""
+    type: str = "jar"
+
+    @cached_property
+    def extension(self) -> str:
+        """Return the extension of the artifact."""
+        type_to_extension = {
+            "pom": "pom",
+            "jar": "jar",
+            "maven-plugin": "jar",
+            "ear": "ear",
+            "ejb": "jar",
+            "ejb-client": "jar",
+            "javadoc": "jar",
+            "javadoc-source": "jar",
+            "rar": "rar",
+            "test-jar": "jar",
+            "war": "war",
+        }
+        return type_to_extension.get(self.type, self.type)
+
+
+class LockfileArtifactMaven(LockfileArtifactBase):
+    """Defines format of a Maven artifact in the lockfile."""
+
+    type: Literal["maven"]
+    attributes: LockfileArtifactMavenAttributes
+
+    @cached_property
+    def filename_from_attributes(self) -> str:
+        """Return the filename of the artifact."""
+        artifact_id = self.attributes.artifact_id
+        version = self.attributes.version
+
+        filename = f"{artifact_id}-{version}"
+        if self.attributes.classifier:
+            filename += f"-{self.attributes.classifier}"
+
+        return f"{filename}.{self.attributes.extension}"
+
+    @cached_property
+    def download_url(self) -> str:
+        """Return the download URL of the artifact."""
+        group_id = self.attributes.group_id.replace(".", "/")
+        artifact_id = self.attributes.artifact_id
+        version = self.attributes.version
+
+        url_path = f"{group_id}/{artifact_id}/{version}/{self.filename_from_attributes}"
+
+        # ensure repository url has a slash in the end, otherwise the last part will
+        # be replaced by the url_path
+        repo_url = str(self.attributes.repository_url)
+        if not repo_url.endswith("/"):
+            repo_url += "/"
+        return urljoin(repo_url, url_path)
+
+    def resolve_filename(self) -> str:
+        """Resolve the filename of the artifact."""
+        return self.filename if self.filename else self.filename_from_attributes
+
+    def get_sbom_component(self) -> Component:
+        """Return an SBOM component representation of the artifact."""
+        purl_qualifiers = {
+            "type": self.attributes.type,
+            "repository_url": str(self.attributes.repository_url),
+            "checksum": self.checksum,
+        }
+        if self.attributes.classifier:
+            purl_qualifiers["classifier"] = self.attributes.classifier
+
+        return Component(
+            name=self.attributes.artifact_id,
+            version=self.attributes.version,
+            purl=PackageURL(
+                type="maven",
+                name=self.attributes.artifact_id,
+                namespace=self.attributes.group_id,
+                version=self.attributes.version,
+                qualifiers=purl_qualifiers,
+            ).to_string(),
+            type="library",
+            external_references=[ExternalReference(url=self.download_url, type="distribution")],
+        )
 
 
 class GenericLockfileV1(BaseModel):
     """Defines format of the cachi2 generic lockfile, version 1.0."""
 
     metadata: LockfileMetadata
-    artifacts: list[LockfileArtifact]
+    artifacts: list[Union[LockfileArtifactUrl, LockfileArtifactMaven]]
     model_config = ConfigDict(extra="forbid")
 
     @model_validator(mode="after")

--- a/docs/generic.md
+++ b/docs/generic.md
@@ -1,0 +1,124 @@
+# Generic fetcher
+
+* Overview [in the README][readme-generic]
+* [Specifying artifacts to fetch](#specifying-artifacts-to-fetch)
+* [Using fetched dependencies](#using-fetched-dependencies)
+
+## Support scope
+Generic fetcher is made specifically for use cases where cachi2 will not implement a full package manager support, or
+for ecosystems where no such package manager exists. It is highly discouraged for this feature to be used for anything
+already supported by cachi2 in other ways (such as e.g. pip packages), because the produced SBOM component will not be
+accurate. 
+
+## Specifying artifacts to fetch
+The generic fetcher requires a lockfile `artifacts.lock.yaml` that specifies which files to download. This file is expected
+to be in the source repository. Alternatively, it can be supplied as an absolute path via the `lockfile` key in the JSON
+input to cachi2.
+
+Below are sections for each type of supported artifact. Several artifacts of different types can be specified in a single
+lockfile.
+
+The lockfile must always contain a `metadata` header and a list of `artifacts`. Currently, the only supported version is
+1.0:
+
+```yaml
+---
+metadata:
+  version: "1.0"
+artifacts: []
+```
+
+Cachi2 can be then ran as follows:
+
+```shell
+
+cachi2 fetch-deps \
+--source ./my-repo \
+--output ./cachi2-output \
+'<JSON input>'
+```
+
+JSON input:
+
+```jsonc
+{
+  "type": "generic",
+  // path to the package (relative to the --source directory)
+  // defaults to "."
+  "path": ".",
+  // option to specify lockfile path, must be an absolute path if specified
+  // defaults to "artifacts.lock.yaml", relative to path
+  "lockfile": "artifacts.lock.yaml",
+}
+```
+
+
+### Arbitrary files
+This artifact type is intended for whatever files are needed at build time that do not fit neatly into other package
+managers.
+
+```yaml
+---
+metadata:
+  version: "1.0"
+artifacts:
+  - download_url: "https://example.com/file.zip"
+    checksum: "algorithm:hash"
+    filename: "optional-custom-name.zip"  # optional
+```
+
+Each artifact requires:
+- `download_url`: The URL to download the file from
+- `checksum`: In format "algorithm:hash" (e.g., "sha256:123...")
+- `filename`: Optional custom filename for the downloaded file. If not present, it will be derived from the url
+
+#### SBOM component
+Since there can't be any assumptions about these files beyond checking their identity against a checksum, these files will
+be reported with `pkg:generic` purl in the output SBOM. 
+
+### Maven artifacts
+This type is for downloading [maven repository artifacts][maven-artifacts]. These are specified using GAV coordinates that
+are enumerated in the artifact's attributes in the lockfile. The download URL will be assembled using this information.
+
+```yaml
+---
+metadata:
+    version: "1.0"
+artifacts:
+    - type: "maven"
+      filename: "ant.jar"
+      attributes:
+          repository_url: "https://repo1.maven.org/maven2"
+          group_id: "org.apache.ant"
+          artifact_id: "ant"
+          version: "1.10.14"
+          type: "jar"
+      checksum: "sha256:4cbbd9243de4c1042d61d9a15db4c43c90ff93b16d78b39481da1c956c8e9671"
+```
+
+Each artifact requires:
+- `type`: type of the artifact (always `maven`)
+- `filename`: Optional custom filename for the downloaded file. If not present, it will be derived from the url
+- `attributes`: Maven-specific attributes
+  - `repository_url`: URL of the Maven repository (required)
+  - `group_id`: Maven group ID  (required)
+  - `artifact_id`: Maven artifact ID  (required)
+  - `version`: Version of the artifact (required)
+  - `type`: Type of the artifact ("jar" by default)
+  - `classfier`: Maven classifier (optional)
+
+- `checksum`: In format "algorithm:hash" (e.g., "sha256:123...")
+
+#### SBOM component
+These files will be reported with `pkg:maven` purl in the output SBOM, because the URL is fully assembled from the
+provided attributes and therefore the file can be assumed to be a maven artifact.
+
+## Using fetched dependencies
+
+Cachi2 downloads the files into the `deps/generic/` subpath of the output directory. Files are named according to the
+`filename` field if specified, otherwise derived from the URL. During your build, you would typically mount cachi2's
+output directory into your container image and reference the individual files. For a detailed example, see [usage.md][usage-example].
+
+[readme-generic]: ../README.md#generic-fetcher
+[maven-artifacts]: https://maven.apache.org/repositories/artifacts.html
+[usage-example]: usage.md#example-generic-fetcher

--- a/tests/integration/test_data/generic_maven_e2e/.build-config.yaml
+++ b/tests/integration/test_data/generic_maven_e2e/.build-config.yaml
@@ -1,0 +1,2 @@
+environment_variables: []
+project_files: []

--- a/tests/integration/test_data/generic_maven_e2e/bom.json
+++ b/tests/integration/test_data/generic_maven_e2e/bom.json
@@ -1,0 +1,51 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "ant-launcher",
+      "purl": "pkg:maven/org.apache.ant/ant-launcher@1.10.14?checksum=sha256:f0909725a7a24e393888f3fbb558347abf506ce2f7ebc581ff26331b94d951a5&repository_url=https://repo1.maven.org/maven2&type=jar",
+      "version": "1.10.14",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library",
+      "externalReferences": [
+        {
+          "url": "https://repo1.maven.org/maven2/org/apache/ant/ant-launcher/1.10.14/ant-launcher-1.10.14.jar",
+          "type": "distribution"
+        }
+      ]
+    },
+    {
+      "name": "ant",
+      "purl": "pkg:maven/org.apache.ant/ant@1.10.14?checksum=sha256:4cbbd9243de4c1042d61d9a15db4c43c90ff93b16d78b39481da1c956c8e9671&repository_url=https://repo1.maven.org/maven2&type=jar",
+      "version": "1.10.14",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "type": "library",
+      "externalReferences": [
+        {
+          "url": "https://repo1.maven.org/maven2/org/apache/ant/ant/1.10.14/ant-1.10.14.jar",
+          "type": "distribution"
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "vendor": "red hat",
+        "name": "cachi2"
+      }
+    ]
+  },
+  "specVersion": "1.4",
+  "version": 1
+}

--- a/tests/integration/test_data/generic_maven_e2e/container/Containerfile
+++ b/tests/integration/test_data/generic_maven_e2e/container/Containerfile
@@ -1,0 +1,5 @@
+FROM docker.io/ibmjava:11-jdk
+
+RUN cp -r /tmp/generic_maven_e2e-output/deps/generic/ /deps
+
+CMD ["java", "-cp", "/deps/ant.jar:/deps/ant-launcher.jar", "org.apache.tools.ant.Main", "-version"]

--- a/tests/integration/test_data/generic_maven_e2e/fetch_deps_sha256sums.json
+++ b/tests/integration/test_data/generic_maven_e2e/fetch_deps_sha256sums.json
@@ -1,0 +1,4 @@
+{
+  "generic/ant.jar": "sha256:4cbbd9243de4c1042d61d9a15db4c43c90ff93b16d78b39481da1c956c8e9671",
+  "generic/ant-launcher.jar": "sha256:f0909725a7a24e393888f3fbb558347abf506ce2f7ebc581ff26331b94d951a5"
+}

--- a/tests/integration/test_generic.py
+++ b/tests/integration/test_generic.py
@@ -61,7 +61,6 @@ def test_generic_fetcher(
                 repo="https://github.com/cachito-testing/cachi2-generic",
                 ref="test-e2e",
                 packages=({"path": ".", "type": "generic"},),
-                flags=["--dev-package-managers"],
                 check_output=True,
                 check_deps_checksums=True,
                 check_vendor_checksums=False,
@@ -70,6 +69,20 @@ def test_generic_fetcher(
             ["ls", "/deps"],
             ["archive.zip\nv1.0.0.zip\n"],
             id="generic_e2e",
+        ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-generic",
+                ref="test-e2e-maven",
+                packages=({"path": ".", "type": "generic"},),
+                check_output=True,
+                check_deps_checksums=True,
+                check_vendor_checksums=False,
+                expected_exit_code=0,
+            ),
+            [],
+            ["Apache Ant(TM) version 1.10.14"],
+            id="generic_maven_e2e",
         ),
     ],
 )


### PR DESCRIPTION
Implements Maven artifact support as described in #692

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
