### PR TITLE
feat: build hermeto container for arm

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -19,6 +19,10 @@ spec:
       value: "quay.io/konflux-ci/pull-request-builds:hermeto-build-{{revision}}"
     - name: dockerfile
       value: Containerfile
+    - name: build-platforms
+      value:
+      - linux/x86_64
+      - linux/arm64
   pipelineRef:
     params:
       - name: bundle

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -20,6 +20,10 @@ spec:
       value: Containerfile
     - name: slack-webhook-notification-team
       value: build
+    - name: build-platforms
+      value:
+      - linux/x86_64
+      - linux/arm64
   pipelineRef:
     params:
       - name: bundle


### PR DESCRIPTION
In order to use hermeto from a Tekton task running on an ARM node, we need to build the container for that architecture.

Signed-off-by: arewm <arewm@users.noreply.github.com>

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

# Maintainers will complete the following section

- [x] Commit messages are descriptive enough
- [x] Code coverage from testing does not decrease and new code is covered
- [x] Docs updated (if applicable)
- [x] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
