### PR TITLE
chore: tests: Force submodules to main in ITs

### DIFF
--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -385,7 +385,12 @@ def fetch_deps_and_check_output(
     else:
         actual_repo_dir = test_repo_dir
         repo = Repo(actual_repo_dir)
-        repo.git.reset("--hard")
+        # Submodule could end up being in detached HEAD state which would
+        # result in a cascading failure for all tests that follow. This does
+        # not happen always and at the moment of writing it is not clear what
+        # exactly triggers such behavior. However ensuring that all submodules
+        # are hard-reset resolves the issue.
+        repo.git.reset("--hard", "--recurse-submodules")
         # remove untracked files and directories from the working tree
         # git will refuse to modify untracked nested git repositories unless a second -f is given
         repo.git.clean("-ffdx")


### PR DESCRIPTION
Integration tests could experience a spontaneous cascading failure which was traced back to a presumably race condition somewhere around updating submodules in golang ITs. After some experimentation it turned out that making sure all submodules are at 'main' prior to checking out the right branch resolved the issue.

This change amends the utility which deals with test repository to always check out 'main' first.

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
