### PR TITLE
[gomod] Change the way we query git tags to favour <refspec> instead of `git fetch --tags`

### DIFF
--- a/hermeto/core/package_managers/gomod.py
+++ b/hermeto/core/package_managers/gomod.py
@@ -1312,7 +1312,10 @@ class ModuleVersionResolver:
         repo = git.Repo(repo_path)
         commit = repo.commit(repo.rev_parse("HEAD").hexsha)
         try:
-            repo.remote().fetch(force=True, tags=True)
+            # Do not run 'git fetch --tags' because that fetches pretty much everything from the
+            # remote. Save bandwidth and storage with an explicit refspec instead.
+            # See man 1 git-fetch for the authoritative answer.
+            repo.remote().fetch(refspec="+refs/tags/*:refs/tags/*", force=True)
         except Exception as ex:
             raise FetchError(
                 f"Failed to fetch the tags on the Git repository ({type(ex).__name__}) "


### PR DESCRIPTION
The commit message contains an extensive explanation of the matter. Unfortunately, the origin of this issue is private and originally pointed to a private repo resource. However, the experiments as noted in the commit message were conducted on publicly available resources.
Worth noting that I ran a test with our current image as well as one built off of this PR and
`diff -u <repo>/hermeto-old/bom.json <repo>/hermeto-new/bom.json` and it didn't return anything. 