### PR TITLE
feat(cargo): Add support for alternative Cargo registries

### DIFF
--- a/tests/unit/package_managers/cargo/test_main.py
+++ b/tests/unit/package_managers/cargo/test_main.py
@@ -1,8 +1,14 @@
+import textwrap
 from typing import Any
 
 import pytest
 
-from hermeto.core.package_managers.cargo.main import CargoPackage, _resolve_main_package
+from hermeto.core.errors import UnexpectedFormat
+from hermeto.core.package_managers.cargo.main import (
+    CargoPackage,
+    _resolve_main_package,
+    _sanitize_cargo_config,
+)
 from hermeto.core.rooted_path import RootedPath
 
 
@@ -88,8 +94,142 @@ def test_virtual_workspace_without_workspace_version(rooted_tmp_path: RootedPath
             "pkg:cargo/foo@0.1.0?vcs_url=git%2Bhttps://github.com/rust-random/rand%40abc123",
             id="package_with_git_source",
         ),
+        pytest.param(
+            {
+                "name": "foo",
+                "version": "0.1.0",
+                "source": "registry+https://my-registry.example.com/index",
+            },
+            "pkg:cargo/foo@0.1.0?repository_url=https://my-registry.example.com/index",
+            id="package_with_alternate_registry",
+        ),
+        pytest.param(
+            {
+                "name": "foo",
+                "version": "0.1.0",
+                "source": "registry+https://my-crates.io-mirror.example.com/index",
+                "checksum": "abc123",
+            },
+            "pkg:cargo/foo@0.1.0?checksum=abc123",
+            id="package_with_crates_io_in_subdomain_no_repository_url",
+        ),
     ],
 )
 def test_cargo_package_purl_generation(pkg: dict[str, Any], expected_purl: str) -> None:
     package = CargoPackage(**pkg)
     assert package.purl.to_string() == expected_purl
+
+
+@pytest.mark.parametrize(
+    "config_input, expected_registries",
+    [
+        pytest.param(
+            """
+            [registries.example-registry]
+            index = "https://my-registry.example.com:8080/index"
+
+            """,
+            textwrap.dedent(
+                """
+                [registries.example-registry]
+                index = "https://my-registry.example.com:8080/index"
+                """,
+            ).lstrip(),
+            id="single_registries_with_only_safe_fields",
+        ),
+        pytest.param(
+            """
+            [registries.my-registry]
+            index =     "https://my-intranet:8080/git/index"
+            token =     "secret-token"
+            credential-provider = "cargo:token"
+            dangerous-field = "should-be-removed"
+
+            [registries.other-registry]
+            index = "https://other.example.com/index"
+            custom-field = "should-be-removed"
+
+            [build]
+            jobs = 4
+            """,
+            textwrap.dedent(
+                """
+                [registries.my-registry]
+                index = "https://my-intranet:8080/git/index"
+                token = "secret-token"
+                credential-provider = "cargo:token"
+
+                [registries.other-registry]
+                index = "https://other.example.com/index"
+                """
+            ).lstrip(),
+            id="multiple_registries_with_safe_and_unsafe_fields",
+        ),
+    ],
+)
+def test_cargo_config_with_correctly_defined_registries(
+    config_input: str, expected_registries: str
+) -> None:
+    result = _sanitize_cargo_config(config_input)
+    assert result == expected_registries
+
+
+@pytest.mark.parametrize(
+    "config_input",
+    [
+        pytest.param(
+            """
+            [registries]
+            """,
+            id="single_invalid_registries_with_no_index",
+        ),
+        pytest.param(
+            """
+            [registries.example-registry]
+            """,
+            id="single_invalid_registries_with_no_value",
+        ),
+        pytest.param(
+            """
+            [build]
+            jobs = 4
+
+            [net]
+            git-fetch-with-cli = true
+            """,
+            id="no_registries_section",
+        ),
+        pytest.param(
+            "",
+            id="empty_config",
+        ),
+    ],
+)
+def test_cargo_config_without_registries_gets_sanitized(config_input: str) -> None:
+    result = _sanitize_cargo_config(config_input)
+    assert result == ""
+
+
+@pytest.mark.parametrize(
+    "invalid_config",
+    [
+        pytest.param(
+            """
+            [registries.my-registry
+            index = "https://example.com"
+            """,
+            id="malformed_toml_missing_closing_bracket",
+        ),
+        pytest.param(
+            """
+            [registries.my-registry]
+            index = "https://example.com"
+            token = [this is invalid without quotes
+            """,
+            id="malformed_toml_invalid_array_syntax",
+        ),
+    ],
+)
+def test_sanitize_cargo_config_raises_unexpected_format(invalid_config: str) -> None:
+    with pytest.raises(UnexpectedFormat):
+        _sanitize_cargo_config(invalid_config)


### PR DESCRIPTION
Change _hidden_cargo_config_file to sanitize: now .cargo/config can keep only safe registry auth fields (index, token, credential-provider)
Add repository_url qualifier to PURLs for packages from alternate registries
Filter out crates.io packages from getting repository_url qualifier
Testing: Add comprehensive unit tests for config sanitization and PURL generation
    
Resolves #1001

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
