### PR TITLE
yarn classic workspaces

### DIFF
--- a/cachi2/core/package_managers/yarn_classic/workspaces.py
+++ b/cachi2/core/package_managers/yarn_classic/workspaces.py
@@ -59,16 +59,13 @@ def _ensure_workspaces_are_well_formed(
             )
 
 
-def _get_workspace_paths(
-    workspaces_globs: list[str],
-    source_dir: RootedPath,
-) -> Iterable[Path]:
+def _get_workspace_paths(workspaces_globs: list[str], source_dir: RootedPath) -> list[Path]:
     """Resolve globs within source directory."""
 
     def all_paths_matching(glob: str) -> Generator[Path, None, None]:
-        return (pth.resolve() for pth in source_dir.path.glob(glob))
+        return (path.resolve() for path in source_dir.path.glob(glob))
 
-    return chain.from_iterable(map(all_paths_matching, workspaces_globs))
+    return list(chain.from_iterable(map(all_paths_matching, workspaces_globs)))
 
 
 def _extract_workspaces_globs(

--- a/cachi2/core/package_managers/yarn_classic/workspaces.py
+++ b/cachi2/core/package_managers/yarn_classic/workspaces.py
@@ -68,15 +68,19 @@ def _get_workspace_paths(workspaces_globs: list[str], source_dir: RootedPath) ->
     return list(chain.from_iterable(map(all_paths_matching, workspaces_globs)))
 
 
-def _extract_workspaces_globs(
-    package: dict[str, Any],
-) -> list[str]:
-    """Extract globs from workspaces entry in package dict."""
-    # This could be an Array or an Array nested in an Object.
-    # Official docs mentioning the former:
-    #   https://classic.yarnpkg.com/lang/en/docs/workspaces/
-    # Official blog containing a hint about the latter:
-    #   https://classic.yarnpkg.com/lang/en/docs/workspaces/
+def _extract_workspaces_globs(package: dict[str, Any]) -> list[str]:
+    """Extract globs from workspaces entry in package dict.
+
+    The 'workspaces' entry can either be:
+    - an array of strings
+      (e.g., "workspaces": ["workspace-a", "workspace-b"])
+    - an object with a 'packages' key containing an array of strings
+      (e.g., "workspaces": {"packages": ["workspace-a", "workspace-b"]})
+
+    See:
+    https://classic.yarnpkg.com/en/docs/workspaces/#toc-how-to-use-it
+    https://classic.yarnpkg.com/blog/2018/02/15/nohoist/#how-to-use-it
+    """
     workspaces_globs = package.get("workspaces", [])
     if isinstance(workspaces_globs, dict):
         workspaces_globs = workspaces_globs.get("packages", [])


### PR DESCRIPTION
# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Docs updated (if applicable)
- [x] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
