### PR TITLE
fix(core): use granular http timeouts (connect/read) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,12 @@ Any settings specified will override the default values present in the
 - `gomod.environment_variables` default environment variables for gomod.
 - `gomod.proxy_url` sets the GOPROXY variable that Hermeto uses internally when
   downloading Go modules. See [Go environment variables][].
-- `http.timeout` timeout (seconds) for HTTP requests.
+- `http.connect_timeout` connection timeout (seconds) for HTTP requests
+  (default: 30).
+- `http.read_timeout` read timeout (seconds) for HTTP requests (default: 300).
+  Long-running downloads can take arbitrarily long as long as bytes keep
+  flowing.
+- `http.timeout` (deprecated) automatically migrated to `http.read_timeout`.
 - `runtime.concurrency_limit` max concurrent operations.
 - `runtime.subprocess_timeout` timeout (seconds) for subprocess commands.
 

--- a/hermeto/core/package_managers/pip/package_distributions.py
+++ b/hermeto/core/package_managers/pip/package_distributions.py
@@ -139,7 +139,8 @@ def _get_project_packages_from(
     version: str,
 ) -> Iterable[pypi_simple.DistributionPackage]:
     """Get all the project packages from the given index URL."""
-    timeout = get_config().http.timeout
+    config = get_config()
+    timeout = (config.http.connect_timeout, config.http.read_timeout)
     with pypi_simple.PyPISimple(index_url) as client:
         try:
             project_page = client.get_project_page(name, timeout)

--- a/tests/unit/package_managers/test_general.py
+++ b/tests/unit/package_managers/test_general.py
@@ -32,7 +32,8 @@ from tests.common_utils import GIT_REF
 def test_download_binary_file(
     mock_get: Any, auth: AuthBase | None, insecure: bool, chunk_size: int, tmp_path: Path
 ) -> None:
-    timeout = get_config().http.timeout
+    config = get_config()
+    timeout = (config.http.connect_timeout, config.http.read_timeout)
     url = "http://example.org/example.tar.gz"
     content = b"file content"
 
@@ -179,7 +180,7 @@ async def test_async_download_binary_file(
     assert session.get.called
     assert session.get.call_args == mock.call(
         url,
-        timeout=aiohttp.ClientTimeout(total=300),
+        timeout=aiohttp.ClientTimeout(total=None, connect=30, sock_read=300),
         auth=None,
         raise_for_status=True,
         ssl=None,

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -48,12 +48,19 @@ def test_normalize_config_structure(caplog: pytest.LogCaptureFixture) -> None:
     assert config.gomod.proxy_url == "https://custom.proxy"
     assert config.gomod.download_max_tries == 10
     assert config.gomod.environment_variables == {"GOPROXY": "off"}
-    assert config.http.timeout == 600
+    assert config.http.read_timeout == 600
     assert config.runtime.subprocess_timeout == 7200
     assert config.runtime.concurrency_limit == 10
     assert config.yarn.enabled is False
     assert config.pip.ignore_dependencies_crates is True
     assert "is deprecated" in caplog.text
+
+
+def test_migrate_http_timeout(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that http.timeout is migrated to http.read_timeout."""
+    config = config_module.Config.model_validate({"http": {"timeout": 123}})
+    assert config.http.read_timeout == 123
+    assert "Config option 'http.timeout' is deprecated" in caplog.text
 
 
 def test_deprecated_field_removed_with_warning(caplog: pytest.LogCaptureFixture) -> None:


### PR DESCRIPTION
Downloads can fail immediately when a single request hits the global timeout. Replace the global `total` HTTP timeout with granular `connect` and`read` timeouts. In aiohttp, `total` is a hard cap on the entire request; by setting `total=None`, downloads can run as long as needed as long as the connection is established within `connect=30` and the server never stalls for more than `read=300` seconds between bytes.
The existing `http.timeout=300` setting is kept unchanged in config to avoid breaking existing users, but is deprecated in favor of `http.read_timeout`.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
