### PR TITLE
.gemini: Flag new unit tests that match against string output

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -20,6 +20,8 @@
 - Detect and flag code duplication, dead code, and code redundancy
 - Maintain a consistent code structure across the whole code base
 - Make sure if unit tests are added they cover both positive and negative scenarios
+- Make sure if unit tests are added they don't perform string matching against
+  the output
 - Prefer test parametrization over standalone unit tests for different test variants
   of the same function if it decreases code duplication
 


### PR DESCRIPTION
We have introduced a handful of exception subtypes to check against instead.

Recent motivation: https://github.com/hermetoproject/hermeto/pull/1278#discussion_r2773247166