### PR TITLE
models: sbom: Placate type checker

### DIFF
--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -90,9 +90,9 @@ class Component(pydantic.BaseModel):
         A package has extra fields which are unnecessary and can cause validation errors.
         """
         return cls(
-            name=package.get("name", None),
-            version=package.get("version", None),
-            purl=package.get("purl", None),
+            name=package.get("name", ""),
+            version=package.get("version"),
+            purl=package.get("purl", ""),
         )
 
 


### PR DESCRIPTION
'Argument of type "Any | None" cannot be assigned to parameter "purl" of type "str"'

was reported by pyright and rightfully so, our Component model mandates both name and purl to be defined. We even have a model correctness unit test specifcally covering this scenario, so it's impossible to get None here. We could access the dict directly, but let's be correct AND conservative at the same time and instead of None, let's use an empty string as a default.


Found during a random review round.
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
