### PR TITLE
bundler git deps fixes

### DIFF
--- a/cachi2/core/package_managers/bundler/main.py
+++ b/cachi2/core/package_managers/bundler/main.py
@@ -90,7 +90,7 @@ def _resolve_bundler_package(
         else:
             properties = []
         if isinstance(dep, GitDependency):
-            git_paths.append((dep.name, dep.name + "-" + dep.ref[:12]))
+            git_paths.append((dep.name, dep.repo_name + "-" + dep.ref[:12]))
 
         c = Component(name=dep.name, version=dep.version, purl=dep.purl, properties=properties)
         components.append(c)

--- a/cachi2/core/package_managers/bundler/parser.py
+++ b/cachi2/core/package_managers/bundler/parser.py
@@ -116,10 +116,12 @@ class GitDependency(_GemMetadata):
 
     Attributes:
         url:        The URL of the git repository.
+        branch:     The branch to checkout.
         ref:        Commit hash.
     """
 
     url: AcceptedUrl
+    branch: Optional[str] = None
     ref: AcceptedGitRef
 
     @cached_property
@@ -153,7 +155,11 @@ class GitDependency(_GemMetadata):
             to_path=git_repo_path.path,
             env={"GIT_TERMINAL_PROMPT": "0"},
         )
-        repo.git.checkout(self.ref)
+
+        if self.branch is not None:
+            repo.git.checkout(self.branch)
+
+        repo.git.reset("--hard", self.ref)
 
 
 class PathDependency(_GemMetadata):

--- a/cachi2/core/package_managers/bundler/scripts/lockfile_parser.rb
+++ b/cachi2/core/package_managers/bundler/scripts/lockfile_parser.rb
@@ -11,21 +11,22 @@ parsed_specs = []
 lockfile_parser.specs.each do |spec|
     parsed_spec = {
       name: spec.name,
-      version: spec.version.to_s
+      version: spec.version
     }
 
     case spec.source
     when Bundler::Source::Rubygems
       parsed_spec[:type] = 'rubygems'
-      parsed_spec[:source] = spec.source.remotes.map(&:to_s).first
+      parsed_spec[:source] = spec.source.remotes.first
       parsed_spec[:platform] = spec.platform
     when Bundler::Source::Git
       parsed_spec[:type] = 'git'
       parsed_spec[:url] = spec.source.uri
+      parsed_spec[:branch] = spec.source.branch
       parsed_spec[:ref] = spec.source.revision
     when Bundler::Source::Path
       parsed_spec[:type] = 'path'
-      parsed_spec[:subpath] = spec.source.path.to_s
+      parsed_spec[:subpath] = spec.source.path
     end
 
     parsed_specs << parsed_spec

--- a/tests/unit/package_managers/bundler/test_parser.py
+++ b/tests/unit/package_managers/bundler/test_parser.py
@@ -153,6 +153,7 @@ def test_parse_gemlock(
         {
             "type": "git",
             "url": "https://github.com/3scale/json-schema.git",
+            "branch": "devel",
             "ref": GIT_REF,
             **base_dep,
         },
@@ -177,6 +178,7 @@ def test_parse_gemlock(
             name="example",
             version="0.1.0",
             url="https://github.com/3scale/json-schema.git",
+            branch="devel",
             ref=GIT_REF,
         ),
         PathDependency(


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
