### PR TITLE
Adding optional RPM summary to SBOMs

### DIFF
--- a/cachi2/core/models/input.py
+++ b/cachi2/core/models/input.py
@@ -214,6 +214,7 @@ class RpmPackageInput(_PackageInputBase):
     """Accepted input for a rpm package."""
 
     type: Literal["rpm"]
+    include_summary_in_sbom: bool = False
     options: Optional[ExtraOptions] = None
 
 

--- a/cachi2/core/models/property_semantics.py
+++ b/cachi2/core/models/property_semantics.py
@@ -34,6 +34,7 @@ class PropertySet:
     npm_development: bool = False
     pip_package_binary: bool = False
     bundler_package_binary: bool = False
+    rpm_summary: str = ""
 
     @classmethod
     def from_properties(cls, props: Iterable[Property]) -> "Self":
@@ -44,6 +45,7 @@ class PropertySet:
         npm_development = False
         pip_package_binary = False
         bundler_package_binary = False
+        rpm_summary = ""
 
         for prop in props:
             if prop.name == "cachi2:found_by":
@@ -58,6 +60,8 @@ class PropertySet:
                 pip_package_binary = True
             elif prop.name == "cachi2:bundler:package:binary":
                 bundler_package_binary = True
+            elif prop.name == "cachi2:rpm_summary":
+                rpm_summary = prop.value
             else:
                 assert_never(prop.name)
 
@@ -68,6 +72,7 @@ class PropertySet:
             npm_development,
             pip_package_binary,
             bundler_package_binary,
+            rpm_summary,
         )
 
     def to_properties(self) -> list[Property]:
@@ -87,6 +92,8 @@ class PropertySet:
             props.append(Property(name="cachi2:pip:package:binary", value="true"))
         if self.bundler_package_binary:
             props.append(Property(name="cachi2:bundler:package:binary", value="true"))
+        if self.rpm_summary:
+            props.append(Property(name="cachi2:rpm_summary", value=self.rpm_summary))
 
         return sorted(props, key=lambda p: (p.name, p.value))
 
@@ -100,4 +107,5 @@ class PropertySet:
             npm_development=self.npm_development and other.npm_development,
             pip_package_binary=self.pip_package_binary or other.pip_package_binary,
             bundler_package_binary=self.bundler_package_binary or other.bundler_package_binary,
+            rpm_summary=self.rpm_summary or other.rpm_summary,
         )

--- a/cachi2/core/models/sbom.py
+++ b/cachi2/core/models/sbom.py
@@ -7,6 +7,7 @@ from cachi2.core.models.validators import unique_sorted
 PropertyName = Literal[
     "cachi2:bundler:package:binary",
     "cachi2:found_by",
+    "cachi2:rpm_summary",
     "cachi2:missing_hash:in_file",
     "cachi2:pip:package:binary",
     "cdx:npm:package:bundled",

--- a/tests/integration/test_data/rpm_summary_is_reported/.build-config.yaml
+++ b/tests/integration/test_data/rpm_summary_is_reported/.build-config.yaml
@@ -1,0 +1,2 @@
+environment_variables: []
+project_files: []

--- a/tests/integration/test_data/rpm_summary_is_reported/bom.json
+++ b/tests/integration/test_data/rpm_summary_is_reported/bom.json
@@ -1,0 +1,91 @@
+{
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "name": "glibc-common",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        },
+        {
+            "name": "cachi2:rpm_summary",
+            "value": "Common binaries and locale data for glibc"
+        }
+      ],
+      "purl": "pkg:rpm/fedora/glibc-common@2.39-6.fc40?arch=x86_64&checksum=sha256:45fe79ffea9358fc7a4f233e2358b08678bdec476680d0655063b4a4058e8789&repository_id=releases",
+      "type": "library",
+      "version": "2.39"
+    },
+    {
+      "name": "glibc-common",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        },
+        {
+          "name": "cachi2:missing_hash:in_file",
+          "value": "another-project/rpms.lock.yaml"
+        }
+      ],
+      "purl": "pkg:rpm/fedora/glibc-common@2.39-6.fc40?arch=x86_64&repository_id=releases",
+      "type": "library",
+      "version": "2.39"
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        }
+      ],
+      "purl": "pkg:rpm/fedora/glibc-minimal-langpack@2.38-7.fc39?arch=x86_64&checksum=sha256:6f9b45618d3b46fbbfb44407e05dd7054f3bd6a4df4f7291b576858b88deadc5&repository_id=releases",
+      "type": "library",
+      "version": "2.38"
+    },
+    {
+      "name": "glibc-minimal-langpack",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        },
+        {
+            "name": "cachi2:rpm_summary",
+            "value": "Minimal language packs for glibc."
+        }
+      ],
+      "purl": "pkg:rpm/fedora/glibc-minimal-langpack@2.39-6.fc40?arch=x86_64&checksum=sha256:9982f68ddcc3e972a2f3f220f29d56b0e9dde0e409bdecfe0bc559fe39013dde&repository_id=releases",
+      "type": "library",
+      "version": "2.39"
+    },
+    {
+      "name": "gzip",
+      "properties": [
+        {
+          "name": "cachi2:found_by",
+          "value": "cachi2"
+        },
+        {
+            "name": "cachi2:rpm_summary",
+            "value": "GNU data compression program"
+        }
+      ],
+      "purl": "pkg:rpm/fedora/gzip@1.13-1.fc40?arch=x86_64&checksum=sha256:6dcc2f8885135fc873c8ab94a6c7df05883060c5b25287956bebb3aa15a84e71&repository_id=releases",
+      "type": "library",
+      "version": "1.13"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "name": "cachi2",
+        "vendor": "red hat"
+      }
+    ]
+  },
+  "specVersion": "1.4",
+  "version": 1
+}

