### PR TITLE
enhancement: allow relative paths for generic lockfiles

### DIFF
--- a/docs/generic.md
+++ b/docs/generic.md
@@ -16,8 +16,9 @@ because the produced SBOM component will not be accurate.
 
 The generic fetcher requires a lockfile `artifacts.lock.yaml` that specifies
 which files to download. This file is expected to be in the source repository.
-Alternatively, it can be supplied as an absolute path via the `lockfile` key in
-the JSON input to hermeto.
+Alternatively, a different filename or location can be supplied via the
+`lockfile` key in the JSON input to hermeto. The value may be either an absolute
+path or a path relative to the package `path`.
 
 Below are sections for each type of supported artifact. Several artifacts of
 different types can be specified in a single lockfile.
@@ -50,8 +51,8 @@ where 'JSON input' is
   // path to the package (relative to the --source directory)
   // defaults to "."
   "path": ".",
-  // option to specify lockfile path, must be an absolute path if specified
-  // defaults to "artifacts.lock.yaml", relative to path
+  // option to specify lockfile path: absolute or relative to package path
+  // defaults to "artifacts.lock.yaml", resolved relative to package path
   "lockfile": "artifacts.lock.yaml",
 }
 ```
@@ -153,9 +154,11 @@ git clone -b sample-app https://github.com/cachito-testing/cachi2-generic.git
 #### Pre-fetch dependencies
 
 In order to retrieve the archive with the tool, either a `artifacts.lock.yaml`
-needs to be in the repository, or an absolute path needs to be supplied in the
-JSON input, pointing to a lockfile. You can find a sample lockfile below. It is
-identical to the one found in the [sample repository][].
+needs to be in the repository, or a lockfile path needs to be supplied in the
+JSON input (either an absolute path or a path relative to the package `path`).
+You can find
+a sample lockfile below. It is identical to the one found in the
+[sample repository][].
 A lockfile for the generic fetcher must contain a `metadata` header and a list
 of artifacts, where each artifact is represented as a pair of URL and a checksum
 string in the format of `"algorithm:checksum"`. Optionally, you can also specify

--- a/hermeto/core/package_managers/generic/main.py
+++ b/hermeto/core/package_managers/generic/main.py
@@ -47,13 +47,20 @@ def _resolve_lockfile_path(
     """
     Return the lockfile path for a package.
     """
+    if lockfile_path and lockfile_path.is_absolute():
+        return lockfile_path
+
     path = source_dir.join_within_root(package_path)
-    lockfile = lockfile_path or path.join_within_root(DEFAULT_LOCKFILE_NAME).path
-    if not lockfile.is_absolute():
+    lockfile_name = lockfile_path or DEFAULT_LOCKFILE_NAME
+    lockfile = path.join_within_root(lockfile_name).path
+
+    if not lockfile.is_relative_to(path.path):
         raise PackageRejected(
-            f"Supplied generic lockfile path '{lockfile}' is not absolute, refusing to continue.",
-            solution="Make sure the supplied path to the generic lockfile is absolute.",
+            f"Supplied generic lockfile path '{lockfile_name}' must be inside the package "
+            f"path '{package_path}'.",
+            solution="Use a lockfile path located within the package path.",
         )
+
     return lockfile
 
 


### PR DESCRIPTION
Previously, the generic package manager rejected relative paths for lockfiles, requiring absolute paths which are often unknown in CI environments.

This change updates `generic` manager to resolve relative lockfile paths against the source directory.

Resolves: https://github.com/hermetoproject/hermeto/issues/761

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
