### PR TITLE
Skip test filtering when using pytest -k option

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -159,6 +159,10 @@ def pytest_collection_modifyitems(
     This function implements a standard pytest hook. Please refer to pytest
     docs for further information.
     """
+    # do not try to skip tests if a keyword or marker is specified
+    if config.getoption("-k") or config.getoption("-m"):
+        return
+
     skip_mark = pytest.mark.skip(reason="No changes to tested code")
     tests_to_skip = utils.determine_integration_tests_to_skip()
     for item in items:


### PR DESCRIPTION
When the -k option is used to select tests by keyword, the existing logic would still skip some tests. This prevents users from running specific tests that are normally skipped. The check ensures that test filtering is bypassed when a keyword is provided.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
