### PR TITLE
cli: do not error out on long fetch-deps inputs

### DIFF
--- a/hermeto/interface/cli.py
+++ b/hermeto/interface/cli.py
@@ -210,8 +210,11 @@ def _looks_like_json(value: str) -> bool:
 
 
 def _looks_like_input_file(value: str) -> bool:
-    path = Path(value)
-    return path.exists() and path.is_file()
+    try:
+        path = Path(value)
+        return path.exists() and path.is_file()
+    except OSError:
+        return False
 
 
 class _Input(pydantic.BaseModel, extra="forbid"):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -357,6 +357,34 @@ class TestFetchDeps:
                     {"type": "gomod", "path": "pkg_b"},
                 ],
             ),
+            pytest.param(
+                dedent(
+                    """
+                    [{"type": "rpm", "path": ".", "options": {"dnf": {
+                        "some-very-long-repo-id-aarch64-rpms": {"gpgcheck": 0},
+                        "some-very-long-repo-id-ppc64le-rpms": {"gpgcheck": 0},
+                        "some-very-long-repo-id-x86_64-rpms": {"gpgcheck": 0},
+                        "some-very-long-repo-id-s390x-rpms": {"gpgcheck": 0}
+                    }}}
+                    ]
+                    """
+                ),
+                [
+                    {
+                        "type": "rpm",
+                        "path": ".",
+                        "options": {
+                            "dnf": {
+                                "some-very-long-repo-id-aarch64-rpms": {"gpgcheck": 0},
+                                "some-very-long-repo-id-ppc64le-rpms": {"gpgcheck": 0},
+                                "some-very-long-repo-id-x86_64-rpms": {"gpgcheck": 0},
+                                "some-very-long-repo-id-s390x-rpms": {"gpgcheck": 0},
+                            }
+                        },
+                    }
+                ],
+                id="very-long-input-string",
+            ),
         ],
     )
     def test_specify_packages(


### PR DESCRIPTION
As a result of a recently introduced possibility to use a filename/path for the fetch-deps command, the input is first tried as filename, and in case it is not then it is loaded as JSON.

Now, in case the input string is very long, then stat'ing the string results in an OSError exception, which causes the whole application to stack trace. Instead, silently accept that failure and fallback to JSON as previously done.

Fixes commit 01140a3f034dabd5e97fac631a8f8ceaf0bd416d.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
