### PR TITLE
Some changes to make local IT runs more stable

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -138,6 +138,11 @@ def local_dnfserver(top_level_test_dir: Path) -> Iterator[None]:
             try:
                 _check_ssl_configuration()
                 break
+            except requests.ConnectionError:
+                # ConnectionResetError is often reported locally, waiting it over
+                # helps.
+                log.info("Failed to connect to the DNF server, retrying...")
+                continue
             except requests.RequestException as e:
                 raise RuntimeError(e)
         else:

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -285,7 +286,12 @@ def _safe_extract(tar: TarFile, path: str = ".", *, numeric_owner: bool = False)
         if not abs_member_path.is_relative_to(abs_path):
             raise ExtractError("Attempted Path Traversal in Tar File")
 
-    tar.extractall(path, numeric_owner=numeric_owner)
+    # This 'if' block is to deal with deprectaion warning for unfiltered tar
+    # extraction in 3.12.
+    if sys.version_info >= (3, 12):
+        tar.extractall(path, numeric_owner=numeric_owner, filter="fully_trusted")
+    else:
+        tar.extractall(path, numeric_owner=numeric_owner)
 
 
 def _json_serialize(data: dict[str, Any]) -> str:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+import sys
 import tarfile
 from pathlib import Path
 from typing import Generator
@@ -20,7 +21,10 @@ def data_dir() -> Path:
 def golang_repo_path(data_dir: Path, tmp_path: Path) -> Path:
     """Return extracted Golang git repository inside a temporary directory."""
     with tarfile.open(data_dir / "golang_git_repo.tar.gz") as tar:
-        tar.extractall(tmp_path)
+        if sys.version_info >= (3, 12):
+            tar.extractall(tmp_path, filter="fully_trusted")
+        else:
+            tar.extractall(tmp_path)
 
     return tmp_path / "golang_git_repo"
 

--- a/tests/unit/models/test_sbom.py
+++ b/tests/unit/models/test_sbom.py
@@ -559,12 +559,14 @@ DEFAULT_ROOT_PACKAGE = SPDXPackage(
     }
 )
 
-DEFAULT_ROOT_RELATION = {
-    "spdxElementId": "SPDXRef-DOCUMENT",
-    "comment": "",
-    "relatedSpdxElement": "SPDXRef-DocumentRoot-File-",
-    "relationshipType": "DESCRIBES",
-}
+DEFAULT_ROOT_RELATION = SPDXRelation(
+    **{
+        "spdxElementId": "SPDXRef-DOCUMENT",
+        "comment": "",
+        "relatedSpdxElement": "SPDXRef-DocumentRoot-File-",
+        "relationshipType": "DESCRIBES",
+    }
+)
 
 
 def _gen_ref(locator: str) -> dict:

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -1,4 +1,5 @@
 import filecmp
+import sys
 import tarfile
 from pathlib import Path
 from typing import Union
@@ -76,7 +77,10 @@ def test_clone_as_tarball(golang_repo_path: Path, tmp_path: Path) -> None:
     clone_as_tarball(f"file://{original_path}", INITIAL_COMMIT, to_path)
 
     with tarfile.open(to_path) as tar:
-        tar.extractall(tmp_path / "my-repo")
+        if sys.version_info >= (3, 12):
+            tar.extractall(tmp_path / "my-repo", filter="fully_trusted")
+        else:
+            tar.extractall(tmp_path / "my-repo")
 
     my_path = tmp_path / "my-repo" / "app"
 


### PR DESCRIPTION
The PR adds several retries to functions which tend to sporadically fail locally for no good reason.

It also addresses several warnings which pollute UTs output. It does not handle
`coroutine 'AsyncMockMixin._execute_mock_call' was never awaited` which is very annoying, but has to be chased with specially trained dogs.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
