### PR TITLE
Dockerfile: ship both cargo & rustc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,13 @@ FROM ubi as base
 RUN dnf -y install \
     --setopt install_weak_deps=0 \
     --nodocs \
+    cargo \
     git-core \
     jq \
     python3 \
     rubygem-bundler \
     rubygem-json \
+    rust \
     subscription-manager && \
     dnf clean all
 
@@ -27,8 +29,6 @@ RUN dnf -y install \
     --setopt install_weak_deps=0 \
     --nodocs \
     gcc \
-    # not a build dependency, but we copy the binary to the final image
-    cargo \
     python3-devel \
     python3-pip \
     python3-setuptools \
@@ -54,7 +54,6 @@ COPY --from=golang_120 /usr/local/go /usr/local/go/go1.20
 COPY --from=golang_121 /usr/local/go /usr/local/go/go1.21
 COPY --from=node /usr/local/lib/node_modules/corepack /usr/local/lib/corepack
 COPY --from=node /usr/local/bin/node /usr/local/bin/node
-COPY --from=builder /usr/bin/cargo /usr/bin/cargo
 COPY --from=builder /venv /venv
 
 # link corepack, yarn, and go to standard PATH location


### PR DESCRIPTION
The `cargo` executable alone may not be enough to resolve/check Rust dependencies. In some cases, it tries to run `rustc`, thus failing because it is missing in the container image.

To make sure that `cargo` can run properly all the time, install that and `rust` directly in the base image used for the final image, rather than copying the `cargo` executable from an helper image. This way not only `cargo` is available, a working `rustc` is too.

Resolves: https://github.com/hermetoproject/hermeto/issues/1061

Fixes commit 55c218dc529e99b284a66d04ef48aa56d3fcc4c0.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
