### PR TITLE
Extract unified _clone_git_repo function for Git operations

### DIFF
--- a/hermeto/core/package_managers/bundler/gem_models.py
+++ b/hermeto/core/package_managers/bundler/gem_models.py
@@ -5,13 +5,12 @@ from typing import Annotated
 from urllib.parse import urljoin, urlparse
 
 import pydantic
-from git import Repo
 from packageurl import PackageURL
 from typing_extensions import Self
 
 from hermeto.core.package_managers.general import download_binary_file
 from hermeto.core.rooted_path import PathOutsideRoot, RootedPath
-from hermeto.core.scm import get_repo_id
+from hermeto.core.scm import clone_git_dependency, get_repo_id
 
 AcceptedUrl = Annotated[
     pydantic.HttpUrl,
@@ -143,16 +142,13 @@ class GitDependency(_GemMetadata):
         git_repo_path.path.mkdir(parents=True)
 
         log.info("Cloning git repository %s", self.url)
-        repo = Repo.clone_from(
+
+        clone_git_dependency(
             url=str(self.url),
+            ref=self.ref,
             to_path=git_repo_path.path,
-            env={"GIT_TERMINAL_PROMPT": "0"},
+            branch=self.branch,
         )
-
-        if self.branch is not None:
-            repo.git.checkout(self.branch)
-
-        repo.git.reset("--hard", self.ref)
 
 
 class PathDependency(_GemMetadata):

--- a/tests/unit/package_managers/bundler/test_parser.py
+++ b/tests/unit/package_managers/bundler/test_parser.py
@@ -257,7 +257,7 @@ def test_binary_gem_dependencies_could_be_downloaded(
     mock_downloader.assert_called_once_with(expected_source_url, expected_destination)
 
 
-@mock.patch("hermeto.core.package_managers.bundler.gem_models.Repo.clone_from")
+@mock.patch("hermeto.core.package_managers.bundler.gem_models.clone_git_dependency")
 def test_download_git_dependency_works(
     mock_git_clone: mock.Mock,
     rooted_tmp_path: RootedPath,
@@ -276,13 +276,14 @@ def test_download_git_dependency_works(
 
     mock_git_clone.assert_called_once_with(
         url=str(dep.url),
+        ref=dep.ref,
         to_path=dep_path,
-        env={"GIT_TERMINAL_PROMPT": "0"},
+        branch=dep.branch,
     )
     assert dep_path.exists()
 
 
-@mock.patch("hermeto.core.package_managers.bundler.gem_models.Repo.clone_from")
+@mock.patch("hermeto.core.package_managers.bundler.gem_models.clone_git_dependency")
 def test_download_duplicate_git_dependency_is_skipped(
     mock_git_clone: mock.Mock,
     rooted_tmp_path: RootedPath,
@@ -302,8 +303,9 @@ def test_download_duplicate_git_dependency_is_skipped(
 
     mock_git_clone.assert_called_once_with(
         url=str(dep.url),
+        ref=dep.ref,
         to_path=dep_path,
-        env={"GIT_TERMINAL_PROMPT": "0"},
+        branch=dep.branch,
     )
     assert dep_path.exists()
 


### PR DESCRIPTION
Consolidates duplicate Repo.clone_from logic from scm.py and bundler into a single function with consistent error handling and SSH fallback.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
