### PR TITLE
feat(pkg_mgrs): allow non-git sources in permissive mode

### DIFF
--- a/hermeto/core/config.py
+++ b/hermeto/core/config.py
@@ -15,6 +15,7 @@ from pydantic_settings import (
 from typing_extensions import Self
 
 from hermeto import APP_NAME
+from hermeto.core.constants import Mode
 from hermeto.core.errors import InvalidInput
 
 # Ascending priority
@@ -182,6 +183,7 @@ class Config(BaseSettings):
     gomod: GomodSettings = GomodSettings()
     http: HttpSettings = HttpSettings()
     runtime: RuntimeSettings = RuntimeSettings()
+    mode: Mode = Mode.STRICT
 
     @model_validator(mode="before")
     @classmethod
@@ -309,7 +311,7 @@ def get_config() -> Config:
     return config
 
 
-def set_config(path: Path) -> None:
+def set_config(path: Path) -> Config:
     """Set global config variable using input from file."""
     global config
     # Validate beforehand for a friendlier error message: https://github.com/pydantic/pydantic-settings/pull/432
@@ -321,3 +323,4 @@ def set_config(path: Path) -> None:
     # Workaround for https://github.com/pydantic/pydantic-settings/issues/259
     cli_config_class = create_cli_config_class(path)
     config = cli_config_class()
+    return config

--- a/hermeto/core/constants.py
+++ b/hermeto/core/constants.py
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: GPL-3.0-only
+import enum
+
+
+class Mode(str, enum.Enum):
+    """Represents a global CLI option to relax input expectations and requirements checks."""
+
+    STRICT = "strict"
+    PERMISSIVE = "permissive"
+
+    def __str__(self) -> str:
+        return self.value

--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -9,7 +9,6 @@ import pydantic
 from typing_extensions import Self
 
 from hermeto import APP_NAME
-from hermeto.core.constants import Mode
 from hermeto.core.errors import InvalidInput
 from hermeto.core.models.validators import check_sane_relpath, unique
 from hermeto.core.rooted_path import PathOutsideRoot, RootedPath
@@ -420,7 +419,6 @@ class Request(pydantic.BaseModel):
     output_dir: RootedPath
     packages: list[PackageInput]
     flags: frozenset[Flag] = frozenset()
-    mode: Mode = Mode.STRICT
 
     @pydantic.field_validator("packages")
     @classmethod

--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-only
-import enum
 import logging
 import re
 from collections.abc import Callable
@@ -10,6 +9,7 @@ import pydantic
 from typing_extensions import Self
 
 from hermeto import APP_NAME
+from hermeto.core.constants import Mode
 from hermeto.core.errors import InvalidInput
 from hermeto.core.models.validators import check_sane_relpath, unique
 from hermeto.core.rooted_path import PathOutsideRoot, RootedPath
@@ -118,16 +118,6 @@ PackageManagerType = Literal[
 Flag = Literal[
     "cgo-disable", "dev-package-managers", "force-gomod-tidy", "gomod-vendor", "gomod-vendor-check"
 ]
-
-
-class Mode(str, enum.Enum):
-    """Represents a global CLI option to relax input expectations and requirements checks."""
-
-    STRICT = "strict"
-    PERMISSIVE = "permissive"
-
-    def __str__(self) -> str:
-        return self.value
 
 
 class _PackageInputBase(pydantic.BaseModel, extra="forbid"):

--- a/hermeto/core/package_managers/bundler/gem_models.py
+++ b/hermeto/core/package_managers/bundler/gem_models.py
@@ -9,9 +9,9 @@ import pydantic
 from packageurl import PackageURL
 from typing_extensions import Self
 
-from hermeto.core.package_managers.general import download_binary_file
+from hermeto.core.package_managers.general import download_binary_file, get_vcs_qualifiers
 from hermeto.core.rooted_path import PathOutsideRoot, RootedPath
-from hermeto.core.scm import GitRepo, get_repo_id
+from hermeto.core.scm import GitRepo
 
 AcceptedUrl = Annotated[
     pydantic.HttpUrl,
@@ -180,12 +180,11 @@ class PathDependency(_GemMetadata):
     @cached_property
     def purl(self) -> str:
         """Get PURL for this dependency."""
-        vcs_url = get_repo_id(self.root.path).as_vcs_url_qualifier()
         purl = PackageURL(
             type="gem",
             name=self.name,
             version=self.version,
-            qualifiers={"vcs_url": vcs_url},
+            qualifiers=get_vcs_qualifiers(self.root.path),
             subpath=self.subpath,
         )
         return purl.to_string()

--- a/hermeto/core/package_managers/bundler/gem_models.py
+++ b/hermeto/core/package_managers/bundler/gem_models.py
@@ -9,6 +9,9 @@ import pydantic
 from packageurl import PackageURL
 from typing_extensions import Self
 
+from hermeto.core.config import get_config
+from hermeto.core.constants import Mode
+from hermeto.core.errors import NotAGitRepo
 from hermeto.core.package_managers.general import download_binary_file, get_vcs_qualifiers
 from hermeto.core.rooted_path import PathOutsideRoot, RootedPath
 from hermeto.core.scm import GitRepo
@@ -180,11 +183,19 @@ class PathDependency(_GemMetadata):
     @cached_property
     def purl(self) -> str:
         """Get PURL for this dependency."""
+        try:
+            qualifiers = get_vcs_qualifiers(self.root.path)
+        except NotAGitRepo:
+            if get_config().mode == Mode.PERMISSIVE:
+                qualifiers = None
+            else:
+                raise
+
         purl = PackageURL(
             type="gem",
             name=self.name,
             version=self.version,
-            qualifiers=get_vcs_qualifiers(self.root.path),
+            qualifiers=qualifiers,
             subpath=self.subpath,
         )
         return purl.to_string()

--- a/hermeto/core/package_managers/bundler/main.py
+++ b/hermeto/core/package_managers/bundler/main.py
@@ -7,7 +7,9 @@ from textwrap import dedent
 from packageurl import PackageURL
 
 from hermeto import APP_NAME
-from hermeto.core.errors import PackageRejected, UnsupportedFeature
+from hermeto.core.config import get_config
+from hermeto.core.constants import Mode
+from hermeto.core.errors import NotAGitRepo, PackageRejected, UnsupportedFeature
 from hermeto.core.models.input import BundlerBinaryFilters, Request
 from hermeto.core.models.output import EnvironmentVariable, ProjectFile, RequestOutput
 from hermeto.core.models.property_semantics import PropertySet
@@ -19,6 +21,7 @@ from hermeto.core.package_managers.bundler.parser import (
     PathDependency,
     parse_lockfile,
 )
+from hermeto.core.package_managers.general import get_vcs_qualifiers
 from hermeto.core.rooted_path import RootedPath
 from hermeto.core.scm import get_repo_id
 
@@ -77,12 +80,18 @@ def _resolve_bundler_package(
     dependencies = parse_lockfile(package_dir, binary_filters)
 
     name, version = _get_main_package_name_and_version(package_dir, dependencies)
-    vcs_url = get_repo_id(package_dir.root).as_vcs_url_qualifier()
+    try:
+        qualifiers = get_vcs_qualifiers(package_dir.root)
+    except NotAGitRepo:
+        if get_config().mode == Mode.PERMISSIVE:
+            qualifiers = None
+        else:
+            raise
     main_package_purl = PackageURL(
         type="gem",
         name=name,
         version=version,
-        qualifiers={"vcs_url": vcs_url},
+        qualifiers=qualifiers,
         subpath=str(package_dir.subpath_from_root),
     )
 
@@ -158,9 +167,18 @@ def _get_name_and_version_from_lockfile(dependencies: ParseResult) -> tuple[str,
 
 def _get_repo_name_from_origin_remote(package_dir: RootedPath) -> str:
     """Extract repository name from git origin remote in the package directory."""
-    repo_path = get_repo_id(package_dir.root).parsed_origin_url.path
-    repo_name = Path(repo_path).stem
+    try:
+        repo_id = get_repo_id(package_dir.root)
+    except NotAGitRepo:
+        raise PackageRejected(
+            reason="Unable to infer package name from origin URL",
+            solution=(
+                "Provide valid metadata in the package files or ensure "
+                "the package files are in a git repository whose 'origin' remote has a valid URL."
+            ),
+        )
 
+    repo_name = Path(repo_id.parsed_origin_url.path).stem
     resolved_path = Path(repo_name).joinpath(package_dir.subpath_from_root)
     return str(resolved_path)
 

--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -138,7 +138,7 @@ def fetch_cargo_source(request: Request) -> RequestOutput:
 
     for package in request.cargo_packages:
         package_dir = request.source_dir.join_within_root(package.path)
-        _verify_lockfile_is_present(package_dir, request.mode)
+        _verify_lockfile_is_present(package_dir)
 
         vendor_result = _fetch_dependencies(package_dir, request)
         # cargo allows to specify configuration per-package
@@ -234,8 +234,9 @@ def _resolve_main_package(package_dir: RootedPath) -> tuple[str, str | None]:
     return name, version
 
 
-def _verify_lockfile_is_present(package_dir: RootedPath, mode: Mode) -> None:
+def _verify_lockfile_is_present(package_dir: RootedPath) -> None:
     """Verify that the Cargo.lock file is present in the package directory."""
+    mode = get_config().mode
     lockfile = package_dir.path / "Cargo.lock"
     if lockfile.exists():
         return

--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -15,6 +15,7 @@ import tomlkit.exceptions
 from packageurl import PackageURL
 
 from hermeto import APP_NAME
+from hermeto.core.constants import Mode
 from hermeto.core.errors import (
     LockfileNotFound,
     NotAGitRepo,
@@ -22,7 +23,7 @@ from hermeto.core.errors import (
     PackageRejected,
     UnexpectedFormat,
 )
-from hermeto.core.models.input import Mode, Request
+from hermeto.core.models.input import Request
 from hermeto.core.models.output import Annotation, Component, ProjectFile, RequestOutput
 from hermeto.core.models.sbom import create_backend_annotation, spdx_now
 from hermeto.core.rooted_path import RootedPath

--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -15,6 +15,7 @@ import tomlkit.exceptions
 from packageurl import PackageURL
 
 from hermeto import APP_NAME
+from hermeto.core.config import get_config
 from hermeto.core.constants import Mode
 from hermeto.core.errors import (
     LockfileNotFound,
@@ -147,7 +148,7 @@ def fetch_cargo_source(request: Request) -> RequestOutput:
                 vendor_result.config_template
             )
             project_files.append(_use_vendored_sources(package_dir, config_template))
-        package_components = _generate_sbom_components(package_dir)
+        package_components = _generate_sbom_components(package_dir, request)
 
         if vendor_result.lockfile_was_generated:
             _update_permissive_mode_annotation(annotations, package_components)
@@ -205,7 +206,6 @@ def _fetch_dependencies(package_dir: RootedPath, request: Request) -> CargoVendo
             cmd=cmd,
             params={"cwd": package_dir, "env": env},
             package_dir=package_dir.path,
-            mode=request.mode,
         )
 
 
@@ -345,7 +345,7 @@ def _temporary_cwd(path_to_new_cwd: Path) -> Generator[None, None, None]:
 
 
 def _run_cmd_watching_out_for_lock_mismatch(
-    cmd: list, params: dict, package_dir: Path, mode: Mode
+    cmd: list, params: dict, package_dir: Path
 ) -> CargoVendorResult:
     warn_about_imminent_update_to_cargo_lock = (
         f"A mismatch between Cargo.lock and Cargo.toml was detected in {package_dir}. "
@@ -354,6 +354,7 @@ def _run_cmd_watching_out_for_lock_mismatch(
         f"is a violation of reproducibility and must be addressed by {package_dir.name} "
         "maintainers."
     )
+    mode = get_config().mode
     update_cargo_lock_cmd = ["cargo", "generate-lockfile"]
     try:
         stdout = run_cmd(cmd=cmd, params=params, suppress_errors=(mode == Mode.PERMISSIVE))
@@ -414,7 +415,7 @@ def _find_local_packages(package_dir: RootedPath) -> dict[str, str]:
     return result
 
 
-def _generate_sbom_components(package_dir: RootedPath) -> list[Component]:
+def _generate_sbom_components(package_dir: RootedPath, request: Request) -> list[Component]:
     """Generate SBOM components from Cargo.lock and for the main package."""
     parsed_lockfile = _parse_toml_project_file(package_dir.path / "Cargo.lock")
 
@@ -422,11 +423,22 @@ def _generate_sbom_components(package_dir: RootedPath) -> list[Component]:
     local_packages = _find_local_packages(package_dir)
     main_package_name, main_package_version = _resolve_main_package(package_dir)
 
+    # When cargo is invoked from pip for extracted sdists, the source directory is
+    # swapped to point at the output directory. Check if source_dir is inside output_dir
+    # to detect this scenario, where we can't expect a git repository (and flip the boolean
+    # for readbility).
+    source_is_outside_output = not request.source_dir.path.is_relative_to(request.output_dir.path)
+
+    # Missing git repo is tolerated in two independent cases:
+    # 1. PERMISSIVE mode: validation is relaxed
+    # 2. Nested PM (pip->cargo for sdists): source_dir is inside output_dir,
+    #    so missing git is expected even in STRICT mode
+    vcs_url = None
     try:
         vcs_url = get_repo_id(package_dir.root).as_vcs_url_qualifier()
     except NotAGitRepo:
-        # Could become invalid when directories are swapped for nested package managers
-        vcs_url = None
+        if get_config().mode != Mode.PERMISSIVE and source_is_outside_output:
+            raise
 
     components = []
 

--- a/hermeto/core/package_managers/general.py
+++ b/hermeto/core/package_managers/general.py
@@ -18,6 +18,7 @@ from hermeto.core.http_requests import (
     SAFE_REQUEST_METHODS,
     get_requests_session,
 )
+from hermeto.core.scm import get_repo_id
 from hermeto.core.type_aliases import StrPath
 
 pkg_requests_session = get_requests_session(retry_options={"allowed_methods": SAFE_REQUEST_METHODS})
@@ -176,6 +177,17 @@ async def async_download_files(
             )
 
         await asyncio.gather(*tasks)
+
+
+def get_vcs_qualifiers(path_root: StrPath) -> dict[str, str]:
+    """Return vcs_url qualifiers dict for the git repository at path_root.
+
+    :param path_root: Root path of the git repository
+    :return: Dictionary containing vcs_url qualifier
+    """
+    repo_id = get_repo_id(path_root)
+    vcs_url = repo_id.as_vcs_url_qualifier()
+    return {"vcs_url": vcs_url}
 
 
 def extract_git_info(vcs_url: str) -> dict[str, Any]:

--- a/hermeto/core/package_managers/gomod/go.py
+++ b/hermeto/core/package_managers/gomod/go.py
@@ -19,8 +19,8 @@ from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_ex
 
 from hermeto import APP_NAME
 from hermeto.core.config import get_config
+from hermeto.core.constants import Mode
 from hermeto.core.errors import PackageManagerError
-from hermeto.core.models.input import Mode
 from hermeto.core.rooted_path import RootedPath
 from hermeto.core.utils import get_cache_dir, run_cmd
 from hermeto.interface.logging import EnforcingModeLoggerAdapter

--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -17,6 +17,7 @@ import semver
 from packageurl import PackageURL
 
 from hermeto import APP_NAME
+from hermeto.core.constants import Mode
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -26,11 +27,12 @@ from hermeto.core.errors import (
     FetchError,
     GitError,
     LockfileNotFound,
+    NotAGitRepo,
     PackageManagerError,
     PackageRejected,
     UnexpectedFormat,
 )
-from hermeto.core.models.input import Mode, Request
+from hermeto.core.models.input import Request
 from hermeto.core.models.output import EnvironmentVariable, RequestOutput
 from hermeto.core.models.property_semantics import PropertySet
 from hermeto.core.models.sbom import (
@@ -435,7 +437,13 @@ def fetch_gomod_source(request: Request) -> RequestOutput:
     annotations: list[Annotation] = []
 
     repo_name = _get_repository_name(request.source_dir)
-    version_resolver = ModuleVersionResolver.from_repo_path(request.source_dir)
+    try:
+        version_resolver = ModuleVersionResolver.from_repo_path(request.source_dir)
+    except NotAGitRepo:
+        if get_config().mode == Mode.PERMISSIVE:
+            version_resolver = ModuleVersionResolver.from_non_git_source()
+        else:
+            raise
 
     gomod_download_dir = request.output_dir.join_within_root("deps/gomod/pkg/mod/cache/download")
     gomod_download_dir.path.mkdir(exist_ok=True, parents=True)
@@ -465,8 +473,14 @@ def fetch_gomod_source(request: Request) -> RequestOutput:
                 log.error("Failed to fetch gomod dependencies")
                 raise
 
-            vendor_changed = _vendor_changed(main_module_dir, request.mode)
-            if vendor_changed and request.mode == Mode.STRICT:
+            try:
+                vendor_changed = _vendor_changed(main_module_dir)
+            except NotAGitRepo:
+                if get_config().mode == Mode.PERMISSIVE:
+                    vendor_changed = False
+                else:
+                    raise
+            if vendor_changed and get_config().mode != Mode.PERMISSIVE:
                 raise PackageRejected(
                     reason=(
                         "The content of the vendor directory is not consistent with go.mod. "
@@ -539,11 +553,14 @@ def fetch_gomod_source(request: Request) -> RequestOutput:
 
 
 def _create_main_module_from_parsed_data(
-    main_module_dir: RootedPath, repo_name: str, parsed_main_module: ParsedModule
+    main_module_dir: RootedPath, repo_name: str | None, parsed_main_module: ParsedModule
 ) -> Module:
     resolved_subpath = main_module_dir.subpath_from_root
 
-    if str(resolved_subpath) == ".":
+    if repo_name is None:
+        # PERMISSIVE mode without git repo - use the module path as resolved_path
+        resolved_path = parsed_main_module.path
+    elif str(resolved_subpath) == ".":
         resolved_path = repo_name
     else:
         resolved_path = f"{repo_name}/{resolved_subpath}"
@@ -560,12 +577,18 @@ def _create_main_module_from_parsed_data(
     )
 
 
-def _get_repository_name(source_dir: RootedPath) -> str:
+def _get_repository_name(source_dir: RootedPath) -> str | None:
     """Return the name resolved from the Git origin URL.
 
     The name is a treated form of the URL, after stripping the scheme, user and .git extension.
     """
-    url = get_repo_id(source_dir).parsed_origin_url
+    try:
+        repo_id = get_repo_id(source_dir)
+    except NotAGitRepo:
+        if get_config().mode == Mode.PERMISSIVE:
+            return None
+        raise
+    url = repo_id.parsed_origin_url
     return f"{url.hostname}{url.path.rstrip('/').removesuffix('.git')}"
 
 
@@ -949,6 +972,8 @@ class GoCacheTemporaryDirectory(tempfile.TemporaryDirectory):
 class ModuleVersionResolver:
     """Resolves the versions of Go modules in a git repository."""
 
+    _DUMMY_PSEUDO_VERSION = "v0.0.0-19700101000000-000000000000"
+
     def __init__(self, repo: GitRepo, commit: git.objects.commit.Commit):
         """Initialize a ModuleVersionResolver for the provided Repo."""
         self._repo = repo
@@ -972,6 +997,14 @@ class ModuleVersionResolver:
             )
 
         return cls(repo, commit)
+
+    @classmethod
+    def from_non_git_source(cls) -> "Self":
+        """Return a resolver for non-git sources that produces a dummy pseudo-version."""
+        resolver = cls.__new__(cls)
+        resolver._repo = None  # type: ignore[assignment]
+        resolver._commit = None  # type: ignore[assignment]
+        return resolver
 
     @cached_property
     def _commit_tags(self) -> list[str]:
@@ -1044,6 +1077,9 @@ class ModuleVersionResolver:
         :param app_dir: the path to the module directory
         :return: a version as `go list` would provide
         """
+        if self._repo is None or self._commit is None:
+            return self._DUMMY_PSEUDO_VERSION
+
         # If the module is version v2 or higher, the major version of the module is included as /vN at
         # the end of the module path. If the module is version v0 or v1, the major version is omitted
         # from the module path.
@@ -1337,12 +1373,13 @@ def _vendor_deps(
     return _parse_vendor(context_dir)
 
 
-def _vendor_changed(context_dir: RootedPath, enforcing_mode: Mode) -> bool:
+def _vendor_changed(context_dir: RootedPath) -> bool:
     """Check for changes in the vendor directory.
 
     :param context_dir: main module dir OR workspace context (directory containing go.work)
     """
     repo_root = context_dir.root
+    enforcing_mode = get_config().mode
 
     # Get the correct repo context (main or submodule)
     repo, context_relative_path = get_repo_for_path(repo_root, context_dir.path)

--- a/hermeto/core/package_managers/npm/project.py
+++ b/hermeto/core/package_managers/npm/project.py
@@ -10,7 +10,13 @@ from packageurl import PackageURL
 
 from hermeto.core.checksum import ChecksumInfo
 from hermeto.core.config import get_config
-from hermeto.core.errors import InvalidLockfileFormat, UnexpectedFormat, UnsupportedFeature
+from hermeto.core.constants import Mode
+from hermeto.core.errors import (
+    InvalidLockfileFormat,
+    NotAGitRepo,
+    UnexpectedFormat,
+    UnsupportedFeature,
+)
 from hermeto.core.models.output import ProjectFile
 from hermeto.core.models.sbom import PROXY_COMMENT, PROXY_REF_TYPE, ExternalReference
 from hermeto.core.package_managers.npm.utils import (
@@ -312,8 +318,13 @@ class _Purlifier:
         self._pkg_path = pkg_path
 
     @cached_property
-    def _repo_id(self) -> RepoID:
-        return get_repo_id(self._pkg_path.root)
+    def _repo_id(self) -> RepoID | None:
+        try:
+            return get_repo_id(self._pkg_path.root)
+        except NotAGitRepo:
+            if get_config().mode == Mode.PERMISSIVE:
+                return None
+            raise
 
     def get_purl(
         self,
@@ -344,7 +355,8 @@ class _Purlifier:
             repo_id = RepoID(origin_url=info["url"], commit_id=info["ref"])
             qualifiers = {"vcs_url": repo_id.as_vcs_url_qualifier()}
         elif dep_type == "file":
-            qualifiers = {"vcs_url": self._repo_id.as_vcs_url_qualifier()}
+            if self._repo_id is not None:
+                qualifiers = {"vcs_url": self._repo_id.as_vcs_url_qualifier()}
             path = urlparse(resolved_url).path
             subpath_from_root = self._pkg_path.join_within_root(path).subpath_from_root
             if subpath_from_root != Path():

--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -23,6 +23,7 @@ from hermeto.core.package_managers.general import (
     async_download_files,
     download_binary_file,
     extract_git_info,
+    get_vcs_qualifiers,
 )
 from hermeto.core.package_managers.pip.package_distributions import (
     DistributionPackageInfo,
@@ -129,8 +130,6 @@ def _generate_purl_main_package(package: dict[str, Any], package_path: RootedPat
     type = "pypi"
     name = package["name"]
     version = package["version"]
-    url = get_repo_id(package_path.root).as_vcs_url_qualifier()
-    qualifiers = {"vcs_url": url}
     if package_path.subpath_from_root != Path("."):
         subpath = package_path.subpath_from_root.as_posix()
     else:
@@ -140,7 +139,7 @@ def _generate_purl_main_package(package: dict[str, Any], package_path: RootedPat
         type=type,
         name=name,
         version=version,
-        qualifiers=qualifiers,
+        qualifiers=get_vcs_qualifiers(package_path.root),
         subpath=subpath,
     )
 

--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -14,7 +14,8 @@ from packaging.utils import canonicalize_name
 
 from hermeto.core.checksum import ChecksumInfo, must_match_any_checksum
 from hermeto.core.config import get_config
-from hermeto.core.errors import LockfileNotFound, PackageRejected, UnsupportedFeature
+from hermeto.core.constants import Mode
+from hermeto.core.errors import LockfileNotFound, NotAGitRepo, PackageRejected, UnsupportedFeature
 from hermeto.core.models.input import PipBinaryFilters, Request
 from hermeto.core.models.output import EnvironmentVariable, ProjectFile, RequestOutput
 from hermeto.core.models.property_semantics import PropertySet
@@ -130,6 +131,14 @@ def _generate_purl_main_package(package: dict[str, Any], package_path: RootedPat
     type = "pypi"
     name = package["name"]
     version = package["version"]
+    try:
+        qualifiers = get_vcs_qualifiers(package_path.root)
+    except NotAGitRepo:
+        if get_config().mode == Mode.PERMISSIVE:
+            qualifiers = None
+        else:
+            raise
+
     if package_path.subpath_from_root != Path("."):
         subpath = package_path.subpath_from_root.as_posix()
     else:
@@ -139,7 +148,7 @@ def _generate_purl_main_package(package: dict[str, Any], package_path: RootedPat
         type=type,
         name=name,
         version=version,
-        qualifiers=get_vcs_qualifiers(package_path.root),
+        qualifiers=qualifiers,
         subpath=subpath,
     )
 
@@ -180,11 +189,19 @@ def _generate_purl_dependency(package: dict[str, Any]) -> str:
 def _infer_package_name_from_origin_url(package_dir: RootedPath) -> str:
     try:
         repo_id = get_repo_id(package_dir.root)
+    except NotAGitRepo:
+        raise PackageRejected(
+            reason="Unable to infer package name from origin URL",
+            solution=(
+                "Provide valid metadata in the package files or ensure "
+                "the package files are in a git repository whose 'origin' remote has a valid URL."
+            ),
+        )
     except UnsupportedFeature:
         raise PackageRejected(
             reason="Unable to infer package name from origin URL",
             solution=(
-                "Provide valid metadata in the package files or ensure"
+                "Provide valid metadata in the package files or ensure "
                 "the git repository has an 'origin' remote with a valid URL."
             ),
         )

--- a/hermeto/core/package_managers/yarn/resolver.py
+++ b/hermeto/core/package_managers/yarn/resolver.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-only
-
 """
 Resolve the dependency list for a yarn project.
 
@@ -335,7 +334,7 @@ class _ComponentResolver:
             try:
                 qualifiers.update(get_vcs_qualifiers(project_path.root))
             except NotAGitRepo:
-                if get_config().mode == Mode.STRICT:
+                if get_config().mode != Mode.PERMISSIVE:
                     raise
             subpath = str(workspace_path)
 
@@ -349,7 +348,7 @@ class _ComponentResolver:
             try:
                 qualifiers.update(get_vcs_qualifiers(project_path.root))
             except NotAGitRepo:
-                if get_config().mode == Mode.STRICT:
+                if get_config().mode != Mode.PERMISSIVE:
                     raise
             subpath = str(normalized.subpath_from_root)
 

--- a/hermeto/core/package_managers/yarn/resolver.py
+++ b/hermeto/core/package_managers/yarn/resolver.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-only
+
 """
 Resolve the dependency list for a yarn project.
 
@@ -25,7 +26,9 @@ from semver import Version
 
 from hermeto import APP_NAME
 from hermeto.core.config import get_config
+from hermeto.core.constants import Mode
 from hermeto.core.errors import (
+    NotAGitRepo,
     PackageManagerError,
     PackageRejected,
     UnsupportedFeature,
@@ -39,6 +42,7 @@ from hermeto.core.models.sbom import (
     PatchDiff,
     Pedigree,
 )
+from hermeto.core.package_managers.general import get_vcs_qualifiers
 from hermeto.core.package_managers.yarn.locators import (
     FileLocator,
     HttpsLocator,
@@ -328,9 +332,11 @@ class _ComponentResolver:
             project_path = project.source_dir
             workspace_path = package.locator.relpath
 
-            repo = get_repo_id(project_path.root)
-
-            qualifiers["vcs_url"] = repo.as_vcs_url_qualifier()
+            try:
+                qualifiers.update(get_vcs_qualifiers(project_path.root))
+            except NotAGitRepo:
+                if get_config().mode == Mode.STRICT:
+                    raise
             subpath = str(workspace_path)
 
         elif isinstance(package.locator, (FileLocator, LinkLocator, PortalLocator)):
@@ -340,8 +346,11 @@ class _ComponentResolver:
 
             normalized = project_path.join_within_root(workspace_path, package_path)
 
-            repo = get_repo_id(project_path.root)
-            qualifiers["vcs_url"] = repo.as_vcs_url_qualifier()
+            try:
+                qualifiers.update(get_vcs_qualifiers(project_path.root))
+            except NotAGitRepo:
+                if get_config().mode == Mode.STRICT:
+                    raise
             subpath = str(normalized.subpath_from_root)
 
         elif isinstance(package.locator, PatchLocator):
@@ -497,7 +506,13 @@ class _ComponentResolver:
             normalized = pp_join(workspace_path, patch_path)
 
         subpath_from_root = str(normalized.subpath_from_root)
-        repo_url = get_repo_id(pp_root).as_vcs_url_qualifier()
+        try:
+            repo_url = get_repo_id(pp_root).as_vcs_url_qualifier()
+        except NotAGitRepo:
+            raise PackageRejected(
+                "Patches *require* git repository context (regardless of mode)",
+                solution="Process from a git repository or avoid using patches in permissive mode",
+            )
         return f"{repo_url}#{subpath_from_root}"
 
     def _get_builtin_patch_url(self, patch: str, yarn_version: Version) -> str:

--- a/hermeto/core/package_managers/yarn_classic/resolver.py
+++ b/hermeto/core/package_managers/yarn_classic/resolver.py
@@ -14,7 +14,10 @@ from pyarn.lockfile import Package as PYarnPackage
 
 from hermeto import APP_NAME
 from hermeto.core.checksum import ChecksumInfo
-from hermeto.core.errors import PackageRejected, UnexpectedFormat
+from hermeto.core.config import get_config
+from hermeto.core.constants import Mode
+from hermeto.core.errors import NotAGitRepo, PackageRejected, UnexpectedFormat
+from hermeto.core.package_managers.general import get_vcs_qualifiers
 from hermeto.core.package_managers.npm import NPM_REGISTRY_CNAMES
 from hermeto.core.package_managers.yarn_classic.project import PackageJson, Project, YarnLock
 from hermeto.core.package_managers.yarn_classic.utils import (
@@ -27,7 +30,6 @@ from hermeto.core.package_managers.yarn_classic.workspaces import (
     extract_workspace_metadata,
 )
 from hermeto.core.rooted_path import RootedPath
-from hermeto.core.scm import get_repo_id
 
 # https://github.com/yarnpkg/yarn/blob/7cafa512a777048ce0b666080a24e80aae3d66a9/src/resolvers/exotics/git-resolver.js#L15-L17
 GIT_HOSTS = frozenset(("github.com", "gitlab.com", "bitbucket.com", "bitbucket.org"))
@@ -65,6 +67,43 @@ class _UrlMixin:
 @dataclass
 class _PathMixin:
     path: RootedPath
+
+
+class _PathPackage(_BasePackage, _PathMixin):
+    def _get_vcs_qualifiers(self) -> dict[str, str] | None:
+        """Return vcs_url qualifiers dict if repo ID is available, else None."""
+        try:
+            return get_vcs_qualifiers(self.path.root)
+        except NotAGitRepo:
+            if get_config().mode == Mode.STRICT:
+                raise
+            return None
+
+    @property
+    def purl(self) -> str:
+        """Return package URL."""
+        return PackageURL(
+            type="npm",
+            name=self.name,
+            version=self.version,
+            qualifiers=self._get_vcs_qualifiers(),
+            subpath=str(self.path.subpath_from_root),
+        ).to_string()
+
+
+@dataclass
+class FilePackage(_PathPackage):
+    """A Yarn 1.x package from a local file path."""
+
+
+@dataclass
+class WorkspacePackage(_PathPackage):
+    """A Yarn 1.x local workspace package."""
+
+
+@dataclass
+class LinkPackage(_PathPackage):
+    """A Yarn 1.x local link package."""
 
 
 @dataclass
@@ -122,60 +161,6 @@ class UrlPackage(_BasePackage, _UrlMixin):
             name=self.name,
             version=self.version,
             qualifiers=qualifiers,
-        ).to_string()
-
-
-@dataclass
-class FilePackage(_BasePackage, _PathMixin):
-    """A Yarn 1.x package from a local file path."""
-
-    @property
-    def purl(self) -> str:
-        """Return package URL."""
-        repo_id = get_repo_id(self.path.root)
-        qualifiers = {"vcs_url": repo_id.as_vcs_url_qualifier()}
-        return PackageURL(
-            type="npm",
-            name=self.name,
-            version=self.version,
-            qualifiers=qualifiers,
-            subpath=str(self.path.subpath_from_root),
-        ).to_string()
-
-
-@dataclass
-class WorkspacePackage(_BasePackage, _PathMixin):
-    """A Yarn 1.x local workspace package."""
-
-    @property
-    def purl(self) -> str:
-        """Return package URL."""
-        repo_id = get_repo_id(self.path.root)
-        qualifiers = {"vcs_url": repo_id.as_vcs_url_qualifier()}
-        return PackageURL(
-            type="npm",
-            name=self.name,
-            version=self.version,
-            qualifiers=qualifiers,
-            subpath=str(self.path.subpath_from_root),
-        ).to_string()
-
-
-@dataclass
-class LinkPackage(_BasePackage, _PathMixin):
-    """A Yarn 1.x local link package."""
-
-    @property
-    def purl(self) -> str:
-        """Return package URL."""
-        repo_id = get_repo_id(self.path.root)
-        qualifiers = {"vcs_url": repo_id.as_vcs_url_qualifier()}
-        return PackageURL(
-            type="npm",
-            name=self.name,
-            version=self.version,
-            qualifiers=qualifiers,
-            subpath=str(self.path.subpath_from_root),
         ).to_string()
 
 

--- a/hermeto/core/package_managers/yarn_classic/resolver.py
+++ b/hermeto/core/package_managers/yarn_classic/resolver.py
@@ -73,11 +73,13 @@ class _PathPackage(_BasePackage, _PathMixin):
     def _get_vcs_qualifiers(self) -> dict[str, str] | None:
         """Return vcs_url qualifiers dict if repo ID is available, else None."""
         try:
-            return get_vcs_qualifiers(self.path.root)
+            qualifiers = get_vcs_qualifiers(self.path.root)
         except NotAGitRepo:
-            if get_config().mode == Mode.STRICT:
+            if get_config().mode == Mode.PERMISSIVE:
+                qualifiers = None
+            else:
                 raise
-            return None
+        return qualifiers
 
     @property
     def purl(self) -> str:

--- a/hermeto/interface/cli.py
+++ b/hermeto/interface/cli.py
@@ -14,10 +14,11 @@ import pydantic
 import typer
 
 from hermeto import APP_NAME
-from hermeto.core.config import set_config
+from hermeto.core.config import get_config, set_config
+from hermeto.core.constants import Mode
 from hermeto.core.errors import BaseError, InvalidInput, UnexpectedFormat
 from hermeto.core.extras.envfile import EnvFormat, generate_envfile
-from hermeto.core.models.input import Flag, Mode, PackageInput, Request, parse_user_input
+from hermeto.core.models.input import Flag, PackageInput, Request, parse_user_input
 from hermeto.core.models.output import BuildConfig
 from hermeto.core.models.sbom import Sbom, SPDXSbom, spdx_now
 from hermeto.core.resolver import (
@@ -191,7 +192,11 @@ def main(  # noqa: D103 -- docstring becomes part of --help message
 ) -> None:
     setup_logging(log_level)
     if config_file:
-        set_config(config_file)
+        config = set_config(config_file)
+    else:
+        config = get_config()
+    # Typer ensures `mode` is already a valid Mode enum value
+    config.mode = mode
 
 
 def _if_json_then_validate(value: str) -> str:

--- a/hermeto/interface/cli.py
+++ b/hermeto/interface/cli.py
@@ -351,7 +351,6 @@ def fetch_deps(  # noqa: D103 -- docstring becomes part of --help message
 
     input = parse_user_input(_Input.model_validate, normalize_input())
 
-    mode = ctx.parent.params.get("mode")  # type: ignore[union-attr]
     request = parse_user_input(
         Request.model_validate,
         {
@@ -359,7 +358,6 @@ def fetch_deps(  # noqa: D103 -- docstring becomes part of --help message
             "output_dir": output,
             "packages": input.packages,
             "flags": combine_option_and_json_flags(input.flags),
-            "mode": mode,
         },
     )
 

--- a/hermeto/interface/cli.py
+++ b/hermeto/interface/cli.py
@@ -160,7 +160,7 @@ def version_callback(value: bool) -> None:
 
 @app.callback()
 @handle_errors
-def main(  # noqa: D103 docstring becomes part of --help message
+def main(  # noqa: D103 -- docstring becomes part of --help message
     version: bool = typer.Option(  # noqa: ARG001
         False,
         "--version",
@@ -242,8 +242,8 @@ def list_backends() -> None:
 
 @app.command(help=FETCH_DEPS_HELP)
 @handle_errors
-def fetch_deps(  # noqa: D103; docstring becomes part of --help message
-    ctx: typer.Context,
+def fetch_deps(  # noqa: D103 -- docstring becomes part of --help message
+    ctx: typer.Context,  # noqa: ARG001
     raw_input: str = typer.Argument(
         ...,
         help="Specify JSON input or path to JSON input file to process. See usage examples.",
@@ -476,7 +476,7 @@ def _prevalidate_sbom_files_args(sbom_files_to_merge: Paths) -> Paths:
 
 @app.command(help=MERGE_SBOMS_HELP)
 @handle_errors
-def merge_sboms(  # noqa: D103; docstring becomes part of --help message
+def merge_sboms(  # noqa: D103 -- docstring becomes part of --help message
     sbom_files_to_merge: Paths = typer.Argument(
         ...,
         callback=_prevalidate_sbom_files_args,

--- a/hermeto/interface/logging.py
+++ b/hermeto/interface/logging.py
@@ -4,7 +4,7 @@ import logging
 from collections.abc import Iterable
 from typing import Any
 
-from hermeto.core.models.input import Mode
+from hermeto.core.constants import Mode
 
 LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
 

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -13,7 +13,6 @@ from hermeto.core.models.input import (
     BundlerBinaryFilters,
     BundlerPackageInput,
     GomodPackageInput,
-    Mode,
     NpmPackageInput,
     PackageInput,
     PipBinaryFilters,
@@ -412,7 +411,6 @@ class TestRequest:
                 },
             ],
             "flags": frozenset(),
-            "mode": Mode.STRICT,
         }
         assert isinstance(request.source_dir, RootedPath)
         assert isinstance(request.output_dir, RootedPath)

--- a/tests/unit/package_managers/cargo/test_main.py
+++ b/tests/unit/package_managers/cargo/test_main.py
@@ -1,13 +1,18 @@
 # SPDX-License-Identifier: GPL-3.0-only
 import textwrap
+from pathlib import Path
 from typing import Any
+from unittest import mock
 
 import pytest
 import tomlkit
 
-from hermeto.core.errors import UnexpectedFormat
+from hermeto.core.constants import Mode
+from hermeto.core.errors import NotAGitRepo, UnexpectedFormat
+from hermeto.core.models.input import Request
 from hermeto.core.package_managers.cargo.main import (
     CargoPackage,
+    _generate_sbom_components,
     _resolve_main_package,
     _sanitize_cargo_config,
     _use_vendored_sources,
@@ -17,6 +22,10 @@ from hermeto.core.rooted_path import RootedPath
 
 def write_cargo_toml(rooted_path: RootedPath, content: str) -> None:
     (rooted_path.path / "Cargo.toml").write_text(content)
+
+
+def write_cargo_lock(rooted_path: RootedPath, content: str) -> None:
+    (rooted_path.path / "Cargo.lock").write_text(content)
 
 
 def test_standard_package_with_name_and_version(rooted_tmp_path: RootedPath) -> None:
@@ -284,3 +293,131 @@ def test_use_vendored_sources(
 
     assert result_toml["source"]["crates-io"]["replace-with"] == "vendored-sources"
     assert result_toml["source"]["vendored-sources"]["directory"] == "${output_dir}/deps/cargo"
+
+
+_MINIMAL_CARGO_TOML = """[package]
+name = "my-crate"
+version = "0.1.0"
+"""
+
+_MINIMAL_CARGO_LOCK = """version = 3
+
+[[package]]
+name = "my-crate"
+version = "0.1.0"
+"""
+
+
+def _make_request(source_dir: Path, output_dir: Path) -> Request:
+    """Build a minimal cargo Request for the given directories."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    return Request(
+        source_dir=source_dir,
+        output_dir=output_dir,
+        packages=[{"type": "cargo", "path": "."}],
+    )
+
+
+@mock.patch("hermeto.core.package_managers.cargo.main.get_config")
+@mock.patch("hermeto.core.package_managers.cargo.main.get_repo_id")
+def test_generate_sbom_components_permissive_no_git_vcs_url_is_none(
+    mock_get_repo_id: mock.Mock,
+    mock_get_config: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    """PERMISSIVE mode + NotAGitRepo: no exception raised and vcs_url absent from PURL."""
+    mock_get_config.return_value.mode = Mode.PERMISSIVE
+    mock_get_repo_id.side_effect = NotAGitRepo("not a git repo", solution=None)
+
+    write_cargo_toml(rooted_tmp_path, _MINIMAL_CARGO_TOML)
+    write_cargo_lock(rooted_tmp_path, _MINIMAL_CARGO_LOCK)
+
+    output_dir = rooted_tmp_path.path / "output"
+    request = _make_request(rooted_tmp_path.path, output_dir)
+
+    # Must not raise; vcs_url should be absent from the component PURL
+    components = _generate_sbom_components(rooted_tmp_path, request)
+
+    assert len(components) == 1
+    assert "vcs_url" not in components[0].purl
+
+
+@mock.patch("hermeto.core.package_managers.cargo.main.get_config")
+@mock.patch("hermeto.core.package_managers.cargo.main.get_repo_id")
+def test_generate_sbom_components_permissive_with_git_vcs_url_populated(
+    mock_get_repo_id: mock.Mock,
+    mock_get_config: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    """PERMISSIVE mode + git repo present: vcs_url is populated in the component PURL."""
+    mock_get_config.return_value.mode = Mode.PERMISSIVE
+    fake_vcs_url = "git+https://github.com/example/my-crate@abc1234"
+    mock_get_repo_id.return_value.as_vcs_url_qualifier.return_value = fake_vcs_url
+
+    write_cargo_toml(rooted_tmp_path, _MINIMAL_CARGO_TOML)
+    write_cargo_lock(rooted_tmp_path, _MINIMAL_CARGO_LOCK)
+
+    output_dir = rooted_tmp_path.path / "output"
+    request = _make_request(rooted_tmp_path.path, output_dir)
+
+    components = _generate_sbom_components(rooted_tmp_path, request)
+
+    assert len(components) == 1
+    # The PURL serializer percent-encodes the vcs_url value; just verify the qualifier key is present.
+    assert "vcs_url=" in components[0].purl
+
+
+@mock.patch("hermeto.core.package_managers.cargo.main.get_config")
+@mock.patch("hermeto.core.package_managers.cargo.main.get_repo_id")
+def test_generate_sbom_components_strict_source_inside_output_no_git_no_raise(
+    mock_get_repo_id: mock.Mock,
+    mock_get_config: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    """STRICT mode + source_dir inside output_dir + NotAGitRepo: short-circuit suppresses error."""
+    mock_get_config.return_value.mode = Mode.STRICT
+    mock_get_repo_id.side_effect = NotAGitRepo("not a git repo", solution=None)
+
+    # Place cargo files inside a subdirectory of the output dir to trigger the short-circuit.
+    output_dir = rooted_tmp_path.path / "output"
+    package_dir_path = output_dir / "src"
+    package_dir_path.mkdir(parents=True)
+    package_dir = RootedPath(package_dir_path)
+
+    write_cargo_toml(package_dir, _MINIMAL_CARGO_TOML)
+    write_cargo_lock(package_dir, _MINIMAL_CARGO_LOCK)
+
+    # source_dir IS inside output_dir -- the pip->cargo sdist scenario
+    request = Request(
+        source_dir=package_dir_path,
+        output_dir=output_dir,
+        packages=[{"type": "cargo", "path": "."}],
+    )
+
+    # Must not raise even though mode is STRICT
+    components = _generate_sbom_components(package_dir, request)
+
+    assert len(components) == 1
+    assert "vcs_url" not in components[0].purl
+
+
+@mock.patch("hermeto.core.package_managers.cargo.main.get_config")
+@mock.patch("hermeto.core.package_managers.cargo.main.get_repo_id")
+def test_generate_sbom_components_strict_mode_raises_without_git_repo(
+    mock_get_repo_id: mock.Mock,
+    mock_get_config: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    """STRICT mode + NotAGitRepo + source NOT inside output_dir: exception propagates."""
+    mock_get_config.return_value.mode = Mode.STRICT
+    mock_get_repo_id.side_effect = NotAGitRepo("not a git repo", solution=None)
+
+    write_cargo_toml(rooted_tmp_path, _MINIMAL_CARGO_TOML)
+    write_cargo_lock(rooted_tmp_path, _MINIMAL_CARGO_LOCK)
+
+    # output_dir is separate from source_dir to avoid the short-circuit path
+    output_dir = rooted_tmp_path.path.parent / "output"
+    request = _make_request(rooted_tmp_path.path, output_dir)
+
+    with pytest.raises(NotAGitRepo):
+        _generate_sbom_components(rooted_tmp_path, request)

--- a/tests/unit/package_managers/gomod/test_main.py
+++ b/tests/unit/package_managers/gomod/test_main.py
@@ -13,13 +13,15 @@ from unittest import mock
 import git
 import pytest
 
+from hermeto.core.constants import Mode
 from hermeto.core.errors import (
     FetchError,
     LockfileNotFound,
+    NotAGitRepo,
     PackageManagerError,
     UnexpectedFormat,
 )
-from hermeto.core.models.input import Flag, Mode, Request
+from hermeto.core.models.input import Flag, Request
 from hermeto.core.models.output import BuildConfig, EnvironmentVariable, RequestOutput
 from hermeto.core.models.sbom import (
     PROXY_COMMENT,
@@ -45,6 +47,7 @@ from hermeto.core.package_managers.gomod.main import (
     ParsedPackage,
     ResolvedGoModule,
     StandardPackage,
+    _create_main_module_from_parsed_data,
     _create_modules_from_parsed_data,
     _create_packages_from_parsed_data,
     _deduplicate_resolved_modules,
@@ -66,7 +69,7 @@ from hermeto.core.package_managers.gomod.main import (
     fetch_gomod_source,
 )
 from hermeto.core.rooted_path import PathOutsideRoot, RootedPath
-from hermeto.core.scm import GitRepo
+from hermeto.core.scm import GitRepo, RepoID
 from hermeto.core.utils import GIT_PRISTINE_ENV, load_json_stream
 from tests.common_utils import GIT_REF, write_file_tree
 from tests.unit.package_managers.gomod.helpers import get_mock_dir, get_mocked_data, proc_mock
@@ -1499,7 +1502,7 @@ def test_vendor_changed(
 
     write_file_tree(vendor_changes, app_dir, exist_ok=True)
 
-    assert _vendor_changed(app_dir, Mode.STRICT) == bool(expected_change)
+    assert _vendor_changed(app_dir) == bool(expected_change)
     if expected_change:
         assert expected_change.format(subpath=subpath) in caplog.text
 
@@ -1777,6 +1780,75 @@ def test_get_repository_name(mock_git_repo: Any, input_url: str) -> None:
     resolved_url = _get_repository_name(RootedPath("/my-folder/cloned-repo"))
 
     assert resolved_url == expected_url
+
+
+@mock.patch("hermeto.core.package_managers.gomod.main.get_repo_id")
+@mock.patch("hermeto.core.package_managers.gomod.main.get_config")
+def test_get_repository_name_permissive_mode(
+    mock_get_config: mock.Mock,
+    mock_get_repo_id: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    """Test that _get_repository_name returns None in PERMISSIVE mode when not a git repo."""
+    mock_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+    mock_get_config.return_value.mode = Mode.PERMISSIVE
+
+    result = _get_repository_name(rooted_tmp_path)
+
+    assert result is None
+
+
+@mock.patch("hermeto.core.package_managers.gomod.main.get_repo_id")
+@mock.patch("hermeto.core.package_managers.gomod.main.get_config")
+def test_get_repository_name_strict_mode_raises_without_git_repo(
+    mock_get_config: mock.Mock,
+    mock_get_repo_id: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    """Test that _get_repository_name re-raises NotAGitRepo in STRICT mode."""
+    mock_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+    mock_get_config.return_value.mode = Mode.STRICT
+
+    with pytest.raises(NotAGitRepo):
+        _get_repository_name(rooted_tmp_path)
+
+
+@mock.patch("hermeto.core.package_managers.gomod.main.get_repo_id")
+@mock.patch("hermeto.core.package_managers.gomod.main.get_config")
+def test_get_repository_name_permissive_mode_with_git_repo(
+    mock_get_config: mock.Mock,
+    mock_get_repo_id: mock.Mock,
+    rooted_tmp_path_repo: RootedPath,
+) -> None:
+    """Test that _get_repository_name returns repo name in PERMISSIVE mode when git repo is available."""
+    repo = git.Repo(rooted_tmp_path_repo)
+    repo.create_remote("origin", "https://github.com/org/repo.git")
+
+    repo_id = RepoID("https://github.com/org/repo.git", repo.head.commit.hexsha)
+    mock_get_repo_id.return_value = repo_id
+    mock_get_config.return_value.mode = Mode.PERMISSIVE
+
+    result = _get_repository_name(rooted_tmp_path_repo)
+
+    assert result == "github.com/org/repo"
+
+
+def test_create_main_module_from_parsed_data_repo_name_none(
+    rooted_tmp_path: RootedPath,
+) -> None:
+    """PERMISSIVE mode without a git repo: resolved_path falls back to the module path."""
+    parsed_main_module = ParsedModule(path="example.com/org/myapp", version="v1.2.3")
+    main_module_dir = rooted_tmp_path  # subpath_from_root == "."
+
+    module = _create_main_module_from_parsed_data(
+        main_module_dir=main_module_dir,
+        repo_name=None,
+        parsed_main_module=parsed_main_module,
+    )
+
+    assert module.real_path == "example.com/org/myapp"
+    assert module.name == "example.com/org/myapp"
+    assert module.version == "v1.2.3"
 
 
 @pytest.fixture

--- a/tests/unit/package_managers/npm/test_project.py
+++ b/tests/unit/package_managers/npm/test_project.py
@@ -7,6 +7,8 @@ from unittest import mock
 import pytest
 from packageurl import PackageURL
 
+from hermeto.core.constants import Mode
+from hermeto.core.errors import NotAGitRepo
 from hermeto.core.package_managers.npm.project import Package, PackageLock, _Purlifier
 from hermeto.core.rooted_path import RootedPath
 from hermeto.core.scm import RepoID
@@ -587,3 +589,97 @@ class TestPurlifier:
         purl = _Purlifier(RootedPath("/foo")).get_purl("foo", None, resolved_url, integrity)
         assert isinstance(purl.qualifiers, dict)
         assert purl.qualifiers.get("checksum") == expect_checksum_qualifier
+
+    @pytest.mark.parametrize(
+        "main_pkg_subpath, pkg_data, expect_purl",
+        [
+            (
+                ".",
+                ("main-pkg", None, "file:."),
+                "pkg:npm/main-pkg",
+            ),
+            (
+                "subpath",
+                ("main-pkg", None, "file:."),
+                "pkg:npm/main-pkg#subpath",
+            ),
+            (
+                ".",
+                ("main-pkg", "1.0.0", "file:."),
+                "pkg:npm/main-pkg@1.0.0",
+            ),
+            (
+                "subpath",
+                ("file-dep", "1.0.0", "file:packages/foo"),
+                "pkg:npm/file-dep@1.0.0#subpath/packages/foo",
+            ),
+        ],
+    )
+    def test_get_purl_for_file_permissive_mode_returns_PackageURL_without_vcs_url(
+        self,
+        main_pkg_subpath: str,
+        pkg_data: tuple[str, str | None, str],
+        expect_purl: PackageURL,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        with (
+            mock.patch("hermeto.core.package_managers.npm.project.get_repo_id") as mock_get_repo_id,
+            mock.patch("hermeto.core.package_managers.npm.project.get_config") as mock_get_config,
+        ):
+            mock_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+            mock_get_config.return_value.mode = Mode.PERMISSIVE
+            pkg_path = rooted_tmp_path.join_within_root(main_pkg_subpath)
+            purl = _Purlifier(pkg_path).get_purl(*pkg_data, integrity=None)
+            assert purl.to_string() == expect_purl
+
+    def test_get_purl_for_file_package_strict_mode_raises_without_git_repo(
+        self,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        with (
+            mock.patch("hermeto.core.package_managers.npm.project.get_repo_id") as mock_get_repo_id,
+            mock.patch("hermeto.core.package_managers.npm.project.get_config") as mock_get_config,
+        ):
+            mock_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+            mock_get_config.return_value.mode = Mode.STRICT
+            pkg_path = rooted_tmp_path.join_within_root(".")
+            with pytest.raises(NotAGitRepo):
+                _Purlifier(pkg_path).get_purl("main-pkg", None, "file:.", integrity=None)
+
+    @pytest.mark.parametrize(
+        "main_pkg_subpath, pkg_data, expect_purl",
+        [
+            (
+                ".",
+                ("main-pkg", None, "file:."),
+                f"pkg:npm/main-pkg?vcs_url={MOCK_REPO_VCS_URL}",
+            ),
+            (
+                "subpath",
+                ("main-pkg", None, "file:."),
+                f"pkg:npm/main-pkg?vcs_url={MOCK_REPO_VCS_URL}#subpath",
+            ),
+            (
+                ".",
+                ("file-dep", "1.0.0", "file:packages/foo"),
+                f"pkg:npm/file-dep@1.0.0?vcs_url={MOCK_REPO_VCS_URL}#packages/foo",
+            ),
+        ],
+    )
+    def test_get_purl_for_file_permissive_mode_returns_PackageURL_with_vcs_url(
+        self,
+        main_pkg_subpath: str,
+        pkg_data: tuple[str, str | None, str],
+        expect_purl: PackageURL,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        with (
+            mock.patch("hermeto.core.package_managers.npm.project.get_repo_id") as mock_get_repo_id,
+            mock.patch("hermeto.core.package_managers.npm.project.get_config") as mock_get_config,
+        ):
+            mock_get_repo_id.return_value = MOCK_REPO_ID
+            mock_get_config.return_value.mode = Mode.PERMISSIVE
+            pkg_path = rooted_tmp_path.join_within_root(main_pkg_subpath)
+            purl = _Purlifier(pkg_path).get_purl(*pkg_data, integrity=None)
+            assert purl.qualifiers is not None
+            assert purl.to_string() == expect_purl

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -14,10 +14,12 @@ from git import Repo
 
 from hermeto import APP_NAME
 from hermeto.core.checksum import ChecksumInfo
+from hermeto.core.constants import Mode
 from hermeto.core.errors import (
     InvalidChecksum,
     LockfileNotFound,
     MissingChecksum,
+    NotAGitRepo,
     PackageRejected,
     UnsupportedFeature,
 )
@@ -1529,6 +1531,100 @@ def test_generate_purl_main_package(
     purl = pip._generate_purl_main_package(package, rooted_tmp_path.join_within_root(subpath))
 
     assert purl == expected_purl
+
+
+@pytest.mark.parametrize(
+    "subpath, expected_purl",
+    [
+        (
+            ".",
+            "pkg:pypi/foo@1.0.0",
+        ),
+        (
+            "path/to/package",
+            "pkg:pypi/foo@1.0.0#path/to/package",
+        ),
+    ],
+)
+@mock.patch("hermeto.core.package_managers.pip.main.get_config")
+@mock.patch("hermeto.core.package_managers.pip.main.get_repo_id")
+def test_generate_purl_main_package_permissive_mode_without_vcs_url(
+    mock_handle_get_repo_id: mock.Mock,
+    mock_get_config: mock.Mock,
+    subpath: Path,
+    expected_purl: str,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    mock_handle_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+    mock_get_config.return_value.mode = Mode.PERMISSIVE
+    package = {"name": "foo", "version": "1.0.0", "type": "pip"}
+
+    purl = pip._generate_purl_main_package(package, rooted_tmp_path.join_within_root(subpath))
+
+    assert purl == expected_purl
+
+
+@mock.patch("hermeto.core.package_managers.pip.main.get_config")
+@mock.patch("hermeto.core.package_managers.pip.main.get_repo_id")
+def test_generate_purl_main_package_strict_mode_raises_without_git_repo(
+    mock_get_repo_id: mock.Mock,
+    mock_get_config: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    mock_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+    mock_get_config.return_value.mode = Mode.STRICT
+    package = {"name": "foo", "version": "1.0.0", "type": "pip"}
+
+    with pytest.raises(NotAGitRepo):
+        pip._generate_purl_main_package(package, rooted_tmp_path.join_within_root("."))
+
+
+@pytest.mark.parametrize(
+    "subpath, expected_purl",
+    [
+        (
+            ".",
+            f"pkg:pypi/foo@1.0.0?vcs_url=git%2Bssh://git%40github.com/my-org/my-repo%40{'f' * 40}",
+        ),
+        (
+            "path/to/package",
+            f"pkg:pypi/foo@1.0.0?vcs_url=git%2Bssh://git%40github.com/my-org/my-repo%40{'f' * 40}#path/to/package",
+        ),
+    ],
+)
+@mock.patch("hermeto.core.package_managers.pip.main.get_config")
+@mock.patch("hermeto.core.package_managers.pip.main.get_repo_id")
+@mock.patch("hermeto.core.scm.GitRepo")
+def test_generate_purl_main_package_permissive_mode_with_vcs_url(
+    mock_git_repo: mock.Mock,
+    mock_get_repo_id: mock.Mock,
+    mock_get_config: mock.Mock,
+    subpath: Path,
+    expected_purl: str,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    mocked_repo = mock.Mock()
+    mocked_repo.remote.return_value.url = "ssh://git@github.com/my-org/my-repo"
+    mocked_repo.head.commit.hexsha = GIT_REF
+    mock_git_repo.return_value = mocked_repo
+
+    mock_get_config.return_value.mode = Mode.PERMISSIVE
+    package = {"name": "foo", "version": "1.0.0", "type": "pip"}
+
+    purl = pip._generate_purl_main_package(package, rooted_tmp_path.join_within_root(subpath))
+
+    assert purl == expected_purl
+
+
+@mock.patch("hermeto.core.package_managers.pip.main.get_repo_id")
+def test_infer_package_name_raises_without_git_repo(
+    mock_handle_get_repo_id: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    mock_handle_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+
+    with pytest.raises(PackageRejected):
+        pip._infer_package_name_from_origin_url(rooted_tmp_path)
 
 
 @mock.patch("hermeto.core.scm.GitRepo")

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -1115,7 +1115,7 @@ def test_pedigree_mapping_flattens_nested_patches(
         ),
     ],
 )
-@mock.patch("hermeto.core.package_managers.general.get_repo_id")
+@mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
 @mock.patch("hermeto.core.package_managers.yarn.resolver.extract_yarn_version_from_env")
 def test_get_pedigree_with_unsupported_locators(
     mock_get_yarn_version: mock.Mock,
@@ -1134,7 +1134,7 @@ def test_get_pedigree_with_unsupported_locators(
 
 
 @mock.patch("hermeto.core.package_managers.yarn.resolver.get_config")
-@mock.patch("hermeto.core.package_managers.general.get_repo_id")
+@mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
 def test_create_components_permissive_mode_without_vcs_url(
     mock_get_repo_id: mock.Mock,
     mock_get_config: mock.Mock,
@@ -1170,7 +1170,7 @@ def test_create_components_permissive_mode_without_vcs_url(
 
 
 @mock.patch("hermeto.core.package_managers.yarn.resolver.get_config")
-@mock.patch("hermeto.core.package_managers.general.get_repo_id")
+@mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
 def test_create_components_strict_mode_raises_without_git_repo(
     mock_get_repo_id: mock.Mock,
     mock_get_config: mock.Mock,

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -11,7 +11,8 @@ import pytest
 from semver import Version
 
 from hermeto import APP_NAME
-from hermeto.core.errors import PackageRejected, UnsupportedFeature
+from hermeto.core.constants import Mode
+from hermeto.core.errors import NotAGitRepo, PackageRejected, UnsupportedFeature
 from hermeto.core.models.sbom import Component, Patch, PatchDiff, Pedigree
 from hermeto.core.package_managers.yarn.locators import (
     Locator,
@@ -329,7 +330,7 @@ def mock_project(project_dir: RootedPath) -> Project:
     )
 
 
-@mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
+@mock.patch("hermeto.core.package_managers.general.get_repo_id")
 @pytest.mark.parametrize(
     "mocked_package, expect_component, expect_logs",
     [
@@ -581,14 +582,17 @@ def test_create_components_single_package(
 
 
 @mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
+@mock.patch("hermeto.core.package_managers.general.get_repo_id")
 @mock.patch("hermeto.core.package_managers.yarn.resolver.extract_yarn_version_from_env")
 def test_create_components_patched_packages(
     mock_get_yarn_version: mock.Mock,
-    mock_get_repo_id: mock.Mock,
+    mock_get_repo_id_general: mock.Mock,
+    mock_get_repo_id_resolver: mock.Mock,
     rooted_tmp_path: RootedPath,
 ) -> None:
     mock_get_yarn_version.return_value = Version(3, 0, 0)
-    mock_get_repo_id.return_value = MOCK_REPO_ID
+    mock_get_repo_id_general.return_value = MOCK_REPO_ID
+    mock_get_repo_id_resolver.return_value = MOCK_REPO_ID
     project_dir = rooted_tmp_path
 
     mocked_packages = [
@@ -662,14 +666,17 @@ def test_create_components_patched_packages(
 
 
 @mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
+@mock.patch("hermeto.core.package_managers.general.get_repo_id")
 @mock.patch("hermeto.core.package_managers.yarn.resolver.extract_yarn_version_from_env")
 def test_create_components_patched_packages_with_multiple_paths(
     mock_get_yarn_version: mock.Mock,
-    mock_get_repo_id: mock.Mock,
+    mock_get_repo_id_general: mock.Mock,
+    mock_get_repo_id_resolver: mock.Mock,
     rooted_tmp_path: RootedPath,
 ) -> None:
     mock_get_yarn_version.return_value = Version(3, 0, 0)
-    mock_get_repo_id.return_value = MOCK_REPO_ID
+    mock_get_repo_id_general.return_value = MOCK_REPO_ID
+    mock_get_repo_id_resolver.return_value = MOCK_REPO_ID
     project_dir = rooted_tmp_path
 
     mocked_packages = [
@@ -973,17 +980,20 @@ def test_create_components_cache_path_reported_but_missing(rooted_tmp_path: Root
     ],
 )
 @mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
+@mock.patch("hermeto.core.package_managers.general.get_repo_id")
 @mock.patch("hermeto.core.package_managers.yarn.resolver.extract_yarn_version_from_env")
 def test_get_path_patch_url(
     mock_get_yarn_version: mock.Mock,
-    mock_get_repo_id: mock.Mock,
+    mock_get_repo_id_general: mock.Mock,
+    mock_get_repo_id_resolver: mock.Mock,
     rooted_tmp_path: RootedPath,
     patch_path_template: str,
     workspace_locator: Optional[WorkspaceLocator],
     expected_url: str,
 ) -> None:
     mock_get_yarn_version.return_value = Version(3, 0, 0)
-    mock_get_repo_id.return_value = MOCK_REPO_ID
+    mock_get_repo_id_general.return_value = MOCK_REPO_ID
+    mock_get_repo_id_resolver.return_value = MOCK_REPO_ID
 
     source_dir_path = rooted_tmp_path.path / "source"
     source_dir_path.mkdir()
@@ -1032,14 +1042,17 @@ def test_get_builtin_patch_url(
 
 
 @mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
+@mock.patch("hermeto.core.package_managers.general.get_repo_id")
 @mock.patch("hermeto.core.package_managers.yarn.resolver.extract_yarn_version_from_env")
 def test_pedigree_mapping_flattens_nested_patches(
     mock_get_yarn_version: mock.Mock,
-    mock_get_repo_id: mock.Mock,
+    mock_get_repo_id_general: mock.Mock,
+    mock_get_repo_id_resolver: mock.Mock,
     rooted_tmp_path: RootedPath,
 ) -> None:
     mock_get_yarn_version.return_value = Version(3, 0, 0)
-    mock_get_repo_id.return_value = MOCK_REPO_ID
+    mock_get_repo_id_general.return_value = MOCK_REPO_ID
+    mock_get_repo_id_resolver.return_value = MOCK_REPO_ID
 
     source_dir_path = rooted_tmp_path.path / "source"
     source_dir_path.mkdir()
@@ -1102,7 +1115,7 @@ def test_pedigree_mapping_flattens_nested_patches(
         ),
     ],
 )
-@mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
+@mock.patch("hermeto.core.package_managers.general.get_repo_id")
 @mock.patch("hermeto.core.package_managers.yarn.resolver.extract_yarn_version_from_env")
 def test_get_pedigree_with_unsupported_locators(
     mock_get_yarn_version: mock.Mock,
@@ -1118,3 +1131,141 @@ def test_get_pedigree_with_unsupported_locators(
 
     with pytest.raises(UnsupportedFeature):
         _ComponentResolver({}, patch_locators, mock_project, rooted_tmp_path.re_root("output"))
+
+
+@mock.patch("hermeto.core.package_managers.yarn.resolver.get_config")
+@mock.patch("hermeto.core.package_managers.general.get_repo_id")
+def test_create_components_permissive_mode_without_vcs_url(
+    mock_get_repo_id: mock.Mock,
+    mock_get_config: mock.Mock,
+    tmp_path: Path,
+) -> None:
+    """Test that workspace packages omit vcs_url when get_repo_id raises NotAGitRepo."""
+    mock_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+    mock_get_config.return_value.mode = Mode.PERMISSIVE
+
+    project_dir = RootedPath(tmp_path / "project")
+
+    mocked_package = MockedPackage(
+        Package(
+            raw_locator="armaments@workspace:./book/armaments",
+            version=None,
+            checksum=None,
+            cache_path=None,
+        ),
+        is_hardlink=False,
+        packjson_path="book/armaments/package.json",
+        packjson_content=json.dumps({"name": "armaments", "version": "42.0.0"}),
+    )
+
+    output_dir = RootedPath(tmp_path / "output")
+    mocked_package = mocked_package.resolve_cache_path(output_dir)
+    mock_package_json(mocked_package, project_dir)
+
+    components = create_components([mocked_package.package], mock_project(project_dir), output_dir)
+
+    assert len(components) == 1
+    # vcs_url should not be present when repo_id is None
+    assert components[0].purl == "pkg:npm/armaments@42.0.0#book/armaments"
+
+
+@mock.patch("hermeto.core.package_managers.yarn.resolver.get_config")
+@mock.patch("hermeto.core.package_managers.general.get_repo_id")
+def test_create_components_strict_mode_raises_without_git_repo(
+    mock_get_repo_id: mock.Mock,
+    mock_get_config: mock.Mock,
+    tmp_path: Path,
+) -> None:
+    """Test that create_components re-raises NotAGitRepo in STRICT mode."""
+    mock_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+    mock_get_config.return_value.mode = Mode.STRICT
+
+    project_dir = RootedPath(tmp_path / "project")
+
+    mocked_package = MockedPackage(
+        Package(
+            raw_locator="armaments@workspace:./book/armaments",
+            version=None,
+            checksum=None,
+            cache_path=None,
+        ),
+        is_hardlink=False,
+        packjson_path="book/armaments/package.json",
+        packjson_content=json.dumps({"name": "armaments", "version": "42.0.0"}),
+    )
+
+    output_dir = RootedPath(tmp_path / "output")
+    mocked_package = mocked_package.resolve_cache_path(output_dir)
+    mock_package_json(mocked_package, project_dir)
+
+    with pytest.raises(NotAGitRepo):
+        create_components([mocked_package.package], mock_project(project_dir), output_dir)
+
+
+@mock.patch("hermeto.core.package_managers.yarn.resolver.get_config")
+@mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
+@mock.patch("hermeto.core.package_managers.general.get_repo_id")
+def test_create_components_permissive_mode_with_vcs_url(
+    mock_get_repo_id_general: mock.Mock,
+    mock_get_repo_id_resolver: mock.Mock,
+    mock_get_config: mock.Mock,
+    tmp_path: Path,
+) -> None:
+    """Test that workspace packages include vcs_url in PERMISSIVE mode when git repo is available."""
+    mock_get_repo_id_general.return_value = MOCK_REPO_ID
+    mock_get_repo_id_resolver.return_value = MOCK_REPO_ID
+    mock_get_config.return_value.mode = Mode.PERMISSIVE
+
+    project_dir = RootedPath(tmp_path / "project")
+
+    mocked_package = MockedPackage(
+        Package(
+            raw_locator="armaments@workspace:./book/armaments",
+            version=None,
+            checksum=None,
+            cache_path=None,
+        ),
+        is_hardlink=False,
+        packjson_path="book/armaments/package.json",
+        packjson_content=json.dumps({"name": "armaments", "version": "42.0.0"}),
+    )
+
+    output_dir = RootedPath(tmp_path / "output")
+    mocked_package = mocked_package.resolve_cache_path(output_dir)
+    mock_package_json(mocked_package, project_dir)
+
+    components = create_components([mocked_package.package], mock_project(project_dir), output_dir)
+
+    assert len(components) == 1
+    # vcs_url should be present when get_repo_id succeeds, even in PERMISSIVE mode
+    assert (
+        components[0].purl == f"pkg:npm/armaments@42.0.0?vcs_url={MOCK_REPO_VCS_URL}#book/armaments"
+    )
+
+
+@mock.patch("hermeto.core.package_managers.yarn.resolver.get_config")
+@mock.patch("hermeto.core.package_managers.yarn.resolver.get_repo_id")
+@mock.patch("hermeto.core.package_managers.yarn.resolver.extract_yarn_version_from_env")
+def test_path_patch_raises_without_repo_in_permissive_mode(
+    mock_get_yarn_version: mock.Mock,
+    mock_get_repo_id: mock.Mock,
+    mock_get_config: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    """Patches require git context regardless of mode."""
+    mock_get_yarn_version.return_value = Version(3, 0, 0)
+    mock_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+    mock_get_config.return_value.mode = Mode.PERMISSIVE
+
+    source_dir_path = rooted_tmp_path.path / "source"
+    source_dir_path.mkdir()
+    source_dir = rooted_tmp_path.re_root("source")
+
+    patch_path = Path("~/my-patches/fsevents.patch")
+    package = NpmLocator(None, "fsevents", "1.0.0")
+    patch_locator = PatchLocator(package, [patch_path], None)
+
+    mock_proj = mock.Mock(source_dir=source_dir)
+
+    with pytest.raises(PackageRejected):
+        _ComponentResolver({}, [patch_locator], mock_proj, rooted_tmp_path.re_root("output"))

--- a/tests/unit/package_managers/yarn_classic/test_resolver.py
+++ b/tests/unit/package_managers/yarn_classic/test_resolver.py
@@ -483,14 +483,14 @@ def test_missing_name_field(rooted_tmp_path: RootedPath) -> None:
 
 
 @mock.patch("hermeto.core.package_managers.yarn_classic.resolver.get_config")
-@mock.patch("hermeto.core.package_managers.general.get_repo_id")
-def test_package_purl_without_vcs_url(
-    mock_handle_get_repo_id: mock.Mock,
+@mock.patch("hermeto.core.package_managers.yarn_classic.resolver.get_vcs_qualifiers")
+def test_package_purl_permissive_mode_without_vcs_url(
+    mock_get_vcs_qualifiers: mock.Mock,
     mock_get_config: mock.Mock,
     rooted_tmp_path: RootedPath,
 ) -> None:
     """Test that file/workspace/link packages omit vcs_url when not in a git repo."""
-    mock_handle_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+    mock_get_vcs_qualifiers.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
     mock_get_config.return_value.mode = Mode.PERMISSIVE
 
     yarn_classic_packages: list[tuple[YarnClassicPackage, str]] = [
@@ -517,6 +517,76 @@ def test_package_purl_without_vcs_url(
                 path=rooted_tmp_path.join_within_root("link/to/package"),
             ),
             "pkg:npm/link-pkg@7.0.0#link/to/package",
+        ),
+    ]
+
+    for package, expected_purl in yarn_classic_packages:
+        assert package.purl == expected_purl
+
+
+@mock.patch("hermeto.core.package_managers.yarn_classic.resolver.get_config")
+@mock.patch("hermeto.core.package_managers.yarn_classic.resolver.get_vcs_qualifiers")
+def test_package_purl_strict_mode_raises_without_git_repo(
+    mock_get_vcs_qualifiers: mock.Mock,
+    mock_get_config: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    """Test that file/workspace/link packages re-raise NotAGitRepo in STRICT mode."""
+    mock_get_vcs_qualifiers.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+    mock_get_config.return_value.mode = Mode.STRICT
+
+    package = FilePackage(
+        name="file-pkg",
+        version="5.0.0",
+        path=rooted_tmp_path.join_within_root("path/to/package"),
+    )
+
+    with pytest.raises(NotAGitRepo):
+        _ = package.purl
+
+
+@mock.patch("hermeto.core.package_managers.yarn_classic.resolver.get_config")
+@mock.patch("hermeto.core.package_managers.yarn_classic.resolver.get_vcs_qualifiers")
+def test_package_purl_permissive_mode_with_vcs_url(
+    mock_get_vcs_qualifiers: mock.Mock,
+    mock_get_config: mock.Mock,
+    rooted_tmp_path_repo: RootedPath,
+) -> None:
+    """Test that file/workspace/link packages include vcs_url in PERMISSIVE mode when git repo is available."""
+    repo = git.Repo(rooted_tmp_path_repo)
+    repo.create_remote("origin", "https://github.com/org/repo.git")
+
+    example_repo_id = get_repo_id(repo)
+    example_vcs_url = example_repo_id.as_vcs_url_qualifier()
+    purl_vcs_url = quote(example_vcs_url, safe=":/")
+
+    mock_get_vcs_qualifiers.return_value = {"vcs_url": example_vcs_url}
+    mock_get_config.return_value.mode = Mode.PERMISSIVE
+
+    yarn_classic_packages: list[tuple[YarnClassicPackage, str]] = [
+        (
+            FilePackage(
+                name="file-pkg",
+                version="5.0.0",
+                path=rooted_tmp_path_repo.join_within_root("path/to/package"),
+            ),
+            f"pkg:npm/file-pkg@5.0.0?vcs_url={purl_vcs_url}#path/to/package",
+        ),
+        (
+            WorkspacePackage(
+                name="workspace-pkg",
+                version="6.0.0",
+                path=rooted_tmp_path_repo.join_within_root("workspace/package"),
+            ),
+            f"pkg:npm/workspace-pkg@6.0.0?vcs_url={purl_vcs_url}#workspace/package",
+        ),
+        (
+            LinkPackage(
+                name="link-pkg",
+                version="7.0.0",
+                path=rooted_tmp_path_repo.join_within_root("link/to/package"),
+            ),
+            f"pkg:npm/link-pkg@7.0.0?vcs_url={purl_vcs_url}#link/to/package",
         ),
     ]
 

--- a/tests/unit/package_managers/yarn_classic/test_resolver.py
+++ b/tests/unit/package_managers/yarn_classic/test_resolver.py
@@ -11,7 +11,8 @@ import pytest
 from pyarn.lockfile import Package as PYarnPackage
 
 from hermeto.core.checksum import ChecksumInfo
-from hermeto.core.errors import PackageRejected, UnexpectedFormat
+from hermeto.core.constants import Mode
+from hermeto.core.errors import NotAGitRepo, PackageRejected, UnexpectedFormat
 from hermeto.core.package_managers.yarn_classic.main import MIRROR_DIR
 from hermeto.core.package_managers.yarn_classic.project import PackageJson
 from hermeto.core.package_managers.yarn_classic.resolver import (
@@ -479,3 +480,45 @@ def test_missing_name_field(rooted_tmp_path: RootedPath) -> None:
     tarball_path = mock_tarball(path=rooted_tmp_path, package_json_content={"key": "foo"})
     with pytest.raises(ValueError, match="No 'name' field found"):
         _read_name_from_tarball(tarball_path)
+
+
+@mock.patch("hermeto.core.package_managers.yarn_classic.resolver.get_config")
+@mock.patch("hermeto.core.package_managers.general.get_repo_id")
+def test_package_purl_without_vcs_url(
+    mock_handle_get_repo_id: mock.Mock,
+    mock_get_config: mock.Mock,
+    rooted_tmp_path: RootedPath,
+) -> None:
+    """Test that file/workspace/link packages omit vcs_url when not in a git repo."""
+    mock_handle_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
+    mock_get_config.return_value.mode = Mode.PERMISSIVE
+
+    yarn_classic_packages: list[tuple[YarnClassicPackage, str]] = [
+        (
+            FilePackage(
+                name="file-pkg",
+                version="5.0.0",
+                path=rooted_tmp_path.join_within_root("path/to/package"),
+            ),
+            "pkg:npm/file-pkg@5.0.0#path/to/package",
+        ),
+        (
+            WorkspacePackage(
+                name="workspace-pkg",
+                version="6.0.0",
+                path=rooted_tmp_path.join_within_root("workspace/package"),
+            ),
+            "pkg:npm/workspace-pkg@6.0.0#workspace/package",
+        ),
+        (
+            LinkPackage(
+                name="link-pkg",
+                version="7.0.0",
+                path=rooted_tmp_path.join_within_root("link/to/package"),
+            ),
+            "pkg:npm/link-pkg@7.0.0#link/to/package",
+        ),
+    ]
+
+    for package, expected_purl in yarn_classic_packages:
+        assert package.purl == expected_purl

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -19,6 +19,7 @@ import yaml
 
 import hermeto.core.config as config_file
 from hermeto import APP_NAME
+from hermeto.core.constants import Mode
 from hermeto.core.models.input import Request
 from hermeto.core.models.output import (
     BuildConfig,
@@ -196,6 +197,17 @@ class TestTopLevelOpts:
     def test_mode_option_is_valid(self, mode: str) -> None:
         args = ["--mode", mode, "fetch-deps", "gomod"]
         with mock_fetch_deps():
+            invoke_expecting_sucess(app, args)
+
+    def test_mode_permissive_propagates_to_config(self) -> None:
+        args = ["--mode", "permissive", "fetch-deps", "gomod"]
+
+        def side_effect(request: Any) -> RequestOutput:
+            assert config_file.get_config().mode == Mode.PERMISSIVE
+            return RequestOutput.empty()
+
+        with mock.patch("hermeto.interface.cli.resolve_packages") as mock_resolve:
+            mock_resolve.side_effect = side_effect
             invoke_expecting_sucess(app, args)
 
     @pytest.mark.parametrize(

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -57,6 +57,7 @@ class TestRepoID:
 
         if isinstance(expect_result, str):
             repo_id = get_repo_id(golang_repo_path)
+            assert repo_id is not None
             assert repo_id.origin_url == expect_result
             assert repo_id.parsed_origin_url == urlsplit(expect_result)
             assert repo_id.commit_id == expect_commit_id


### PR DESCRIPTION
Enable processing of non-git input sources (e.g., tarballs) when using --mode=permissive.

In permissive mode, non-git sources are now accepted and the vcs_url
qualifier is omitted from the generated PURL. In strict mode, non-git
sources continue to raise NotAGitRepo as expected.

User-requested feature

Closes #938

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
