### PR TITLE
.github: dependabot: Ignore updates to Golang/Node images via config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,16 @@ updates:
       interval: "monthly"
     commit-message:
       prefix: "Dockerfile"
+    ignore:
+      # We must handle major.minor Go releases manually due to direct feature support
+      - dependency-name: "library/golang"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      # Node v25 stopped shipping corepack which we need
+      - dependency-name: "library/node"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "pip"
     directory: "/"


### PR DESCRIPTION
Rather than using the Github comments mechanism which is completely opaque and non-transparent define the ignores in the config file.

For Go we only want patch release updates, i.e. toolchain updates, for Node we're fine with minor releases but we can't bump to v25 since that version dropped corepack which we need and haven't taken adjustments for yet.