### PR TITLE
tests: Update the base image for generic_e2e_maven tests

### DIFF
--- a/tests/integration/test_data/generic_e2e_maven/container/Containerfile
+++ b/tests/integration/test_data/generic_e2e_maven/container/Containerfile
@@ -1,4 +1,4 @@
-FROM mirror.gcr.io/ibmjava:11-jdk
+FROM mirror.gcr.io/eclipse-temurin:11-jre-jammy
 
 # Test disabled network access
 RUN if curl -IsS www.google.com; then echo "Has network access!"; exit 1; fi


### PR DESCRIPTION
The ibmjava does not support arch `arm64`, which will cause the test failure as follows on MacOS,  and eclipse-temurin java works. 

` 
Error: creating build container: choosing an image from manifest list docker://mirror.gcr.io/ibmjava:11-jdk: no image found in manifest list for architecture "arm64", variant "v8", OS "linux"
`

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
