### PR TITLE
Backport github release workflow to the 0.28 branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-        with:
-          fetch-tags: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
This backports the recently adopted GitHub release workflow which builds and pushes a container image to the GitHub registry.