### PR TITLE
fix: merge SBOM components when deduping

### DIFF
--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -17,7 +17,6 @@ from typing_extensions import Self
 
 from hermeto import APP_NAME
 from hermeto.core.models.property_semantics import Property, PropertyEnum, PropertySet
-from hermeto.core.models.validators import unique_sorted
 from hermeto.core.utils import first_for
 
 log = logging.getLogger(__name__)
@@ -159,7 +158,7 @@ class Sbom(pydantic.BaseModel):
     @classmethod
     def _unique_components(cls, components: list[Component]) -> list[Component]:
         """Sort and de-duplicate components."""
-        return unique_sorted(components, by=lambda component: component.key())
+        return merge_component_properties(components)
 
     def to_cyclonedx(self) -> Self:
         """Return self, self is already the right type of Sbom."""

--- a/tests/unit/models/test_sbom.py
+++ b/tests/unit/models/test_sbom.py
@@ -309,9 +309,36 @@ class TestSbom:
                 {"name": "fmt", "version": None, "purl": "pkg:golang/fmt"},
                 {"name": "fmt", "version": None, "purl": "pkg:golang/fmt"},
                 {"name": "bytes", "version": None, "purl": "pkg:golang/bytes"},
+                {
+                    "name": "mypkg",
+                    "version": "1.0.0",
+                    "purl": "pkg:generic/mypkg@1.0.0",
+                },
+                {
+                    "name": "mypkg",
+                    "version": "1.0.0",
+                    "purl": "pkg:generic/mypkg@1.0.0",
+                    "properties": [{"name": f"{APP_NAME}:missing_hash:in_file", "value": "file2"}],
+                },
+                {
+                    "name": "mypkg",
+                    "version": "1.0.0",
+                    "purl": "pkg:generic/mypkg@1.0.0",
+                    "properties": [{"name": f"{APP_NAME}:missing_hash:in_file", "value": "file1"}],
+                },
             ],
         )
         assert sbom.components == [
+            Component(
+                name="mypkg",
+                purl="pkg:generic/mypkg@1.0.0",
+                version="1.0.0",
+                properties=[
+                    FOUND_BY_APP_PROPERTY,
+                    Property(name=f"{APP_NAME}:missing_hash:in_file", value="file1"),
+                    Property(name=f"{APP_NAME}:missing_hash:in_file", value="file2"),
+                ],
+            ),
             Component(name="bytes", purl="pkg:golang/bytes"),
             Component(name="fmt", purl="pkg:golang/fmt"),
             Component(


### PR DESCRIPTION
- use merge_component_properties in the SBOM components validator
- add test: dedup when missing_hash properties differ

Closes: https://github.com/hermetoproject/hermeto/issues/1057

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
