### PR TITLE
yarn: Update workspace model

### DIFF
--- a/cachi2/core/errors.py
+++ b/cachi2/core/errors.py
@@ -46,6 +46,15 @@ class UsageError(Cachi2Error):
     is_invalid_usage: ClassVar[bool] = True
 
 
+class PathOutsideRoot(UsageError):
+    """Afer joining a subpath, the result is outside the root of a rooted path."""
+
+    default_solution = (
+        "With security in mind, Cachi2 will not access files outside the "
+        "specified source/output directories."
+    )
+
+
 class InvalidInput(UsageError):
     """User input was invalid."""
 

--- a/cachi2/core/package_managers/yarn_classic/resolver.py
+++ b/cachi2/core/package_managers/yarn_classic/resolver.py
@@ -218,8 +218,8 @@ def _get_workspace_packages(
     """Return a WorkspacePackage for each Workspace."""
     return [
         WorkspacePackage(
-            name=ws.package_contents["name"],
-            version=ws.package_contents.get("version"),
+            name=ws.package_json.data.get("name"),
+            version=ws.package_json.data.get("version"),
             relpath=ws.path.relative_to(source_dir.path),
         )
         for ws in workspaces

--- a/cachi2/core/package_managers/yarn_classic/workspaces.py
+++ b/cachi2/core/package_managers/yarn_classic/workspaces.py
@@ -6,7 +6,7 @@ from typing import Any, Generator, Iterable
 import pydantic
 
 from cachi2.core.errors import PackageRejected
-from cachi2.core.rooted_path import PathOutsideRoot, RootedPath
+from cachi2.core.rooted_path import RootedPath
 
 
 class Workspace(pydantic.BaseModel):
@@ -32,16 +32,7 @@ def ensure_no_path_leads_out(
     Does nothing when path does not exist in the file system.
     """
     for path in paths:
-        try:
-            source_dir.join_within_root(path)
-        except PathOutsideRoot:
-            raise PackageRejected(
-                f"Found a workspace path which is not relative to package: {path}",
-                solution=(
-                    "Avoid using packages which try to access your filesystem "
-                    "outside of package directory."
-                ),
-            )
+        source_dir.join_within_root(path)
 
 
 def _ensure_workspaces_are_well_formed(

--- a/cachi2/core/package_managers/yarn_classic/workspaces.py
+++ b/cachi2/core/package_managers/yarn_classic/workspaces.py
@@ -1,4 +1,3 @@
-import json
 from itertools import chain
 from pathlib import Path
 from typing import Any, Generator, Iterable
@@ -83,11 +82,6 @@ def _extract_workspaces_globs(package: dict[str, Any]) -> list[str]:
     if isinstance(workspaces_globs, dict):
         workspaces_globs = workspaces_globs.get("packages", [])
     return workspaces_globs
-
-
-def _read_package_from(path: RootedPath) -> dict[str, Any]:
-    """Read package.json from a path."""
-    return json.loads(path.join_within_root("package.json").path.read_text())
 
 
 def extract_workspace_metadata(package_path: RootedPath) -> list[Workspace]:

--- a/cachi2/core/rooted_path.py
+++ b/cachi2/core/rooted_path.py
@@ -4,17 +4,7 @@ from typing import Any, TypeVar, Union
 
 from pydantic_core import CoreSchema, core_schema
 
-from cachi2.core.errors import UsageError
-
-
-class PathOutsideRoot(UsageError):
-    """Afer joining a subpath, the result is outside the root of a rooted path."""
-
-    default_solution = (
-        "With security in mind, Cachi2 will not access files outside the "
-        "specified source/output directories."
-    )
-
+from cachi2.core.errors import PathOutsideRoot
 
 StrPath = Union[str, PathLike[str]]
 RootedPathT = TypeVar("RootedPathT", bound="RootedPath")

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -500,11 +500,8 @@ def test_resolve_gomod_suspicious_symlinks(symlinked_file: str, gomod_request: R
     app_dir = gomod_request.source_dir
 
     expect_err_msg = re.escape(f"Joining path '{symlinked_file}' to '{app_dir}'")
-    with pytest.raises(PathOutsideRoot, match=expect_err_msg) as exc_info:
+    with pytest.raises(PathOutsideRoot, match=expect_err_msg):
         _resolve_gomod(app_dir, gomod_request, tmp_path, version_resolver)
-
-    e = exc_info.value
-    assert "Found a potentially harmful symlink" in e.friendly_msg()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/package_managers/yarn_classic/test_resolver.py
+++ b/tests/unit/package_managers/yarn_classic/test_resolver.py
@@ -324,16 +324,23 @@ def test__get_main_package_no_name(rooted_tmp_path: RootedPath) -> None:
 
 
 def test__get_workspace_packages(rooted_tmp_path: RootedPath) -> None:
-    workspace_path = rooted_tmp_path.join_within_root("foo").path
+    workspace_path = rooted_tmp_path.join_within_root("foo")
+    workspace_path.path.mkdir()
+
+    package_json_path = workspace_path.join_within_root("package.json")
+    package_json_path.path.write_text('{"name": "foo", "version": "1.0.0"}')
+
+    package_json = PackageJson.from_file(package_json_path)
     workspace = Workspace(
-        path=workspace_path,
-        package_contents={"name": "foo", "version": "1.0.0"},
+        path=workspace_path.path,
+        package_json=package_json,
     )
+
     expected = [
         WorkspacePackage(
             name="foo",
             version="1.0.0",
-            relpath=workspace_path.relative_to(rooted_tmp_path.path),
+            relpath=workspace_path.path.relative_to(rooted_tmp_path.path),
         )
     ]
 

--- a/tests/unit/package_managers/yarn_classic/test_workspaces.py
+++ b/tests/unit/package_managers/yarn_classic/test_workspaces.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from cachi2.core.errors import PackageRejected
+from cachi2.core.errors import PathOutsideRoot
 from cachi2.core.package_managers.yarn_classic.workspaces import (
     Workspace,
     _extract_workspaces_globs,
@@ -23,7 +23,7 @@ def test_packages_with_workspaces_outside_source_dir_are_rejected(
     mock_get_ws_paths.return_value = [Path("/tmp/foo/bar"), Path("/usr")]
     package_path = RootedPath("/tmp/foo")
 
-    with pytest.raises(PackageRejected):
+    with pytest.raises(PathOutsideRoot):
         extract_workspace_metadata(package_path)
 
 


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
