### PR TITLE
README: Drop the Go workspace vendoring note

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ original Cachito.*
 
 <https://go.dev/ref/mod>
 
-Current version: 1.23 [^go-version] [^go-compat] [^workspace-vendoring]
+Current version: 1.23 [^go-version] [^go-compat]
 
 The gomod package manager works by parsing the [go.mod](https://go.dev/ref/mod#go-mod-file) file present in the source
 repository to determine which dependencies to download. Cachi2 does not parse this file on its own - rather, we rely on
@@ -176,10 +176,6 @@ See [docs/gomod.md](docs/gomod.md) for more details.
   [go 1.19][go119-changelog]. Things are a bit more complicated with [Go 1.21][go121-changelog], if
   you are or have been experiencing issues with cachi2 related to Go 1.21+, please refer to
   [docs/gomod.md](docs/gomod.md#go-121-since-cachi2-v050).
-
-[^workspace-vendoring]: Although Cachi2 supports Go 1.23, support for workspace vendoring
-  introduced in Go 1.22 hasn't been added yet (still in development) and so if your project makes
-  use of the feature cachi2 will error out.
 
 ### pip
 


### PR DESCRIPTION
The work was done in commit 1a746952 . Remove the documentation note that we don't support it.

#553 failed to include this change.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
