### PR TITLE
Revert "build(deps): bump backrefs from 5.9 to 6.0.1"

### DIFF
--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -131,14 +131,14 @@ backports-asyncio-runner==1.2.0 ; python_full_version < '3.11' \
     --hash=sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5 \
     --hash=sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162
     # via pytest-asyncio
-backrefs==6.0.1 \
-    --hash=sha256:2f440f79f5ef5b9083fd366a09a976690044eca0ea0e59ac0508c3630e0ebc7c \
-    --hash=sha256:3ba0d943178d24a3721c5d915734767fa93f3bde1d317c4ef9e0f33b21b9c302 \
-    --hash=sha256:54f8453c9ae38417a83c06d23745c634138c8da622d87a12cb3eef9ba66dd466 \
-    --hash=sha256:62ea7e9b286808576f35b2d28a0daa09b85ae2fc71b82a951d35729b0138e66b \
-    --hash=sha256:6ba76d616ccb02479a3a098ad1f46d92225f280d7bdce7583bc62897f32d946c \
-    --hash=sha256:78a69e21b71d739b625b52b5adbf7eb1716fb4cf0a39833826f59546f321cb99 \
-    --hash=sha256:b1a61b29c35cc72cfb54886164b626fbe64cab74e9d8dcac125155bd3acdb023
+backrefs==5.9 \
+    --hash=sha256:6907635edebbe9b2dc3de3a2befff44d74f30a4562adbb8b36f21252ea19c5cf \
+    --hash=sha256:7fdf9771f63e6028d7fee7e0c497c81abda597ea45d6b8f89e8ad76994f5befa \
+    --hash=sha256:808548cb708d66b82ee231f962cb36faaf4f2baab032f2fbb783e9c2fdddaa59 \
+    --hash=sha256:cc37b19fa219e93ff825ed1fed8879e47b4d89aa7a1884860e2db64ccd7c676b \
+    --hash=sha256:db8e8ba0e9de81fcd635f440deab5ae5f2591b54ac1ebe0550a2ca063488cd9f \
+    --hash=sha256:df5e169836cc8acb5e440ebae9aad4bf9d15e226d3bad049cf3f6a5c20cc8dc9 \
+    --hash=sha256:f48ee18f6252b8f5777a22a00a09a85de0ca931658f1dd96d4406a34f3748c60
     # via mkdocs-material
 bandit==1.8.6 \
     --hash=sha256:3348e934d736fcdb68b6aa4030487097e23a501adf3e7827b63658df464dddd0 \


### PR DESCRIPTION
This reverts commit e2ddf643dcb21cc75df0b638ffea73796dd9f212.

One can't even create a virtual environment due to:
    ERROR: Cannot install -r requirements-extras.txt (line 687) and
    backrefs==6.0.1 because these package versions have conflicting
    dependencies.

    The conflict is caused by:
        The user requested backrefs==6.0.1
        mkdocs-material 9.6.16 depends on backrefs~=5.7.post1

I don't really know how CI could *not* have caught this since we install to a virtual environment as part of it, so beats me why we were able to merge the change in the first place.