### PR TITLE
Dockerfile: Add jq dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN dnf -y install \
     --setopt install_weak_deps=0 \
     --nodocs \
     git-core \
+    jq \
     python3 \
     rubygem-bundler \
     rubygem-json \


### PR DESCRIPTION
Although not strictly a direct dependency, it's a convenient tool to have in the image to construct input JSONs for our CLI from within Bash. The total install size is ~1MB so nothing tragically affecting the resulting image size.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
