### PR TITLE
Moved from getting the Go toolchain with 'go version' to 'go env GOVERSION'

### DIFF
--- a/hermeto/core/package_managers/gomod.py
+++ b/hermeto/core/package_managers/gomod.py
@@ -406,27 +406,9 @@ class Go:
         return GoVersion(self._get_release())
 
     def _get_release(self) -> str:
-        output = self(["version"], params={"env": {"GOTOOLCHAIN": "local"}})
+        output = self(["env", "GOVERSION"], params={"env": {"GOTOOLCHAIN": "local"}})
         log.debug(f"Go release: {output}")
-        release_pattern = f"go{version.VERSION_PATTERN}"
-
-        # packaging.version requires passing the re.VERBOSE|re.IGNORECASE flags [1]
-        # [1] https://packaging.pypa.io/en/latest/version.html#packaging.version.VERSION_PATTERN
-        if match := re.search(release_pattern, output, re.VERBOSE | re.IGNORECASE):
-            release = match.group(0)
-        else:
-            # This should not happen, otherwise we must figure out a more reliable way of
-            # extracting Go version.
-            # Ideally we'd want to rely only on doing 'go env GOVERSION' which doesn't require any
-            # further post-processing, but GOVERSION variable was introduced in Go 1.16 and so
-            # 'go version' has been around for longer, then again, it's CLI output bound to
-            # change.
-            raise PackageManagerError(
-                f"Could not extract Go toolchain version from Go's output: '{output}'",
-                solution=f"This is a fatal error, please open a bug report against {APP_NAME}",
-            )
-
-        return release
+        return output.strip()
 
     @staticmethod
     def _retry(cmd: list[str], **kwargs: Any) -> str:


### PR DESCRIPTION
Changed the way of getting Go toolchain version from `go version` to `go env GOVERSION` which is supported from Go version 1.16 and should suffice the needs of this project.

closes https://github.com/hermetoproject/hermeto/issues/1114