### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+ We actively maintain and support the latest version of the project. Security updates are only
+ provided for the latest release.
+
+ | Version | Supported          |
+ | ------- | ------------------ |
+ | Latest  | :white_check_mark: |
+ | Older   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability or even **think** you may have discovered one, we
+encourage you to report it to us. Please follow the GitHub Security
+Advisory feature's process described in the [docs](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability). 
+
+Once the report is submitted, it will only be visible to the advisory collaborators (you) and
+repository admins.
+
+## What Happens Next
+
+- The admins will review your report and may reach out for further information.
+- If the vulnerability is confirmed, we will work on a fix in a private space (collaboration
+welcome). You'll be able to follow the whole process.
+- Once resolved, the issue will be disclosed responsibly and the fix released promptly.
+
+Thank you for helping us maintain a secure project!


### PR DESCRIPTION
We had our first CVE reported and fixed using the GH integrated Security Advisory feature. We should treat that as a signal to officially define a security policy for the project.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
