### PR TITLE
Fix project files absolute paths when a work copy is used

### DIFF
--- a/cachi2/core/resolver.py
+++ b/cachi2/core/resolver.py
@@ -48,6 +48,13 @@ def resolve_packages(request: Request) -> RequestOutput:
             output = _resolve_packages(request)
             request.source_dir = original_source_dir
 
+            # Temporary solution to project files paths that are pointing to the work copy.
+            # Should be replaced once we extend the work copy solution to other package managers.
+            # https://github.com/containerbuildsystem/cachi2/issues/712
+            for project_file in output.build_config.project_files:
+                subpath = project_file.abspath.relative_to(source_backup)
+                project_file.abspath = original_source_dir / subpath
+
             return output
     else:
         return _resolve_packages(request)


### PR DESCRIPTION
To avoid unintended source code modifications, Cachi2 makes a copy of the source directory when some package managers are used (currently, it's being done just for yarn).

This creates a problem with project files, since the absolute path of files now is pointing to the temporary working copy. The solution introced by this patch reverts these paths back to the original source dir path.

This is intended to be a quick fix, and should only be kept until we solve #712.

Resolves #785.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)