### PR TITLE
cli: split --version and package-managers output

### DIFF
--- a/hermeto/core/resolver.py
+++ b/hermeto/core/resolver.py
@@ -24,8 +24,14 @@ _package_managers: dict[PackageManagerType, Handler] = {
 }
 
 
-# This is *only* used to provide a list for `hermeto --version`
-supported_package_managers = list(_package_managers)
+def get_supported_backends() -> list[PackageManagerType | str]:
+    """List all supported backends sorted alphabetically by name."""
+    return sorted(x for x in _package_managers if not x.startswith("x-"))
+
+
+def get_experimental_backends() -> list[PackageManagerType | str]:
+    """List all experimental backends sorted alphabetically by name."""
+    return sorted(x for x in _package_managers if x.startswith("x-"))
 
 
 def resolve_packages(request: Request) -> RequestOutput:

--- a/hermeto/interface/cli.py
+++ b/hermeto/interface/cli.py
@@ -19,7 +19,12 @@ from hermeto.core.extras.envfile import EnvFormat, generate_envfile
 from hermeto.core.models.input import Flag, Mode, PackageInput, Request, parse_user_input
 from hermeto.core.models.output import BuildConfig
 from hermeto.core.models.sbom import Sbom, SPDXSbom, spdx_now
-from hermeto.core.resolver import inject_files_post, resolve_packages
+from hermeto.core.resolver import (
+    get_experimental_backends,
+    get_supported_backends,
+    inject_files_post,
+    resolve_packages,
+)
 from hermeto.core.rooted_path import RootedPath
 from hermeto.interface.logging import LogLevel, setup_logging
 
@@ -219,6 +224,19 @@ def _looks_like_input_file(value: str) -> bool:
 class _Input(pydantic.BaseModel, extra="forbid"):
     packages: list[PackageInput]
     flags: list[Flag] = list()
+
+
+@app.command()
+@handle_errors
+def list_backends() -> None:
+    """List supported backends."""
+    supported = get_supported_backends()
+    if supported:
+        print("Supported:", ", ".join(supported))
+
+    experimental = get_experimental_backends()
+    if experimental:
+        print("Experimental:", ", ".join(experimental))
 
 
 @app.command(help=FETCH_DEPS_HELP)

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -89,6 +89,16 @@ class TestTopLevelOpts:
         result = invoke_expecting_sucess(app, ["--version"])
         assert expect_version in result.output
 
+    @mock.patch(
+        "hermeto.core.resolver._package_managers",
+        {"foo": mock.Mock(), "bar": mock.Mock(), "x-baz": mock.Mock()},
+    )
+    def test_list_backends_option(self) -> None:
+        result = invoke_expecting_sucess(app, ["list-backends"])
+        lines = result.output.splitlines()
+        assert "bar, foo" in lines[0]
+        assert "x-baz" in lines[1]
+
     @pytest.mark.parametrize(
         "config_values",
         [


### PR DESCRIPTION
--version mixed version and package-manager list.
This is non-standard behavior for cli tools.
Separate --package-managers option fixes that.

closes https://github.com/hermetoproject/hermeto/issues/1234