### PR TITLE
.gemini: Adjust the styleguide on Python docstrings

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -25,5 +25,7 @@
 
 ### Python Docstrings
 
-- Ensure that a new function parameter is documented
+- Suggest docstring updates only for public functions, methods, and classes
+- Do not suggest docstrings for private helper methods (prefixed with underscore)
+- Ensure that new parameters on public functions are documented
 - Focus on good stylistic and correct english grammar


### PR DESCRIPTION
In one of my recent reviews or PRs I noticed Gemini to complain about a missing docstring update on a simple private helper function.