### PR TITLE
[CI] Drop the 'fetch-tags' checkout action argument

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-        with:
-          fetch-tags: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
When commit 005d7b83 added this setting it was based on a CodeRabbit AI review suggestion which appeared to make sense, however, in practice led to the following CI workflow failure:

    /usr/bin/git -c protocol.version=2 fetch --prune
    --no-recurse-submodules --depth=1 origin
    +b108bb4c2502d9179555be0db717766e5607e98c:refs/tags/0.41.0-alpha
    Error: fatal: Cannot fetch both
    b108bb4c2502d9179555be0db717766e5607e98c and refs/tags/0.41.0-alpha
    to refs/tags/0.41.0-alpha The process '/usr/bin/git' failed with
    exit code 128

Drop the argument, the CI action will checkout a specific ref which we tagged via the native GitHub release process.

For reference: https://github.com/hermetoproject/hermeto/actions/runs/18468902781/job/52617658988
With the argument dropped: https://github.com/eskultety/hermeto/actions/runs/18469261495
Container image version reporting:
```
$ podman run -it --entrypoint /bin/bash ghcr.io/eskultety/hermeto:latest
[root@9ce20dfa1392 /]# hermeto --version
hermeto 0.300.4
```