### PR TITLE
[CONTRIBUTING] Add a note on the 'hack/mock-unittest-data' directory and how to re-generate mock unit test data

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,7 @@ Whenever adding a new feature to Cachi2, it is important to keep these fundament
 
     The content provided to the build will only be safe if all of the downloaded packages have their checksums verified. In case a mismatch is found, the entire request must be failed, since the prefetched content is tainted and is potentially malicious. There are two types of checksums: server-provided and user-provided. Cachi2 prefers but does not require the latter. Every dependency which does not have a user-provided checksum verified, must be clearly marked as such in the resulting SBOM (e.g. see 'pip' support). All dependencies must have at least one checksum in order to be considered validated.
 
-4. Favor reproducibilty
+4. Favor reproducibility
 
     Always use fully resolved lockfiles or similar input files to determine what content needs to be download for a specific project (e.g. npm's `package-lock.json`, a `pip-compile` generated `requirements.txt`, etc). Resolving the dependencies during the prefetch will prevent its behavior from being deterministic—in other words, the same repository and the same commit hash should always result in identical prefetch results.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -205,6 +205,26 @@ nox -s python-3.9 -- tests/unit/extras/test_envfile.py::test_cannot_determine_fo
 
 In short, nox passes all arguments to the right of `--` directly to pytest.
 
+#### Generating new test data
+
+Whenever a particular package manager supported version is bumped it is considered good practice
+to also re-generate the mocked unit test data using that version of package manager (make sure you
+have it available in path). You do that by executing the corresponding script under
+`hack/mock-unittest-data`. Note that there may be times the data has to be re-generated even
+without bumping the backend version, e.g. we added support for a particular feature of the package
+manager which we didn't add at the time of the initial support release.
+
+Example:
+```shell
+hack/mock-unittest-data/gomod.sh
+```
+
+Generate data for test cases matching a pytest pattern:
+
+```shell
+nox -s generate-test-data -- -k test_e2e_gomod
+```
+
 ### Running integration tests
 
 Build Cachi2 image (localhost/cachi2:latest) and run most integration tests:
@@ -229,7 +249,7 @@ CACHI2_IMAGE=quay.io/konflux-ci/cachi2:{tag} nox -s integration-tests
 CACHI2_IMAGE=localhost/cachi2:latest nox -s  integration-tests
 ```
 
-#### Running integration tests and generating new test data
+#### Generating new test data
 
 To re-generate new data (output, dependencies checksums, vendor checksums) and run integration tests with them:
 


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
