### PR TITLE
Report Yarn v3/v4 patches as pedigree rather than components

### DIFF
--- a/cachi2/core/models/sbom.py
+++ b/cachi2/core/models/sbom.py
@@ -27,6 +27,25 @@ class ExternalReference(pydantic.BaseModel):
     type: Literal["distribution"] = "distribution"
 
 
+class PatchDiff(pydantic.BaseModel):
+    """A Diff inside a Patch."""
+
+    url: str
+
+
+class Patch(pydantic.BaseModel):
+    """A Patch inside a SBOM Component Pedigree."""
+
+    type: Literal["backport", "cherry-pick", "monkey", "unofficial"] = "unofficial"
+    diff: PatchDiff
+
+
+class Pedigree(pydantic.BaseModel):
+    """A Pedigree inside a SBOM component."""
+
+    patches: list[Patch]
+
+
 FOUND_BY_CACHI2_PROPERTY: Property = Property(name="cachi2:found_by", value="cachi2")
 
 
@@ -45,6 +64,7 @@ class Component(pydantic.BaseModel):
     external_references: Optional[list[ExternalReference]] = pydantic.Field(
         serialization_alias="externalReferences", default=None
     )
+    pedigree: Optional[Pedigree] = None
 
     def key(self) -> str:
         """Uniquely identifies a package.

--- a/cachi2/core/package_managers/yarn/locators.py
+++ b/cachi2/core/package_managers/yarn/locators.py
@@ -205,10 +205,14 @@ def _parse_patch_locator(locator: "_ParsedLocator") -> PatchLocator:
 
     original_package = parse_locator(reference.source)
 
-    # https://github.com/yarnpkg/berry/blob/b6026842dfec4b012571b5982bb74420c7682a73/packages/plugin-patch/sources/patchUtils.ts#L92
     def process_patch_path(patch: str) -> Union[str, Path]:
-        # '~' denotes an optional patch (failing to apply the patch is not fatal, only a warning)
+        # Yarn patches can be optional, where failing to apply the patch is not fatal, only a warning
+        # '~' denotes an optional patch in Yarn v3
+        # https://github.com/yarnpkg/berry/blob/b6026842dfec4b012571b5982bb74420c7682a73/packages/plugin-patch/sources/patchUtils.ts#L92
         patch = patch.removeprefix("~")
+        # `optional!' denotes an optional patch in Yarn v4
+        # https://github.com/yarnpkg/berry/blob/93a56643ba3c813a87920dcf75c644eaf3b38e6f/packages/plugin-patch/sources/patchUtils.ts#L147
+        patch = patch.removeprefix("optional!")
         if re.match(r"^builtin<([^>]+)>$", patch):
             return patch
         else:

--- a/tests/integration/test_data/yarn_e2e_test/bom.json
+++ b/tests/integration/test_data/yarn_e2e_test/bom.json
@@ -314,18 +314,16 @@
     },
     {
       "name": "cachito-npm-without-deps",
-      "properties": [
-        {
-          "name": "cachi2:found_by",
-          "value": "cachi2"
-        }
-      ],
-      "purl": "pkg:npm/cachito-npm-without-deps@1.0.0",
-      "type": "library",
-      "version": "1.0.0"
-    },
-    {
-      "name": "cachito-npm-without-deps",
+      "pedigree": {
+        "patches": [
+          {
+            "diff": {
+              "url": "git+https://github.com/cachito-testing/cachi2-yarn-berry.git@70515793108df42547d3320c7ea4cd6b6e505c46#.yarn/patches/ccto-wo-deps-git@github.com-e0fce8c89c.patch"
+            },
+            "type": "unofficial"
+          }
+        ]
+      },
       "properties": [
         {
           "name": "cachi2:found_by",
@@ -662,6 +660,22 @@
     },
     {
       "name": "fsevents",
+      "pedigree": {
+        "patches": [
+          {
+            "diff": {
+              "url": "git+https://github.com/cachito-testing/cachi2-yarn-berry.git@70515793108df42547d3320c7ea4cd6b6e505c46#my-patches/fsevents.patch"
+            },
+            "type": "unofficial"
+          },
+          {
+            "diff": {
+              "url": "git+https://github.com/yarnpkg/berry@%40yarnpkg/cli/3.6.1#packages/plugin-compat/sources/patches/fsevents.patch.ts"
+            },
+            "type": "unofficial"
+          }
+        ]
+      },
       "properties": [
         {
           "name": "cachi2:found_by",
@@ -961,6 +975,22 @@
     },
     {
       "name": "left-pad",
+      "pedigree": {
+        "patches": [
+          {
+            "diff": {
+              "url": "git+https://github.com/cachito-testing/cachi2-yarn-berry.git@70515793108df42547d3320c7ea4cd6b6e505c46#my-patches/left-pad.patch"
+            },
+            "type": "unofficial"
+          },
+          {
+            "diff": {
+              "url": "git+https://github.com/cachito-testing/cachi2-yarn-berry.git@70515793108df42547d3320c7ea4cd6b6e505c46#my-patches/left-pad-2.patch"
+            },
+            "type": "unofficial"
+          }
+        ]
+      },
       "properties": [
         {
           "name": "cachi2:found_by",
@@ -1691,6 +1721,16 @@
     },
     {
       "name": "typescript",
+      "pedigree": {
+        "patches": [
+          {
+            "diff": {
+              "url": "git+https://github.com/yarnpkg/berry@%40yarnpkg/cli/3.6.1#packages/plugin-compat/sources/patches/typescript.patch.ts"
+            },
+            "type": "unofficial"
+          }
+        ]
+      },
       "properties": [
         {
           "name": "cachi2:found_by",

--- a/tests/integration/test_data/yarn_v4/bom.json
+++ b/tests/integration/test_data/yarn_v4/bom.json
@@ -314,18 +314,16 @@
     },
     {
       "name": "cachito-npm-without-deps",
-      "properties": [
-        {
-          "name": "cachi2:found_by",
-          "value": "cachi2"
-        }
-      ],
-      "purl": "pkg:npm/cachito-npm-without-deps@1.0.0",
-      "type": "library",
-      "version": "1.0.0"
-    },
-    {
-      "name": "cachito-npm-without-deps",
+      "pedigree": {
+        "patches": [
+          {
+            "diff": {
+              "url": "git+https://github.com/cachito-testing/cachi2-yarn-berry.git@53a2bfe8d5ee7ed9c2f752fe75831a881d54895f#.yarn/patches/ccto-wo-deps-git@github.com-e0fce8c89c.patch"
+            },
+            "type": "unofficial"
+          }
+        ]
+      },
       "properties": [
         {
           "name": "cachi2:found_by",
@@ -662,6 +660,22 @@
     },
     {
       "name": "fsevents",
+      "pedigree": {
+        "patches": [
+          {
+            "diff": {
+              "url": "git+https://github.com/cachito-testing/cachi2-yarn-berry.git@53a2bfe8d5ee7ed9c2f752fe75831a881d54895f#my-patches/fsevents.patch"
+            },
+            "type": "unofficial"
+          },
+          {
+            "diff": {
+              "url": "git+https://github.com/yarnpkg/berry@%40yarnpkg/cli/4.5.2#packages/plugin-compat/sources/patches/fsevents.patch.ts"
+            },
+            "type": "unofficial"
+          }
+        ]
+      },
       "properties": [
         {
           "name": "cachi2:found_by",
@@ -961,6 +975,22 @@
     },
     {
       "name": "left-pad",
+      "pedigree": {
+        "patches": [
+          {
+            "diff": {
+              "url": "git+https://github.com/cachito-testing/cachi2-yarn-berry.git@53a2bfe8d5ee7ed9c2f752fe75831a881d54895f#my-patches/left-pad.patch"
+            },
+            "type": "unofficial"
+          },
+          {
+            "diff": {
+              "url": "git+https://github.com/cachito-testing/cachi2-yarn-berry.git@53a2bfe8d5ee7ed9c2f752fe75831a881d54895f#my-patches/left-pad-2.patch"
+            },
+            "type": "unofficial"
+          }
+        ]
+      },
       "properties": [
         {
           "name": "cachi2:found_by",
@@ -1691,6 +1721,16 @@
     },
     {
       "name": "typescript",
+      "pedigree": {
+        "patches": [
+          {
+            "diff": {
+              "url": "git+https://github.com/yarnpkg/berry@%40yarnpkg/cli/4.5.2#packages/plugin-compat/sources/patches/typescript.patch.ts"
+            },
+            "type": "unofficial"
+          }
+        ]
+      },
       "properties": [
         {
           "name": "cachi2:found_by",

--- a/tests/unit/package_managers/test_generic.py
+++ b/tests/unit/package_managers/test_generic.py
@@ -255,7 +255,6 @@ def test_resolve_generic_lockfile_invalid(
                     "properties": [{"name": "cachi2:found_by", "value": "cachi2"}],
                     "purl": "pkg:generic/archive.zip?checksum=md5:3a18656e1cea70504b905836dee14db0&download_url=https://example.com/artifact",
                     "type": "file",
-                    "version": None,
                 },
                 {
                     "external_references": [
@@ -268,7 +267,6 @@ def test_resolve_generic_lockfile_invalid(
                     "properties": [{"name": "cachi2:found_by", "value": "cachi2"}],
                     "purl": "pkg:generic/file.tar.gz?checksum=md5:32112bed1914cfe3799600f962750b1d&download_url=https://example.com/more/complex/path/file.tar.gz%3Ffoo%3Dbar%23fragment",
                     "type": "file",
-                    "version": None,
                 },
             ],
             id="valid_lockfile",
@@ -324,7 +322,8 @@ def test_resolve_generic_lockfile_valid(
         f.write(lockfile_content)
 
     assert [
-        c.model_dump() for c in _resolve_generic_lockfile(lockfile_path.path, rooted_tmp_path)
+        c.model_dump(exclude_none=True)
+        for c in _resolve_generic_lockfile(lockfile_path.path, rooted_tmp_path)
     ] == expected_components
     mock_checksums.assert_called()
 

--- a/tests/unit/package_managers/yarn/test_locators.py
+++ b/tests/unit/package_managers/yarn/test_locators.py
@@ -42,9 +42,11 @@ SUPPORTED_LOCATORS = [
     # optional custom patch for a registry dep
     "left-pad@npm:1.3.0",
     "left-pad@patch:left-pad@npm%3A1.3.0#~./my-patches/left-pad.patch::version=1.3.0&hash=629bda&locator=berryscary%40workspace%3A.",
+    "left-pad@patch:left-pad@npm%3A1.3.0#optional!./my-patches/left-pad.patch::version=1.3.0&hash=629bda&locator=berryscary%40workspace%3A.",
     # optional builtin patch
     "fsevents@npm:2.3.2",
     "fsevents@patch:fsevents@npm%3A2.3.2#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1",
+    "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1",
     # patched patch dependency
     "fsevents@patch:fsevents@patch%3Afsevents@npm%253A2.3.2%23./my-patches/fsevents.patch%3A%3Aversion=2.3.2&hash=cf0bf0&locator=berryscary%2540workspace%253A.#~builtin<compat/fsevents>::version=2.3.2&hash=df0bf1",
     # non-optional builtin patch (in reality, the typescript patch is optional)
@@ -202,6 +204,23 @@ PARSED_LOCATORS_AND_REFERENCES = [
         ),
     ),
     (
+        _ParsedLocator(
+            scope=None,
+            name="left-pad",
+            raw_reference="patch:left-pad@npm%3A1.3.0#optional!./my-patches/left-pad.patch::version=1.3.0&hash=629bda&locator=berryscary%40workspace%3A.",
+        ),
+        _ParsedReference(
+            protocol="patch:",
+            source="left-pad@npm:1.3.0",
+            selector="optional!./my-patches/left-pad.patch",
+            params={
+                "version": ["1.3.0"],
+                "hash": ["629bda"],
+                "locator": ["berryscary@workspace:."],
+            },
+        ),
+    ),
+    (
         _ParsedLocator(scope=None, name="fsevents", raw_reference="npm:2.3.2"),
         _ParsedReference(protocol="npm:", source=None, selector="2.3.2", params=None),
     ),
@@ -215,6 +234,19 @@ PARSED_LOCATORS_AND_REFERENCES = [
             protocol="patch:",
             source="fsevents@npm:2.3.2",
             selector="~builtin<compat/fsevents>",
+            params={"version": ["2.3.2"], "hash": ["df0bf1"]},
+        ),
+    ),
+    (
+        _ParsedLocator(
+            scope=None,
+            name="fsevents",
+            raw_reference="patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1",
+        ),
+        _ParsedReference(
+            protocol="patch:",
+            source="fsevents@npm:2.3.2",
+            selector="optional!builtin<compat/fsevents>",
             params={"version": ["2.3.2"], "hash": ["df0bf1"]},
         ),
     ),
@@ -376,7 +408,17 @@ PARSED_SUPPORTED_LOCATORS = [
         patches=(Path("my-patches/left-pad.patch"),),
         locator=WorkspaceLocator(scope=None, name="berryscary", relpath=Path(".")),
     ),
+    PatchLocator(
+        package=NpmLocator(scope=None, name="left-pad", version="1.3.0"),
+        patches=(Path("my-patches/left-pad.patch"),),
+        locator=WorkspaceLocator(scope=None, name="berryscary", relpath=Path(".")),
+    ),
     NpmLocator(scope=None, name="fsevents", version="2.3.2"),
+    PatchLocator(
+        package=NpmLocator(scope=None, name="fsevents", version="2.3.2"),
+        patches=("builtin<compat/fsevents>",),
+        locator=None,
+    ),
     PatchLocator(
         package=NpmLocator(scope=None, name="fsevents", version="2.3.2"),
         patches=("builtin<compat/fsevents>",),


### PR DESCRIPTION
Yarn has a `patch` protocol for the [package patching feature](https://yarnpkg.com/features/patching). Patches should not be reported as independent Components in the SBOM, but should instead be reported as [pedigree](https://cyclonedx.org/docs/1.4/json/#components_items_pedigree_patches) for the patched "regular" package Component.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
