### PR TITLE
gomod: Add a clarifying commentary on the matching toolchain selection

### DIFF
--- a/hermeto/core/package_managers/gomod.py
+++ b/hermeto/core/package_managers/gomod.py
@@ -940,6 +940,7 @@ def _select_toolchain(go_mod_file: RootedPath, installed_toolchains: Iterable[Go
     # If we cannot find a matching toolchain, we'll try to fallback to a 1.21 one
     matching_toolchains = filter(lambda t: t.version >= target_version, installed_toolchains)
     try:
+        # pick the closest matching toolchain version for best compatibility
         go = min(matching_toolchains)
         log.debug("Using Go toolchain version '%s'", go.version)
     except ValueError:


### PR DESCRIPTION
Cosmetic change. It might not be obvious to anyone beyond the author why `min` was employed here in the version selection process, but it is so to ensure the best toolchain compatibility.
