### PR TITLE
fix(npm): make version optional for workspace packages

### DIFF
--- a/hermeto/core/package_managers/npm.py
+++ b/hermeto/core/package_managers/npm.py
@@ -42,7 +42,7 @@ class NpmComponentInfo(TypedDict):
 
     name: str
     purl: str
-    version: str
+    version: str | None
     dev: bool
     bundled: bool
     missing_hash_in_file: Path | None
@@ -86,13 +86,13 @@ class Package:
         self._package_dict["integrity"] = integrity
 
     @property
-    def version(self) -> str:
+    def version(self) -> str | None:
         """Get the package version.
 
         This will be a semver from the package.json file.
         https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json#packages
         """
-        return self._package_dict["version"]
+        return self._package_dict.get("version")
 
     @property
     def resolved_url(self) -> str | None:

--- a/tests/unit/package_managers/test_npm.py
+++ b/tests/unit/package_managers/test_npm.py
@@ -162,10 +162,23 @@ class TestPackage:
                 "file:///foo-1.0.0.tgz",
                 id="package",
             ),
+            pytest.param(
+                Package(
+                    "foo",
+                    "foo",
+                    {
+                        # version omitted for workspace/unpublished package
+                        "resolved": "file:foo",
+                    },
+                ),
+                None,
+                "file:///foo-1.0.0.tgz",
+                id="workspace_no_version",
+            ),
         ],
     )
     def test_set_resolved_url(
-        self, package: Package, expected_version: str, expected_resolved_url: str
+        self, package: Package, expected_version: str | None, expected_resolved_url: str
     ) -> None:
         package.resolved_url = "file:///foo-1.0.0.tgz"
         assert package.version == expected_version


### PR DESCRIPTION
In npm lockfile versions 2 and 3, workspace dependencies may omit the 'version' field. Changed Package.version to return None instead of raising KeyError when version is missing.

The root package version remains required.

Closes: https://github.com/hermetoproject/hermeto/issues/1069

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
