### PR TITLE
yarn: Detect offline mirror collisions

### DIFF
--- a/tests/integration/test_yarn_classic.py
+++ b/tests/integration/test_yarn_classic.py
@@ -81,6 +81,20 @@ log = logging.getLogger(__name__)
             ),
             id="yarn_classic_lifecycle_scripts",
         ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-yarn.git",
+                ref="offline-mirror-collision",
+                packages=({"path": ".", "type": "yarn-classic"},),
+                flags=["--dev-package-managers"],
+                check_output=False,
+                check_deps_checksums=False,
+                check_vendor_checksums=False,
+                expected_exit_code=1,
+                expected_output="Duplicate tarballs detected",
+            ),
+            id="yarn_classic_offline_mirror_collision",
+        ),
     ],
 )
 def test_yarn_classic_packages(

--- a/tests/integration/test_yarn_classic.py
+++ b/tests/integration/test_yarn_classic.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
         pytest.param(
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
-                ref="3d596bd12839bff7ca8965895f4ce70c00bc3c7f",
+                ref="corepack_packagemanager_ignored",
                 packages=({"path": ".", "type": "yarn-classic"},),
                 flags=["--dev-package-managers"],
                 check_output=False,
@@ -28,7 +28,7 @@ log = logging.getLogger(__name__)
         pytest.param(
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
-                ref="e02f9f5ba278ad412e2823acf6f68a521acabfab",
+                ref="yarnpath_ignored",
                 packages=({"path": ".", "type": "yarn-classic"},),
                 flags=["--dev-package-managers"],
                 check_output=False,
@@ -42,7 +42,7 @@ log = logging.getLogger(__name__)
         pytest.param(
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
-                ref="ab0e1befff22af6fe92b75c8a75cb024fa7d8c33",
+                ref="invalid_checksum",
                 packages=({"path": ".", "type": "yarn-classic"},),
                 flags=["--dev-package-managers"],
                 check_output=False,
@@ -70,7 +70,7 @@ log = logging.getLogger(__name__)
         pytest.param(
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
-                ref="200cc9423b1df173c12b61f951e463d8a18d9e19",
+                ref="lifecycle_scripts",
                 packages=({"path": ".", "type": "yarn-classic"},),
                 flags=["--dev-package-managers"],
                 check_output=False,
@@ -127,7 +127,7 @@ def test_yarn_classic_packages(
         pytest.param(
             utils.TestParameters(
                 repo="https://github.com/cachito-testing/cachi2-yarn.git",
-                ref="db27afd28d5b5fdc349f3ffb12b0f58140f6be32",
+                ref="valid_multiple_packages",
                 packages=(
                     {"path": "first-pkg", "type": "yarn-classic"},
                     {"path": "second-pkg", "type": "yarn-classic"},


### PR DESCRIPTION
When yarn fetches a URL dependency into the offline mirror, the name of the tarball is used as the name of the tarball in the mirror.

After running `yarn install` command, in a project where are two different URL dependencies have the same name of the tarball, there will be only one tarball in the offline mirror with such name, because the first one gets replaced by the second one.

closes https://github.com/containerbuildsystem/cachi2/issues/634

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
