### PR TITLE
yarn: Automated Yarn version detector

### DIFF
--- a/cachi2/core/config.py
+++ b/cachi2/core/config.py
@@ -25,6 +25,8 @@ class Config(BaseModel, extra="forbid"):
     requests_timeout: int = 300
     concurrency_limit: int = 5
 
+    allow_yarnberry_processing: bool = True
+
     @model_validator(mode="before")
     @classmethod
     def _print_deprecation_warning(cls, data: Any) -> Any:

--- a/cachi2/core/models/input.py
+++ b/cachi2/core/models/input.py
@@ -52,9 +52,7 @@ def _present_user_input_error(validation_error: pydantic.ValidationError) -> str
 
 
 # Supported package managers
-PackageManagerType = Literal[
-    "bundler", "generic", "gomod", "npm", "pip", "rpm", "yarn", "yarn-classic"
-]
+PackageManagerType = Literal["bundler", "generic", "gomod", "npm", "pip", "rpm", "yarn"]
 
 Flag = Literal[
     "cgo-disable", "dev-package-managers", "force-gomod-tidy", "gomod-vendor", "gomod-vendor-check"
@@ -225,12 +223,6 @@ class YarnPackageInput(_PackageInputBase):
     type: Literal["yarn"]
 
 
-class YarnClassicPackageInput(_PackageInputBase):
-    """Accepted input for a yarn classic package."""
-
-    type: Literal["yarn-classic"]
-
-
 PackageInput = Annotated[
     Union[
         BundlerPackageInput,
@@ -239,7 +231,6 @@ PackageInput = Annotated[
         NpmPackageInput,
         PipPackageInput,
         RpmPackageInput,
-        YarnClassicPackageInput,
         YarnPackageInput,
     ],
     # https://pydantic-docs.helpmanual.io/usage/types/#discriminated-unions-aka-tagged-unions
@@ -340,11 +331,6 @@ class Request(pydantic.BaseModel):
     def yarn_packages(self) -> list[YarnPackageInput]:
         """Get the yarn packages specified for this request."""
         return self._packages_by_type(YarnPackageInput)
-
-    @property
-    def yarn_classic_packages(self) -> list[YarnClassicPackageInput]:
-        """Get the yarn classic packages specified for this request."""
-        return self._packages_by_type(YarnClassicPackageInput)
 
     def _packages_by_type(self, pkgtype: type[T]) -> list[T]:
         return [package for package in self.packages if isinstance(package, pkgtype)]

--- a/cachi2/core/package_managers/metayarn.py
+++ b/cachi2/core/package_managers/metayarn.py
@@ -1,0 +1,28 @@
+from cachi2.core.config import get_config
+from cachi2.core.models.input import Request
+from cachi2.core.models.output import RequestOutput
+from cachi2.core.package_managers.yarn.main import fetch_yarn_source as fetch_yarnberry_source
+from cachi2.core.package_managers.yarn_classic.main import MissingLockfile, NotV1Lockfile
+from cachi2.core.package_managers.yarn_classic.main import (
+    fetch_yarn_source as fetch_yarn_classic_source,
+)
+from cachi2.core.utils import merge_outputs
+
+
+def fetch_yarn_source(request: Request) -> RequestOutput:
+    """Fetch yarn source."""
+    # Packages could be a mixture of yarn v1 and v2 (at least this is how it
+    # looks now). To preserve this behavior each request is split into individual
+    # packages which are assessed one by one.
+    fetched_packages = []
+    for package in request.packages:
+        new_request = request.model_copy(update={"packages": [package]})
+        try:
+            fetched_packages.append(fetch_yarn_classic_source(new_request))
+        except (MissingLockfile, NotV1Lockfile) as e:
+            # It is assumed that if a package is not v1 then it is probably v2.
+            if get_config().allow_yarnberry_processing:
+                fetched_packages.append(fetch_yarnberry_source(new_request))
+            else:
+                raise e
+    return merge_outputs(fetched_packages)

--- a/cachi2/core/package_managers/yarn_classic/main.py
+++ b/cachi2/core/package_managers/yarn_classic/main.py
@@ -2,7 +2,7 @@ import logging
 import re
 from collections import Counter
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 from urllib.parse import urlparse
 
 from cachi2.core.errors import PackageManagerError, PackageRejected
@@ -27,6 +27,26 @@ log = logging.getLogger(__name__)
 
 
 MIRROR_DIR = "deps/yarn-classic"
+_yarn_classic_pattern = "yarn lockfile v1"  # See [yarn_classic_trait].
+
+
+class MissingLockfile(PackageRejected):
+    """Indicate that a lock file is missing."""
+
+    def __init__(self) -> None:
+        """Initialize a Missing Lockfile error."""
+        reason = "Yarn lockfile 'yarn.lock' missing, refusing to continue"
+        solution = "Make sure your repository has a Yarn lockfile (i.e. yarn.lock) checked in"
+        super().__init__(reason, solution=solution)
+
+
+class NotV1Lockfile(PackageRejected):
+    """Indicate that a lockfile is of wrong tyrpoe."""
+
+    def __init__(self, package_path: Any) -> None:
+        """Initialize a Missing Lockfile error."""
+        reason = f"{package_path} not a Yarn v1"
+        super().__init__(reason, solution=None)
 
 
 def fetch_yarn_source(request: Request) -> RequestOutput:
@@ -36,7 +56,7 @@ def fetch_yarn_source(request: Request) -> RequestOutput:
     def _ensure_mirror_dir_exists(output_dir: RootedPath) -> None:
         output_dir.join_within_root(MIRROR_DIR).path.mkdir(parents=True, exist_ok=True)
 
-    for package in request.yarn_classic_packages:
+    for package in request.yarn_packages:
         package_path = request.source_dir.join_within_root(package.path)
         _ensure_mirror_dir_exists(request.output_dir)
         _resolve_yarn_project(Project.from_source_dir(package_path), request.output_dir)
@@ -121,9 +141,27 @@ def _reject_if_pnp_install(project: Project) -> None:
         )
 
 
+def _get_path_to_yarn_lock(project: Project) -> Path:
+    return project.source_dir.join_within_root("yarn.lock").path
+
+
+def _reject_if_wrong_lockfile_version(project: Project) -> None:
+    yarnlock_path = _get_path_to_yarn_lock(project)
+    text = yarnlock_path.read_text()
+    if _yarn_classic_pattern not in text:
+        raise NotV1Lockfile(project.source_dir)
+
+
+def _reject_if_lockfile_is_missing(project: Project) -> None:
+    yarnlock_path = _get_path_to_yarn_lock(project)
+    if not yarnlock_path.exists():
+        raise MissingLockfile()
+
+
 def _verify_repository(project: Project) -> None:
+    _reject_if_lockfile_is_missing(project)
+    _reject_if_wrong_lockfile_version(project)
     _reject_if_pnp_install(project)
-    # _check_lockfile(project)
 
 
 def _verify_corepack_yarn_version(source_dir: RootedPath, env: dict[str, str]) -> None:
@@ -194,3 +232,7 @@ def _get_git_tarball_mirror_name(url: str) -> str:
         package_filename = package_filename[1:]
 
     return package_filename
+
+
+# References
+# [yarn_classic_trait]:  https://github.com/yarnpkg/berry/blob/13d5b3041794c33171808fdce635461ff4ab5c4e/packages/yarnpkg-core/sources/Project.ts#L434

--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -37,7 +37,7 @@ def resolve_packages(request: Request) -> RequestOutput:
     This function performs the operations in a working copy of the source directory in case
     a package manager that can make unwanted modifications will be used.
     """
-    if request.yarn_packages or request.yarn_classic_packages:
+    if request.yarn_packages:
         original_source_dir = request.source_dir
 
         with TemporaryDirectory(".cachi2-source-copy", dir=".") as temp_dir:

--- a/cachi2/core/utils.py
+++ b/cachi2/core/utils.py
@@ -8,10 +8,11 @@ import subprocess
 import sys
 from functools import cache
 from pathlib import Path
-from typing import Callable, Iterator, Optional, Sequence
+from typing import Callable, Iterable, Iterator, Optional, Sequence
 
 from cachi2.core.config import get_config
 from cachi2.core.errors import Cachi2Error
+from cachi2.core.models.output import RequestOutput
 
 log = logging.getLogger(__name__)
 
@@ -195,3 +196,22 @@ def get_cache_dir() -> Path:
     except KeyError:
         cache_dir = Path.home().joinpath(".cache")
     return cache_dir.joinpath("cachi2")
+
+
+def merge_outputs(outputs: Iterable[RequestOutput]) -> RequestOutput:
+    """Merge RequestOutput instances."""
+    components = []
+    env_vars = []
+    project_files = []
+
+    for output in outputs:
+        components.extend(output.components)
+        env_vars.extend(output.build_config.environment_variables)
+        project_files.extend(output.build_config.project_files)
+
+    return RequestOutput.from_obj_list(
+        components=components,
+        environment_variables=env_vars,
+        project_files=project_files,
+        options=output.build_config.options if output.build_config.options else None,
+    )

--- a/tests/integration/test_yarn_classic.py
+++ b/tests/integration/test_yarn_classic.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
                 ref="corepack_packagemanager_ignored",
-                packages=({"path": ".", "type": "yarn-classic"},),
+                packages=({"path": ".", "type": "yarn"},),
                 flags=["--dev-package-managers"],
                 check_output=False,
                 check_deps_checksums=False,
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
                 ref="yarnpath_ignored",
-                packages=({"path": ".", "type": "yarn-classic"},),
+                packages=({"path": ".", "type": "yarn"},),
                 flags=["--dev-package-managers"],
                 check_output=False,
                 check_deps_checksums=False,
@@ -43,7 +43,7 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
                 ref="invalid_checksum",
-                packages=({"path": ".", "type": "yarn-classic"},),
+                packages=({"path": ".", "type": "yarn"},),
                 flags=["--dev-package-managers"],
                 check_output=False,
                 check_deps_checksums=False,
@@ -57,7 +57,7 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
                 ref="invalid_frozen_lockfile_add_dependency",
-                packages=({"path": ".", "type": "yarn-classic"},),
+                packages=({"path": ".", "type": "yarn"},),
                 flags=["--dev-package-managers"],
                 check_output=False,
                 check_deps_checksums=False,
@@ -71,7 +71,7 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
                 ref="lifecycle_scripts",
-                packages=({"path": ".", "type": "yarn-classic"},),
+                packages=({"path": ".", "type": "yarn"},),
                 flags=["--dev-package-managers"],
                 check_output=False,
                 check_deps_checksums=False,
@@ -85,7 +85,7 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
                 ref="offline-mirror-collision",
-                packages=({"path": ".", "type": "yarn-classic"},),
+                packages=({"path": ".", "type": "yarn"},),
                 flags=["--dev-package-managers"],
                 check_output=False,
                 check_deps_checksums=False,
@@ -128,8 +128,7 @@ def test_yarn_classic_packages(
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
                 ref="valid_yarn_all_dependency_types",
-                packages=({"path": ".", "type": "yarn-classic"},),
-                flags=["--dev-package-managers"],
+                packages=({"path": ".", "type": "yarn"},),
                 check_vendor_checksums=False,
                 expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
@@ -143,10 +142,9 @@ def test_yarn_classic_packages(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
                 ref="valid_multiple_packages",
                 packages=(
-                    {"path": "first-pkg", "type": "yarn-classic"},
-                    {"path": "second-pkg", "type": "yarn-classic"},
+                    {"path": "first-pkg", "type": "yarn"},
+                    {"path": "second-pkg", "type": "yarn"},
                 ),
-                flags=["--dev-package-managers"],
                 check_vendor_checksums=False,
                 expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -155,7 +155,7 @@ class TestPackageInput:
             ),
             pytest.param(
                 {"type": "go-package"},
-                r"Input tag 'go-package' found using 'type' does not match any of the expected tags: 'bundler', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn-classic', 'yarn'",
+                r"Input tag 'go-package' found using 'type' does not match any of the expected tags: 'bundler', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn'",
                 id="incorrect_type_tag",
             ),
             pytest.param(

--- a/tests/unit/package_managers/test_metayarn.py
+++ b/tests/unit/package_managers/test_metayarn.py
@@ -1,0 +1,130 @@
+from unittest import mock
+
+import pytest
+
+from cachi2.core.errors import PackageRejected
+from cachi2.core.models.input import Request
+from cachi2.core.package_managers.metayarn import fetch_yarn_source
+from cachi2.core.package_managers.yarn_classic.main import NotV1Lockfile
+
+
+@pytest.mark.parametrize(
+    "input_request",
+    (pytest.param([{"type": "yarn", "path": "."}], id="no_input_packages"),),
+    indirect=["input_request"],
+)
+@mock.patch("cachi2.core.package_managers.metayarn.merge_outputs")
+@mock.patch("cachi2.core.package_managers.metayarn.fetch_yarnberry_source")
+@mock.patch("cachi2.core.package_managers.metayarn.fetch_yarn_classic_source")
+def test_fetch_yarn_source_detects_yarn_classic(
+    mock_yarnclassic_fetch_source: mock.Mock,
+    mock_yarnberry_fetch_source: mock.Mock,
+    mock_merge_outputs: mock.Mock,
+    input_request: Request,
+) -> None:
+
+    _ = fetch_yarn_source(input_request)
+
+    mock_yarnclassic_fetch_source.assert_called_once()
+    mock_yarnberry_fetch_source.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "input_request",
+    (pytest.param([{"type": "yarn", "path": "."}], id="no_input_packages"),),
+    indirect=["input_request"],
+)
+@mock.patch("cachi2.core.package_managers.metayarn.merge_outputs")
+@mock.patch("cachi2.core.package_managers.metayarn.fetch_yarnberry_source")
+@mock.patch("cachi2.core.package_managers.metayarn.fetch_yarn_classic_source")
+def test_fetch_yarn_source_detects_yarnberry(
+    mock_yarnclassic_fetch_source: mock.Mock,
+    mock_yarnberry_fetch_source: mock.Mock,
+    mock_merge_outputs: mock.Mock,
+    input_request: Request,
+) -> None:
+    mock_yarnclassic_fetch_source.side_effect = NotV1Lockfile("/some/path")
+
+    _ = fetch_yarn_source(input_request)
+
+    mock_yarnclassic_fetch_source.assert_called_once()
+    mock_yarnberry_fetch_source.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "input_request",
+    (pytest.param([{"type": "yarn", "path": "."}], id="no_input_packages"),),
+    indirect=["input_request"],
+)
+@mock.patch("cachi2.core.package_managers.metayarn.merge_outputs")
+@mock.patch("cachi2.core.package_managers.metayarn.fetch_yarnberry_source")
+@mock.patch("cachi2.core.package_managers.metayarn.fetch_yarn_classic_source")
+def test_fetch_yarn_source_propagates_yarn_classic_error(
+    mock_yarnclassic_fetch_source: mock.Mock,
+    mock_yarnberry_fetch_source: mock.Mock,
+    mock_merge_outputs: mock.Mock,
+    input_request: Request,
+) -> None:
+    mock_yarnclassic_fetch_source.side_effect = PackageRejected(
+        "this is a very bad package!", solution=None
+    )
+
+    with pytest.raises(PackageRejected):
+        _ = fetch_yarn_source(input_request)
+
+    mock_yarnclassic_fetch_source.assert_called_once()
+    mock_yarnberry_fetch_source.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "input_request",
+    (pytest.param([{"type": "yarn", "path": "."}], id="no_input_packages"),),
+    indirect=["input_request"],
+)
+@mock.patch("cachi2.core.package_managers.metayarn.merge_outputs")
+@mock.patch("cachi2.core.package_managers.metayarn.fetch_yarnberry_source")
+@mock.patch("cachi2.core.package_managers.metayarn.fetch_yarn_classic_source")
+def test_fetch_yarn_source_propagates_yarnberry_error(
+    mock_yarnclassic_fetch_source: mock.Mock,
+    mock_yarnberry_fetch_source: mock.Mock,
+    mock_merge_outputs: mock.Mock,
+    input_request: Request,
+) -> None:
+    mock_yarnclassic_fetch_source.side_effect = NotV1Lockfile("/some/path")
+    mock_yarnberry_fetch_source.side_effect = PackageRejected(
+        "this is a very bad package!", solution=None
+    )
+
+    with pytest.raises(PackageRejected):
+        _ = fetch_yarn_source(input_request)
+
+    mock_yarnclassic_fetch_source.assert_called_once()
+    mock_yarnberry_fetch_source.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "input_request",
+    (pytest.param([{"type": "yarn", "path": "."}], id="no_input_packages"),),
+    indirect=["input_request"],
+)
+@mock.patch("cachi2.core.package_managers.metayarn.merge_outputs")
+@mock.patch("cachi2.core.package_managers.metayarn.fetch_yarnberry_source")
+@mock.patch("cachi2.core.package_managers.metayarn.fetch_yarn_classic_source")
+@mock.patch("cachi2.core.package_managers.metayarn.get_config")
+def test_fetch_yarn_source_propagates_yarn_classic_rejection_when_yarnberry_is_forbidden(
+    mock_get_config: mock.Mock,
+    mock_yarnclassic_fetch_source: mock.Mock,
+    mock_yarnberry_fetch_source: mock.Mock,
+    mock_merge_outputs: mock.Mock,
+    input_request: Request,
+) -> None:
+    mock_yarnclassic_fetch_source.side_effect = NotV1Lockfile("/path/to/package")
+    mock_config = mock.Mock
+    mock_config.allow_yarnberry_processing = False
+    mock_get_config.return_value = mock_config
+
+    with pytest.raises(NotV1Lockfile):
+        _ = fetch_yarn_source(input_request)
+
+    mock_yarnclassic_fetch_source.assert_called_once()
+    mock_yarnberry_fetch_source.assert_not_called()

--- a/tests/unit/package_managers/yarn_classic/test_main.py
+++ b/tests/unit/package_managers/yarn_classic/test_main.py
@@ -56,12 +56,12 @@ def test_generate_build_environment_variables(
     "input_request, components",
     [
         pytest.param(
-            [{"type": "yarn-classic", "path": "."}],
+            [{"type": "yarn", "path": "."}],
             [],
             id="single_input_package",
         ),
         pytest.param(
-            [{"type": "yarn-classic", "path": "."}, {"type": "yarn-classic", "path": "./path"}],
+            [{"type": "yarn", "path": "."}, {"type": "yarn", "path": "./path"}],
             [],
             id="multiple_input_packages",
         ),

--- a/tests/unit/package_managers/yarn_classic/test_project.py
+++ b/tests/unit/package_managers/yarn_classic/test_project.py
@@ -230,6 +230,15 @@ def test_pnp_installs_false(
         config_file_name,
         config_file_content,
     )
+    # A yarn v1 project needs a valid yarn lock to be accepted.
+    _prepare_config_file(
+        rooted_tmp_path,
+        # Ignoring type checking because of
+        #   incompatible type "type[YarnLock]"; expected "Union[PackageJson, YarnLock]"
+        YarnLock,  # type: ignore
+        "yarn.lock",
+        VALID_YARN_LOCK_FILE,
+    )
 
     project = Project.from_source_dir(rooted_tmp_path)
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -358,7 +358,7 @@ class TestFetchDeps:
                 [
                     "Error: InvalidInput: 1 validation error for user input",
                     "packages -> 0",
-                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'bundler', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn-classic', 'yarn'",
+                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'bundler', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn'",
                 ],
             ),
             (
@@ -366,7 +366,7 @@ class TestFetchDeps:
                 [
                     "Error: InvalidInput: 1 validation error for user input",
                     "packages -> 0",
-                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'bundler', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn-classic', 'yarn'",
+                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'bundler', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn'",
                 ],
             ),
             (
@@ -374,7 +374,7 @@ class TestFetchDeps:
                 [
                     "Error: InvalidInput: 1 validation error for user input",
                     "packages -> 0",
-                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'bundler', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn-classic', 'yarn'",
+                    "Input tag 'idk' found using 'type' does not match any of the expected tags: 'bundler', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn'",
                 ],
             ),
             # Missing package type

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -104,7 +104,6 @@ def test_resolve_packages(tmp_path: Path) -> None:
     "packages, copy_exists",
     [
         ([{"type": "yarn"}], True),
-        ([{"type": "yarn-classic"}], True),
         ([{"type": "gomod"}, {"type": "pip"}, {"type": "npm"}], False),
     ],
 )


### PR DESCRIPTION
In order to simplify user interface some logic is added to automatically distinguish between supported Yarn versions.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
