### PR TITLE
Handle missing copy_file_range attribute in os module

### DIFF
--- a/hermeto/core/utils.py
+++ b/hermeto/core/utils.py
@@ -136,9 +136,12 @@ def _fast_copy(src: Path, dest: Path, *, follow_symlinks: bool = True) -> int:
             raise _FastCopyFailedFallback()
 
         try:
-            # mypy: `os` module has no attribute "copy_file_range" on some platforms
             while nbytes := os.copy_file_range(srcfd, destfd, count=_get_blocksize(srcfd)):  # type: ignore
                 total += nbytes
+
+        # `os` module deos not have attribute `copy_file_range` on some platforms (see type ignore above)
+        except AttributeError:
+            raise _FastCopyFailedFallback()
 
         except OSError as ex:
             # ...in oder to have a more informative exception.


### PR DESCRIPTION
The `_fast_copy` function uses `os.copy_file_range` for efficient copying. However, this function is not available on all platforms such as macOS.

Previously, an uncaught AttributeError would crash the process when the function was missing. By catching AttributeError explicitly and raising _FastCopyFailedFallback, we trigger the existing fallback mechanism for unsupported platforms. This maintains cross-platform compatibility while preserving fast copy operations where supported.

Should be part of 14e1491.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
