### PR TITLE
models: Silence CodeQL complaints about missing @classmethod decorators

### DIFF
--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -134,6 +134,7 @@ class _PackageInputBase(pydantic.BaseModel, extra="forbid"):
     path: Path = Path(".")
 
     @pydantic.field_validator("path")
+    @classmethod
     def _path_is_relative(cls, path: Path) -> Path:
         return check_sane_relpath(path)
 
@@ -287,6 +288,7 @@ class PipPackageInput(_PackageInputBase):
     binary: Optional[PipBinaryFilters] = None
 
     @pydantic.field_validator("requirements_files", "requirements_build_files")
+    @classmethod
     def _no_explicit_none(cls, paths: Optional[list[Path]]) -> list[Path]:
         """Fail if the user explicitly passes None."""
         if paths is None:
@@ -295,6 +297,7 @@ class PipPackageInput(_PackageInputBase):
         return paths
 
     @pydantic.field_validator("requirements_files", "requirements_build_files")
+    @classmethod
     def _requirements_file_path_is_relative(cls, paths: list[Path]) -> list[Path]:
         for p in paths:
             check_sane_relpath(p)
@@ -322,6 +325,7 @@ class ExtraOptions(pydantic.BaseModel, extra="forbid"):
     ssl: Optional[SSLOptions] = None
 
     @pydantic.model_validator(mode="before")
+    @classmethod
     def _validate_dnf_options(cls, data: Any) -> Any:
         """DNF options model.
 
@@ -400,11 +404,13 @@ class Request(pydantic.BaseModel):
     mode: Mode = Mode.STRICT
 
     @pydantic.field_validator("packages")
+    @classmethod
     def _unique_packages(cls, packages: list[PackageInput]) -> list[PackageInput]:
         """De-duplicate the packages to be processed."""
         return unique(packages, by=lambda pkg: (pkg.type, pkg.path))
 
     @pydantic.field_validator("packages")
+    @classmethod
     def _check_packages_paths(
         cls, packages: list[PackageInput], info: pydantic.ValidationInfo
     ) -> list[PackageInput]:
@@ -428,6 +434,7 @@ class Request(pydantic.BaseModel):
         return packages
 
     @pydantic.field_validator("flags")
+    @classmethod
     def _deprecation_warning(cls, flags: frozenset[Flag]) -> frozenset[Flag]:
         """Print a deprecation warning for flags, if needed."""
         if "gomod-vendor" in flags:
@@ -447,6 +454,7 @@ class Request(pydantic.BaseModel):
         return flags
 
     @pydantic.field_validator("packages")
+    @classmethod
     def _packages_not_empty(cls, packages: list[PackageInput]) -> list[PackageInput]:
         """Check that the packages list is not empty."""
         if len(packages) == 0:

--- a/hermeto/core/models/output.py
+++ b/hermeto/core/models/output.py
@@ -136,11 +136,13 @@ class BuildConfig(pydantic.BaseModel):
     options: Optional[dict[str, Any]] = None
 
     @pydantic.field_validator("environment_variables")
+    @classmethod
     def _unique_env_vars(cls, env_vars: list[EnvironmentVariable]) -> list[EnvironmentVariable]:
         """Sort and de-duplicate environment variables by name."""
         return unique_sorted(env_vars, by=lambda env_var: env_var.name)
 
     @pydantic.field_validator("project_files")
+    @classmethod
     def _unique_project_files(cls, project_files: list[ProjectFile]) -> list[ProjectFile]:
         """Sort and de-duplicate project files by path."""
         return unique_sorted(project_files, by=lambda f: f.abspath)

--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -77,6 +77,7 @@ class Component(pydantic.BaseModel):
         return self.purl
 
     @pydantic.field_validator("properties")
+    @classmethod
     def _add_found_by_property(cls, properties: list[Property]) -> list[Property]:
         if FOUND_BY_APP_PROPERTY not in properties:
             properties.append(FOUND_BY_APP_PROPERTY)
@@ -155,6 +156,7 @@ class Sbom(pydantic.BaseModel):
             return self + other.to_cyclonedx()
 
     @pydantic.field_validator("components")
+    @classmethod
     def _unique_components(cls, components: list[Component]) -> list[Component]:
         """Sort and de-duplicate components."""
         return unique_sorted(components, by=lambda component: component.key())
@@ -391,6 +393,7 @@ class SPDXPackage(pydantic.BaseModel):
         return hashlib.sha256(json.dumps(package_dict, sort_keys=True).encode()).hexdigest()
 
     @pydantic.field_validator("externalRefs")
+    @classmethod
     def _purls_validation(
         cls, refs: list[SPDXPackageExternalRefType]
     ) -> list[SPDXPackageExternalRefType]:
@@ -539,6 +542,7 @@ class SPDXSbom(pydantic.BaseModel):
         return sorted(unique_items.values(), key=lambda item: (item.name, item.versionInfo or ""))
 
     @pydantic.field_validator("packages")
+    @classmethod
     def _unique_packages(cls, packages: list[SPDXPackage]) -> list[SPDXPackage]:
         """Sort and de-duplicate components."""
         return cls.deduplicate_spdx_packages(packages)

--- a/hermeto/core/package_managers/rpm/redhat.py
+++ b/hermeto/core/package_managers/rpm/redhat.py
@@ -69,6 +69,7 @@ class RedhatRpmsLock(BaseModel):
         return self.generated_repoid + "-source"
 
     @field_validator("lockfileVersion")
+    @classmethod
     def _version_redhat(cls, version: PositiveInt) -> PositiveInt:
         """Evaluate whether the lockfile header matches the format specification."""
         if version != 1:
@@ -76,6 +77,7 @@ class RedhatRpmsLock(BaseModel):
         return version
 
     @field_validator("lockfileVendor")
+    @classmethod
     def _vendor_redhat(cls, vendor: str) -> str:
         """Evaluate whether the lockfile header matches the format specification."""
         if vendor != "redhat":

--- a/hermeto/core/package_managers/yarn_classic/workspaces.py
+++ b/hermeto/core/package_managers/yarn_classic/workspaces.py
@@ -25,6 +25,7 @@ class Workspace(pydantic.BaseModel):
     package_json: PackageJson
 
     @pydantic.field_validator("package_json")
+    @classmethod
     def _ensure_package_is_named(cls, package_json: PackageJson) -> PackageJson:
         if "name" not in package_json.data:
             raise ValueError("Workspaces must contain 'name' field.")


### PR DESCRIPTION
CodeQL started to randomly complain that we use an unusual denominator 'cls' for model methods without being marked as classmethods explicitly. These complaints are annoying but the truth is we weren't exactly following Pydantic's official documentation where they declare validators like this in the examples [1]

[1] https://docs.pydantic.dev/latest/concepts/validators/

Resolves https://github.com/hermetoproject/hermeto/issues/1147