### PR TITLE
gomod: Include proxy config in SBOM 

### DIFF
--- a/hermeto/core/package_managers/gomod.py
+++ b/hermeto/core/package_managers/gomod.py
@@ -41,8 +41,11 @@ from hermeto.core.models.input import Mode, Request
 from hermeto.core.models.output import EnvironmentVariable, RequestOutput
 from hermeto.core.models.property_semantics import PropertySet
 from hermeto.core.models.sbom import (
+    PROXY_COMMENT,
+    PROXY_REF_TYPE,
     Annotation,
     Component,
+    ExternalReference,
     create_backend_annotation,
     spdx_now,
 )
@@ -153,6 +156,8 @@ class Module(NamedTuple):
     main: if this is the main module in the repository subpath that is being processed
     missing_hash_in_file: path (relative to repository root) to the go.sum file which should have
         had a checksum for this module but didn't
+    proxy: the list of custom proxy URLs used to fetch this module, or None if the module was
+        fetched directly from VCS or only via the canonical Go proxy (proxy.golang.org).
     """
 
     name: str
@@ -161,6 +166,7 @@ class Module(NamedTuple):
     version: str
     main: bool = False
     missing_hash_in_file: Path | None = None
+    proxy: list[str] | None = None
 
     @property
     def purl(self) -> str:
@@ -180,11 +186,19 @@ class Module(NamedTuple):
         else:
             missing_hash_in_file = frozenset()
 
+        ref_rest = dict(type=PROXY_REF_TYPE, comment=PROXY_COMMENT)
+
+        if self.proxy:
+            refs = [ExternalReference(url=p, **ref_rest) for p in self.proxy]
+        else:
+            refs = None
+
         return Component(
             name=self.name,
             version=self.version,
             purl=self.purl,
             properties=PropertySet(missing_hash_in_file=missing_hash_in_file).to_properties(),
+            external_references=refs,
         )
 
 
@@ -556,6 +570,27 @@ def _get_module_id(module: ParsedModule) -> ModuleID:
     return name, version_or_path
 
 
+def _get_proxy_for_module(module: ParsedModule) -> list[str] | None:
+    """
+    Returns None when the module was fetched directly from VCS (origin is set), or when
+    the configured GOPROXY contains only canonical entries (proxy.golang.org, direct).
+    When custom proxies are present, returns all configured proxy URLs except 'direct',
+    including proxy.golang.org if set alongside custom proxies.
+    """
+    if module.origin:
+        return None
+
+    canonical_proxies = {"direct", "https://proxy.golang.org"}
+    proxy_config = get_config().gomod.proxy_url
+
+    proxies = [p.strip() for p in re.split(r"[|,]", proxy_config) if p.strip()]
+
+    if not any(p not in canonical_proxies for p in proxies):
+        return None
+
+    return [p for p in proxies if p != "direct"]
+
+
 def _create_modules_from_parsed_data(
     main_module: Module,
     main_module_dir: RootedPath,
@@ -573,6 +608,7 @@ def _create_modules_from_parsed_data(
         if not version_or_path.startswith("."):
             version = version_or_path
             real_path = name
+            proxy = _get_proxy_for_module(module)
 
             if mod_id not in modules_in_go_sum:
                 if go_work:
@@ -587,6 +623,7 @@ def _create_modules_from_parsed_data(
             resolved_replacement_path = main_module_dir.join_within_root(version_or_path)
             version = version_resolver.get_golang_version(module.path, resolved_replacement_path)
             real_path = _resolve_path_for_local_replacement(module)
+            proxy = None
 
         return Module(
             name=name,
@@ -594,6 +631,7 @@ def _create_modules_from_parsed_data(
             original_name=original_name,
             real_path=real_path,
             missing_hash_in_file=missing_hash_in_file,
+            proxy=proxy,
         )
 
     def _resolve_path_for_local_replacement(module: ParsedModule) -> str:

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -22,7 +22,15 @@ from hermeto.core.errors import (
 )
 from hermeto.core.models.input import Flag, Mode, Request
 from hermeto.core.models.output import BuildConfig, EnvironmentVariable, RequestOutput
-from hermeto.core.models.sbom import Annotation, Component, Property, PropertyEnum
+from hermeto.core.models.sbom import (
+    PROXY_COMMENT,
+    PROXY_REF_TYPE,
+    Annotation,
+    Component,
+    ExternalReference,
+    Property,
+    PropertyEnum,
+)
 from hermeto.core.package_managers.gomod import (
     Go,
     GoVersion,
@@ -34,6 +42,7 @@ from hermeto.core.package_managers.gomod import (
     Package,
     ParsedGoWork,
     ParsedModule,
+    ParsedOrigin,
     ParsedPackage,
     ResolvedGoModule,
     StandardPackage,
@@ -44,6 +53,7 @@ from hermeto.core.package_managers.gomod import (
     _get_go_sum_files,
     _get_go_work_path,
     _get_gomod_version,
+    _get_proxy_for_module,
     _get_repository_name,
     _go_exec_env,
     _go_list_deps,
@@ -980,6 +990,13 @@ def test_module_to_component() -> None:
         name="github.com/another-org/nice-repo",
         version="v0.0.1",
         purl="pkg:golang/github.com/another-org/nice-repo@v0.0.1?type=module",
+        external_references=[
+            ExternalReference(
+                url="https://goproxy.corp.example.com",
+                type=PROXY_REF_TYPE,
+                comment=PROXY_COMMENT,
+            )
+        ],
     )
 
     component = Module(
@@ -987,9 +1004,41 @@ def test_module_to_component() -> None:
         version="v0.0.1",
         original_name="github.com/my-org/nice-repo",
         real_path="github.com/another-org/nice-repo",
+        proxy=["https://goproxy.corp.example.com"],
     ).to_component()
 
     assert component == expected_component
+
+
+@pytest.mark.parametrize(
+    "proxy_url, has_origin, expected_proxies",
+    [
+        ("https://goproxy.corp.example.com,direct", True, None),
+        ("https://proxy.golang.org,direct", False, None),
+        ("https://goproxy.corp.example.com,direct", False, ["https://goproxy.corp.example.com"]),
+        (
+            "https://goproxy.corp.example.com,https://proxy.golang.org,direct",
+            False,
+            ["https://goproxy.corp.example.com", "https://proxy.golang.org"],
+        ),
+    ],
+)
+@mock.patch("hermeto.core.package_managers.gomod.get_config")
+def test_get_proxy_for_module(
+    mock_config: mock.Mock,
+    proxy_url: str,
+    has_origin: bool,
+    expected_proxies: list[str] | None,
+) -> None:
+    mock_config.return_value.gomod.proxy_url = proxy_url
+    origin = (
+        ParsedOrigin(vcs="git", url="https://github.com/org/repo", hash="abc123")
+        if has_origin
+        else None
+    )
+    module = ParsedModule(path="github.com/org/repo", version="v1.0.0", origin=origin)
+
+    assert _get_proxy_for_module(module) == expected_proxies
 
 
 def test_create_packages_from_parsed_data() -> None:
@@ -2690,8 +2739,6 @@ def test_go_exec_env(
 )
 def test_parsed_origin_from_json(input_json: dict, expected_fields: dict) -> None:
     """Test ParsedOrigin parsing from JSON with PascalCase field mapping."""
-    from hermeto.core.package_managers.gomod import ParsedOrigin
-
     origin = ParsedOrigin.model_validate(input_json)
 
     assert origin.vcs == expected_fields["vcs"]


### PR DESCRIPTION
Add ParsedOrigin class to parse Go module origin data from `go mod download`. The Origin field is the indicator that NO proxy was used in fetching a particular module.  And record the proxy as a property into SBOM. 

Issue: https://github.com/hermetoproject/hermeto/issues/577

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
