### PR TITLE
Fix externalReferences field serialization in SBOM

### DIFF
--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -64,9 +64,12 @@ class Component(pydantic.BaseModel):
     properties: list[Property] = pydantic.Field(default_factory=list, validate_default=True)
     type: Literal["library", "file"] = "library"
     external_references: list[ExternalReference] | None = pydantic.Field(
-        serialization_alias="externalReferences", default=None
+        alias="externalReferences", default=None
     )
     pedigree: Pedigree | None = None
+
+    # Aliased fields may be populated by their name as given by the model attribute.
+    model_config = pydantic.ConfigDict(validate_by_name=True, extra="forbid")
 
     def key(self) -> str:
         """Uniquely identifies a package.

--- a/tests/unit/package_managers/test_generic.py
+++ b/tests/unit/package_managers/test_generic.py
@@ -268,7 +268,7 @@ def test_resolve_generic_lockfile_invalid(
             LOCKFILE_VALID,
             [
                 {
-                    "external_references": [
+                    "externalReferences": [
                         {"type": "distribution", "url": "https://example.com/artifact"}
                     ],
                     "name": "archive.zip",
@@ -277,7 +277,7 @@ def test_resolve_generic_lockfile_invalid(
                     "type": "file",
                 },
                 {
-                    "external_references": [
+                    "externalReferences": [
                         {
                             "type": "distribution",
                             "url": "https://example.com/more/complex/path/file.tar.gz?foo=bar#fragment",
@@ -295,7 +295,7 @@ def test_resolve_generic_lockfile_invalid(
             LOCKFILE_VALID_MAVEN,
             [
                 {
-                    "external_references": [
+                    "externalReferences": [
                         {
                             "type": "distribution",
                             "url": "https://repo.spring.io/release/org/springframework/boot/spring-boot-starter/3.1.5/spring-boot-starter-3.1.5.jar",
@@ -308,7 +308,7 @@ def test_resolve_generic_lockfile_invalid(
                     "version": "3.1.5",
                 },
                 {
-                    "external_references": [
+                    "externalReferences": [
                         {
                             "type": "distribution",
                             "url": "https://repo1.maven.org/maven2/io/netty/netty-transport-native-epoll/4.1.100.Final/netty-transport-native-epoll-4.1.100.Final-sources.jar",
@@ -342,7 +342,7 @@ def test_resolve_generic_lockfile_valid(
         f.write(lockfile_content)
 
     assert [
-        c.model_dump(exclude_none=True)
+        c.model_dump(by_alias=True, exclude_none=True)
         for c in _resolve_generic_lockfile(lockfile_path.path, rooted_tmp_path)
     ] == expected_components
     mock_checksums.assert_called()


### PR DESCRIPTION
# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
