### PR TITLE
Add experimental package manager support with annotations

### DIFF
--- a/docs/design/package-manager-template.md
+++ b/docs/design/package-manager-template.md
@@ -182,6 +182,11 @@ This section helps the community evaluate the maturity of the package manager. E
 managers use the `x-` prefix in their package manager name. This section should be completed prior
 to the community declaring the package manager "fully supported."
 
+**Note**: Components produced by experimental package managers (those with `x-` prefix) are
+identified through document-level annotations in generated SBOMs. Each experimental package manager
+creates a separate annotation listing the components it produced, with text such as
+`hermeto:backend:experimental:x-foo` and subjects containing the relevant bom-ref values.
+
 ### Current Limitations
 
 Document known limitations of the current implementation:

--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -158,15 +158,21 @@ def create_backend_annotation(
 ) -> Annotation | None:
     """Create an annotation that tags components with the backend that fetched them.
 
+    Experimental backends (those with an x- prefix) use a distinct label in the annotation text.
+
     Returns None if there are no components to annotate.
     """
     if not components:
         return None
+    if backend_name.startswith("x-"):
+        text = f"{APP_NAME}:backend:experimental:{backend_name}"
+    else:
+        text = f"{APP_NAME}:backend:{backend_name}"
     return Annotation(
         subjects={c.bom_ref for c in components},
         annotator={"organization": {"name": "red hat"}},
         timestamp=spdx_now(),
-        text=f"{APP_NAME}:backend:{backend_name}",
+        text=text,
     )
 
 


### PR DESCRIPTION
Mark the components generated by experimental package managers
(those with `x-` prefix like "x-foo") using document-level
annotations for better processing.

Resolves: https://github.com/hermetoproject/hermeto/issues/688

Assisted-by: Claude Code

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