--- a/tests/integration/test_rpm.py
+++ b/tests/integration/test_rpm.py
@@ -112,6 +112,22 @@ from . import utils
                 reason="CACHI2_TEST_LOCAL_DNF_SERVER!=true",
             ),
         ),
+        pytest.param(
+            utils.TestParameters(
+                repo="https://github.com/cachito-testing/cachi2-rpm",
+                ref="multiple-packages",
+                packages=(
+                    {"path": "this-project", "type": "rpm", "include_summary_in_sbom": "true"},
+                    {"path": "another-project", "type": "rpm"},
+                ),
+                flags=["--dev-package-managers"],
+                check_output=True,
+                check_deps_checksums=False,
+                check_vendor_checksums=False,
+                expected_exit_code=0,
+            ),
+            id="rpm_summary_is_reported",
+        ),
     ],
 )
 def test_rpm_packages(

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -69,6 +69,7 @@ class TestPackageInput:
                     "type": "rpm",
                     "path": Path("."),
                     "options": None,
+                    "include_summary_in_sbom": False,
                 },
             ),
             (
@@ -80,6 +81,7 @@ class TestPackageInput:
                             "foorepo": {"arch": "x86_64", "enabled": True},
                         }
                     },
+                    "include_summary_in_sbom": False,
                 },
                 {
                     "type": "rpm",
@@ -91,6 +93,7 @@ class TestPackageInput:
                         },
                         "ssl": None,
                     },
+                    "include_summary_in_sbom": False,
                 },
             ),
             (
@@ -110,6 +113,7 @@ class TestPackageInput:
                             "ssl_verify": False,
                         },
                     },
+                    "include_summary_in_sbom": False,
                 },
             ),
             (
@@ -138,6 +142,7 @@ class TestPackageInput:
                             "ssl_verify": False,
                         },
                     },
+                    "include_summary_in_sbom": False,
                 },
             ),
         ],

--- a/tests/unit/package_managers/test_rpm.py
+++ b/tests/unit/package_managers/test_rpm.py
@@ -361,7 +361,7 @@ def test_resolve_rpm_project(
         mock_model_validate.return_value, mock_package_dir_path, None
     )
     mock_verify_downloaded.assert_called_once_with({})
-    mock_generate_sbom_components.assert_called_once_with({}, Path("rpms.lock.yaml"))
+    mock_generate_sbom_components.assert_called_once_with({}, Path("rpms.lock.yaml"), False)
 
 
 @mock.patch("cachi2.core.package_managers.rpm.main.run_cmd")


### PR DESCRIPTION
This change adds an option to include RPM summary in a SBOM.


# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
