### PR TITLE
noxfile: Add option to prevent downloading Python

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -30,6 +30,9 @@ nox.options.reuse_venv = "always"
 # use venv as the default virtual environment backend
 nox.options.default_venv_backend = "venv"
 
+# do not download missing Python interpreter
+nox.options.download_python = "never"
+
 
 def install_requirements(session: Session) -> None:
     """Install requirements for all sessions."""


### PR DESCRIPTION
When executing nox session I always see a warning: "Nox was installed without the `[pbs]` extra, can't download Python"

Explicitly set to ignore missing Python interpreter and do not try to download it.

---
https://nox.thea.codes/en/stable/usage.html#downloading-python-interpreters

# Maintainers will complete the following section

- [ ] Commit messages are descriptive enough
- [ ] Code coverage from testing does not decrease and new code is covered
- [ ] Docs updated (if applicable)
- [ ] Docs links in the code are still valid (if docs were updated)

**Note:** if the contribution is external (not from an organization member), the CI
pipeline will not run automatically. After verifying that the CI is safe to run:

- [approve GitHub Actions workflows][approve-gh-actions] by clicking a button
- approve the Red Hat Trusted App Pipeline container build by commenting `/ok-to-test`
  (as is the [standard for Pipelines as Code][pac-running-pipeline])

[approve-gh-actions]: https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks
[pac-running-pipeline]: https://pipelinesascode.com/docs/guide/running/#running-the-pipelinerun
