### PR TITLE
refactor(pip): introduce CommonArtifact dataclass

### DIFF
--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
+
 import asyncio
+import dataclasses
 import logging
 import tarfile
 import zipfile
@@ -23,6 +25,12 @@ from hermeto.core.package_managers.general import (
     async_download_files,
     download_binary_file,
     extract_git_info,
+)
+from hermeto.core.package_managers.pip.models import (
+    Artifact,
+    PyPIArtifact,
+    URLArtifact,
+    VCSArtifact,
 )
 from hermeto.core.package_managers.pip.package_distributions import (
     DistributionPackageInfo,
@@ -260,11 +268,14 @@ def _process_req(
     pip_deps_dir: RootedPath,
     download_info: dict[str, Any],
     dpi: DistributionPackageInfo | None = None,
-) -> dict[str, Any]:
-    download_info["kind"] = req.kind
-    download_info["requirement_file"] = str(requirements_file.file_path.subpath_from_root)
-    download_info["missing_req_file_checksum"] = True
-    download_info["package_type"] = ""
+    build_dependency: bool = False,
+) -> Artifact:
+    """Process a downloaded PipRequirement and return an Artifact."""
+    # Extract common fields from download_info dict
+    package_name = download_info["package"]
+    path = download_info["path"]
+    requirement_file = str(requirements_file.file_path.subpath_from_root)
+    missing_req_file_checksum = True
 
     def _checksum_must_match_or_path_unlink(
         path: Path, checksum_info: Iterable[ChecksumInfo]
@@ -276,34 +287,67 @@ def _process_req(
             path.unlink()
             log.warning("Download '%s' was removed from the output directory", path.name)
 
+    artifact: Artifact
     if dpi:
+        # PyPI artifact
         if dpi.req_file_checksums:
-            download_info["missing_req_file_checksum"] = False
+            missing_req_file_checksum = False
         if dpi.checksums_to_match:
             _checksum_must_match_or_path_unlink(dpi.path, dpi.checksums_to_match)
         if dpi.package_type == "sdist":
             _check_metadata_in_sdist(dpi.path)
-        download_info["package_type"] = dpi.package_type
-        download_info["index_url"] = dpi.index_url
+
+        artifact = PyPIArtifact(
+            package=package_name,
+            path=path,
+            requirement_file=requirement_file,
+            missing_req_file_checksum=missing_req_file_checksum,
+            build_dependency=build_dependency,
+            index_url=dpi.index_url,
+            package_type=dpi.package_type,
+            _version=dpi.version,
+        )
     elif req.kind == "vcs":
-        # `missing_req_file_checksum` is *always* True for VCS deps
-        pass
+        # VCS artifact - extract git info from download_info
+        artifact = VCSArtifact(
+            package=package_name,
+            path=path,
+            requirement_file=requirement_file,
+            missing_req_file_checksum=True,  # Always True for VCS deps
+            build_dependency=build_dependency,
+            url=download_info["url"],
+            host=download_info["host"],
+            namespace=download_info["namespace"],
+            repo=download_info["repo"],
+            ref=download_info["ref"],
+        )
+    elif req.kind == "url":
+        # URL artifact
+        hashes = req.hashes or [req.qualifiers.get("cachito_hash", "")]
+        if hashes:
+            missing_req_file_checksum = False
+            _checksum_must_match_or_path_unlink(path, list(map(ChecksumInfo.from_hash, hashes)))
+
+        artifact = URLArtifact(
+            package=package_name,
+            path=path,
+            requirement_file=requirement_file,
+            missing_req_file_checksum=missing_req_file_checksum,
+            build_dependency=build_dependency,
+            original_url=download_info["original_url"],
+            url_with_hash=download_info["url_with_hash"],
+            package_type=download_info.get("package_type"),
+        )
     else:
-        if req.kind == "url":
-            hashes = req.hashes
-            if hashes:
-                download_info["missing_req_file_checksum"] = False
-                _checksum_must_match_or_path_unlink(
-                    download_info["path"], list(map(ChecksumInfo.from_hash, hashes))
-                )
+        raise ValueError(f"Unknown requirement kind: {req.kind}")
 
     log.debug(
         "Successfully processed '%s' in path '%s'",
         req.download_line,
-        download_info["path"].relative_to(pip_deps_dir.root),
+        path.relative_to(pip_deps_dir.root),
     )
 
-    return download_info
+    return artifact
 
 
 def _process_pypi_req(
@@ -312,18 +356,23 @@ def _process_pypi_req(
     index_url: str,
     pip_deps_dir: RootedPath,
     binary_filters: PipBinaryFilters | None = None,
-) -> list[dict[str, Any]]:
-    download_infos: list[dict[str, Any]] = []
+) -> list[Artifact]:
+    """Process a PipRequirement, getting DPIs, then download artifacts.
+
+    Artifacts are filtered and allowed by type. Uses `aiohttp_retry.RetryClient`.
+    """
+    download_artifacts: list[Artifact] = []
 
     artifacts: list[DistributionPackageInfo] = process_package_distributions(
         req, pip_deps_dir, binary_filters, index_url
     )
 
     files: dict[str, StrPath] = {dpi.url: dpi.path for dpi in artifacts if not dpi.path.exists()}
+
     asyncio.run(async_download_files(files, get_config().runtime.concurrency_limit))
 
     for artifact in artifacts:
-        download_infos.append(
+        download_artifacts.append(
             _process_req(
                 req,
                 requirements_file,
@@ -333,12 +382,10 @@ def _process_pypi_req(
             )
         )
 
-    return download_infos
+    return download_artifacts
 
 
-def _process_vcs_req(
-    req: PipRequirement, pip_deps_dir: RootedPath, **kwargs: Any
-) -> dict[str, Any]:
+def _process_vcs_req(req: PipRequirement, pip_deps_dir: RootedPath, **kwargs: Any) -> Artifact:
     return _process_req(
         req,
         pip_deps_dir=pip_deps_dir,
@@ -349,37 +396,36 @@ def _process_vcs_req(
 
 def _process_url_req(
     req: PipRequirement, pip_deps_dir: RootedPath, trusted_hosts: set[str], **kwargs: Any
-) -> dict[str, Any]:
-    result = _process_req(
+) -> Artifact:
+    download_info = _download_url_package(req, pip_deps_dir, trusted_hosts)
+    if req.url.endswith(WHEEL_FILE_EXTENSION):
+        download_info["package_type"] = "wheel"
+
+    return _process_req(
         req,
         pip_deps_dir=pip_deps_dir,
-        download_info=_download_url_package(req, pip_deps_dir, trusted_hosts),
+        download_info=download_info,
         **kwargs,
     )
-    if req.url.endswith(WHEEL_FILE_EXTENSION):
-        result["package_type"] = "wheel"
-
-    return result
 
 
 def _download_dependencies(
     output_dir: RootedPath,
     requirements_file: PipRequirementsFile,
     binary_filters: PipBinaryFilters | None = None,
-) -> list[dict[str, Any]]:
+) -> list[Artifact]:
     """
     Download artifacts of all dependency packages in a requirements.txt file.
 
     :param output_dir: the root output directory for this request
     :param requirements_file: A requirements.txt file
     :param binary_filters: process wheels?
-    :return: Info about downloaded packages; all items will contain "kind" and "path" keys
-        (and more based on kind, see _download_*_package functions for more details)
-    :rtype: list[dict]
+    :return: List of artifact download objects
+    :rtype: list[Artifact]
     """
     options: dict[str, Any] = process_requirements_options(requirements_file.options)
     trusted_hosts = set(options["trusted_hosts"])
-    processed: list[dict[str, Any]] = []
+    processed: list[Artifact] = []
 
     if options["require_hashes"]:
         log.info("Global --require-hashes option used, will require hashes")
@@ -402,29 +448,29 @@ def _download_dependencies(
     for req in requirements_file.requirements:
         log.info("-- Processing requirement line '%s'", req.download_line)
         if req.kind == "pypi":
-            download_infos: list[dict[str, Any]] = _process_pypi_req(
+            download_artifacts: list[Artifact] = _process_pypi_req(
                 req,
                 requirements_file=requirements_file,
                 index_url=options["index_url"] or pypi_simple.PYPI_SIMPLE_ENDPOINT,
                 pip_deps_dir=pip_deps_dir,
                 binary_filters=binary_filters,
             )
-            processed.extend(download_infos)
+            processed.extend(download_artifacts)
         elif req.kind == "vcs":
-            download_info = _process_vcs_req(
+            artifact = _process_vcs_req(
                 req,
                 requirements_file=requirements_file,
                 pip_deps_dir=pip_deps_dir,
             )
-            processed.append(download_info)
+            processed.append(artifact)
         elif req.kind == "url":
-            download_info = _process_url_req(
+            artifact = _process_url_req(
                 req,
                 requirements_file=requirements_file,
                 pip_deps_dir=pip_deps_dir,
                 trusted_hosts=trusted_hosts,
             )
-            processed.append(download_info)
+            processed.append(artifact)
         else:
             # Should not happen
             raise RuntimeError(f"Unexpected requirement kind: '{req.kind!r}'")
@@ -436,7 +482,7 @@ def _download_dependencies(
 
 def _download_vcs_package(requirement: PipRequirement, pip_deps_dir: RootedPath) -> dict[str, Any]:
     """
-    Fetch the source for a Python package from VCS (only git is supported).
+    Clone the source for a Python package from a VCS to a local tarball. Only "git" is supported.
 
     :param PipRequirement requirement: VCS requirement from a requirements.txt file
     :param RootedPath pip_deps_dir: The deps/pip directory in an application request bundle
@@ -461,7 +507,7 @@ def _download_url_package(
     requirement: PipRequirement, pip_deps_dir: RootedPath, trusted_hosts: set[str]
 ) -> dict[str, Any]:
     """
-    Download a Python package from a URL.
+    Download a Python package from a URL (uses `requests`).
 
     :param PipRequirement requirement: URL requirement from a requirements.txt file
     :param RootedPath pip_deps_dir: The deps/pip directory in an application request bundle
@@ -497,18 +543,17 @@ def _download_from_requirement_files(
     output_dir: RootedPath,
     files: list[RootedPath],
     binary_filters: PipBinaryFilters | None = None,
-) -> list[dict[str, Any]]:
+) -> list[Artifact]:
     """
     Download dependencies listed in the requirement files.
 
     :param output_dir: the root output directory for this request
     :param files: list of absolute paths to pip requirements files
     :param binary_filters: process wheels?
-    :return: Info about downloaded packages; see download_dependencies return docs for further
-        reference
+    :return: List of artifact download objects
     :raises PackageRejected: If requirement file does not exist
     """
-    requirements: list[dict[str, Any]] = []
+    requirements: list[Artifact] = []
     for req_file in files:
         if not req_file.path.exists():
             raise LockfileNotFound(
@@ -579,41 +624,42 @@ def _resolve_pip(
         output_dir, resolved_build_req_files, binary_filters
     )
 
-    if get_config().pip.ignore_dependencies_crates:
+    # Mark build dependencies by creating new frozen instances
+    build_requires_marked = [
+        dataclasses.replace(dependency, build_dependency=True) for dependency in build_requires
+    ]
+
+    all_artifacts = requires + build_requires_marked
+
+    # No need to search for Rust code when a user requested only binaries.
+    if binary_filters is not None or get_config().pip.ignore_dependencies_crates:
         packages_containing_rust_code = []
     else:
-        packages_containing_rust_code = filter_packages_with_rust_code(requires + build_requires)
+        packages_containing_rust_code = filter_packages_with_rust_code(
+            [artifact.to_filter_dict() for artifact in all_artifacts]
+        )
 
-    # Mark all build dependencies as such
-    for dependency in build_requires:
-        dependency["build_dependency"] = True
+    dependencies = []
 
-    def _version(dep: dict[str, Any]) -> str:
-        if dep["kind"] == "pypi":
-            version = dep["version"]
-        elif dep["kind"] == "vcs":
-            # Version is "git+" followed by the URL used to fetch from git
-            version = f"git+{dep['url']}@{dep['ref']}"
-        else:
-            # Version is the original URL for URL dependencies
-            version = dep["original_url"]
-        return version
-
-    dependencies = [
-        {
-            "name": dep["package"],
-            "version": _version(dep),
-            "checksum": dep.get("checksum"),
-            "index_url": dep.get("index_url"),
+    for artifact in all_artifacts:
+        dep: dict[str, Any] = {
+            "name": artifact.package,
+            "version": artifact.version,
             "type": "pip",
-            "build_dependency": dep.get("build_dependency", False),
-            "kind": dep["kind"],
-            "requirement_file": dep["requirement_file"],
-            "missing_req_file_checksum": dep["missing_req_file_checksum"],
-            "package_type": dep["package_type"],
+            "build_dependency": artifact.build_dependency,
+            "kind": artifact.kind,
+            "requirement_file": artifact.requirement_file,
+            "missing_req_file_checksum": artifact.missing_req_file_checksum,
         }
-        for dep in (requires + build_requires)
-    ]
+        if artifact.kind == "pypi":
+            dep["index_url"] = artifact.index_url
+            dep["package_type"] = artifact.package_type
+        elif artifact.kind == "url":
+            dep["package_type"] = artifact.package_type
+        else:
+            # VCS artifacts have neither package_type nor index_url
+            dep["package_type"] = None
+        dependencies.append(dep)
 
     return {
         "package": {"name": pkg_name, "version": pkg_version, "type": "pip"},

--- a/hermeto/core/package_managers/pip/models.py
+++ b/hermeto/core/package_managers/pip/models.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Data models for pip package manager artifacts and dependencies."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Union
+
+
+@dataclass(frozen=True)
+class CommonArtifact(ABC):
+    """Base class for representing a packaged Python artifact."""
+
+    # The package name.
+    package: str
+
+    # Path where the artifact is stored locally.
+    path: Path
+
+    # Path to the requirements file that specified this dependency.
+    requirement_file: str
+
+    # Whether this artifact is missing checksums in the requirements file.
+    missing_req_file_checksum: bool
+
+    # Whether this is a build-time dependency (from requirements-build.txt).
+    build_dependency: bool
+
+    # Discriminator set by each subclass.
+    kind: Literal["pypi", "url", "vcs"] = field(init=False)
+
+    @property
+    @abstractmethod
+    def version(self) -> str:
+        """Version identifier for the artifact."""
+
+    def to_filter_dict(self) -> dict[str, Any]:
+        """Convert to dict format expected by filter_packages_with_rust_code."""
+        return {
+            "package": self.package,
+            "path": self.path,
+            "kind": self.kind,
+        }
+
+
+@dataclass(frozen=True)
+class PyPIArtifact(CommonArtifact):
+    """Artifact downloaded from a Python Package Index (e.g., PyPI)."""
+
+    # URL of the package index.
+    index_url: str
+
+    # Type of Python package distribution.
+    package_type: Literal["sdist", "wheel"]
+
+    _version: str
+
+    @property
+    def version(self) -> str:
+        """Return version string for PyPI artifacts."""
+        return self._version
+
+    kind: Literal["pypi"] = field(default="pypi", init=False)
+
+
+@dataclass(frozen=True)
+class VCSArtifact(CommonArtifact):
+    """Artifact downloaded from a version control system (e.g., git)."""
+
+    # The VCS URL.
+    url: str
+
+    # The VCS host (e.g., github.com).
+    host: str
+
+    # The namespace/organization (e.g., 'containerbuildsystem').
+    namespace: str
+
+    # The repository name.
+    repo: str
+
+    # The git reference (commit hash, branch, tag).
+    ref: str
+
+    kind: Literal["vcs"] = field(default="vcs", init=False)
+
+    def __post_init__(self) -> None:
+        if not self.url:
+            raise ValueError("VCS artifact must have non-empty url")
+        if not self.ref:
+            raise ValueError("VCS artifact must have non-empty ref")
+        if not self.host:
+            raise ValueError("VCS artifact must have non-empty host")
+        if not self.namespace:
+            raise ValueError("VCS artifact must have non-empty namespace")
+        if not self.repo:
+            raise ValueError("VCS artifact must have non-empty repo")
+
+    @property
+    def version(self) -> str:
+        """Return version string for VCS artifacts."""
+        return f"git+{self.url}@{self.ref}"
+
+
+@dataclass(frozen=True)
+class URLArtifact(CommonArtifact):
+    """Artifact downloaded from a direct URL."""
+
+    # The original URL specified in requirements.
+    original_url: str
+
+    # The URL with hash fragment added if needed.
+    url_with_hash: str
+
+    # Package type, set to 'wheel' for wheel URLs, None otherwise.
+    package_type: Literal["wheel"] | None = None
+
+    kind: Literal["url"] = field(default="url", init=False)
+
+    @property
+    def version(self) -> str:
+        """Return version string for URL artifacts."""
+        return self.url_with_hash
+
+
+# Type alias for any artifact download
+Artifact = Union[PyPIArtifact, VCSArtifact, URLArtifact]

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import subprocess
 from collections.abc import Collection
-from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
@@ -26,6 +25,7 @@ from hermeto.core.models.output import ProjectFile
 from hermeto.core.models.sbom import Annotation, Component, Property
 from hermeto.core.package_managers.cargo.main import PackageWithCorruptLockfileRejected
 from hermeto.core.package_managers.pip import main as pip
+from hermeto.core.package_managers.pip.models import PyPIArtifact, URLArtifact, VCSArtifact
 from hermeto.core.rooted_path import RootedPath
 from tests.common_utils import GIT_REF
 
@@ -567,13 +567,16 @@ class TestDownload:
             pypi_checksum={pypi_checksum_sdist},
             req_file_checksums=set() if missing_req_file_checksum else {req_file_checksum_sdist},
         )
-        sdist_d_i = sdist_DPI.download_info | {
-            "kind": "pypi",
-            "requirement_file": str(req_file.file_path.subpath_from_root),
-            "missing_req_file_checksum": missing_req_file_checksum,
-            "package_type": "sdist",
-            "index_url": expect_index_url,
-        }
+        sdist_d_i = PyPIArtifact(
+            package="foo",
+            path=sdist_download,
+            requirement_file=str(req_file.file_path.subpath_from_root),
+            missing_req_file_checksum=missing_req_file_checksum,
+            build_dependency=False,
+            index_url=expect_index_url,
+            package_type="sdist",
+            _version="1.0",
+        )
         verify_sdist_checksum_call = mock.call(sdist_download, {pypi_checksum_sdist})
         expected_downloads = [sdist_d_i]
 
@@ -582,7 +585,7 @@ class TestDownload:
             wheel_0_download = pip_deps.join_within_root("foo-1.0-cp35-many-linux.whl").path
             wheel_1_download = pip_deps.join_within_root("foo-1.0-cp25-win32.whl").path
             wheel_2_download = pip_deps.join_within_root("foo-1.0-any.whl").path
-            wheel_downloads: list[dict[str, Any]] = []
+            wheel_downloads: list[PyPIArtifact] = []
 
             for wheel_path, pypi_checksum in zip(
                 [wheel_0_download, wheel_1_download, wheel_2_download],
@@ -600,14 +603,16 @@ class TestDownload:
                 )
                 wheels_DPI.append(dpi)
                 wheel_downloads.append(
-                    dpi.download_info
-                    | {
-                        "kind": "pypi",
-                        "requirement_file": str(req_file.file_path.subpath_from_root),
-                        "missing_req_file_checksum": missing_req_file_checksum,
-                        "package_type": "wheel",
-                        "index_url": expect_index_url,
-                    }
+                    PyPIArtifact(
+                        package="foo",
+                        path=wheel_path,
+                        requirement_file=str(req_file.file_path.subpath_from_root),
+                        missing_req_file_checksum=missing_req_file_checksum,
+                        build_dependency=False,
+                        index_url=expect_index_url,
+                        package_type="wheel",
+                        _version="1.0",
+                    )
                 )
 
             verify_wheel0_checksum_call = mock.call(
@@ -747,18 +752,25 @@ class TestDownload:
             "external-bar", "bar-external-sha256-654321.tar.gz"
         ).path
 
-        url_download_info = {
+        url_download_info = URLArtifact(
+            package="bar",
+            path=url_download,
+            requirement_file=str(req_file.file_path.subpath_from_root),
+            missing_req_file_checksum=False,
+            build_dependency=False,
+            original_url=plain_url,
+            url_with_hash=plain_url,
+        )
+
+        mock_download_url_package.return_value = {
             "package": "bar",
             "path": url_download,
             "requirement_file": str(req_file.file_path.subpath_from_root),
-            # Checksums are *mandatory*
             "missing_req_file_checksum": False,
-            "package_type": "",
+            "package_type": None,
             "original_url": plain_url,
             "checksum": "sha256:654321",
         }
-
-        mock_download_url_package.return_value = deepcopy(url_download_info)
 
         mock_must_match_any_checksum.side_effect = [
             None if checksum_match else PackageRejected("", solution=None),
@@ -768,7 +780,7 @@ class TestDownload:
         # <call>
         found_download = pip._download_dependencies(rooted_tmp_path, req_file, None)
         expected_download = [
-            url_download_info | {"kind": "url"},
+            url_download_info,
         ]
         assert found_download == expected_download
         assert pip_deps.path.is_dir()
@@ -841,24 +853,34 @@ class TestDownload:
             f"bacon-gitcommit-{GIT_REF}.tar.gz",
         ).path
 
-        vcs_download_info = {
+        vcs_download_info = VCSArtifact(
+            package="bacon",
+            path=vcs_download,
+            requirement_file=str(req_file.file_path.subpath_from_root),
+            missing_req_file_checksum=True,
+            build_dependency=False,
+            url=git_url,
+            host="github.com",
+            namespace="spam",
+            repo="bacon",
+            ref=GIT_REF,
+        )
+
+        mock_download_vcs_package.return_value = {
             "package": "bacon",
             "path": vcs_download,
-            "requirement_file": str(req_file.file_path.subpath_from_root),
-            # vcs deps *can't have* checksums
-            "missing_req_file_checksum": True,
-            "package_type": "",
+            "url": git_url,
+            "host": "github.com",
+            "namespace": "spam",
             "repo": "bacon",
-            # etc., not important for this test
+            "ref": GIT_REF,
         }
-
-        mock_download_vcs_package.return_value = deepcopy(vcs_download_info)
         # </setup>
 
         # <call>
         found_download = pip._download_dependencies(rooted_tmp_path, req_file, None)
         expected_download = [
-            vcs_download_info | {"kind": "vcs"},
+            vcs_download_info,
         ]
         assert found_download == expected_download
         assert pip_deps.path.is_dir()
@@ -911,22 +933,26 @@ class TestDownload:
 
         downloads = pip._download_from_requirement_files(rooted_tmp_path, [req_file1, req_file2])
         assert downloads == [
-            pypi_package1.download_info
-            | {
-                "kind": "pypi",
-                "requirement_file": str(req_file1.subpath_from_root),
-                "missing_req_file_checksum": True,
-                "package_type": "sdist",
-                "index_url": pypi_simple.PYPI_SIMPLE_ENDPOINT,
-            },
-            pypi_package2.download_info
-            | {
-                "kind": "pypi",
-                "requirement_file": str(req_file2.subpath_from_root),
-                "missing_req_file_checksum": True,
-                "package_type": "sdist",
-                "index_url": pypi_simple.PYPI_SIMPLE_ENDPOINT,
-            },
+            PyPIArtifact(
+                package="foo",
+                path=pypi_download1,
+                requirement_file=str(req_file1.subpath_from_root),
+                missing_req_file_checksum=True,
+                build_dependency=False,
+                index_url=pypi_simple.PYPI_SIMPLE_ENDPOINT,
+                package_type="sdist",
+                _version="1.0.0",
+            ),
+            PyPIArtifact(
+                package="bar",
+                path=pypi_download2,
+                requirement_file=str(req_file2.subpath_from_root),
+                missing_req_file_checksum=True,
+                build_dependency=False,
+                index_url=pypi_simple.PYPI_SIMPLE_ENDPOINT,
+                package_type="sdist",
+                _version="0.0.1",
+            ),
         ]
         _check_metadata_in_sdist.assert_has_calls(
             [mock.call(pypi_package1.path), mock.call(pypi_package2.path)], any_order=True
@@ -1022,28 +1048,28 @@ def test_resolve_pip(
     mock_metadata.return_value = ("foo", "1.0")
     mock_download.side_effect = [
         [
-            {
-                "version": "2.1",
-                "kind": "pypi",
-                "package": "bar",
-                "path": "some/path",
-                "requirement_file": str(req_file.subpath_from_root),
-                "missing_req_file_checksum": False,
-                "package_type": "sdist",
-                "index_url": pypi_simple.PYPI_SIMPLE_ENDPOINT,
-            }
+            PyPIArtifact(
+                package="bar",
+                path=Path("some/path"),
+                requirement_file=str(req_file.subpath_from_root),
+                missing_req_file_checksum=False,
+                build_dependency=False,
+                index_url=pypi_simple.PYPI_SIMPLE_ENDPOINT,
+                package_type="sdist",
+                _version="2.1",
+            )
         ],
         [
-            {
-                "version": "0.0.5",
-                "kind": "pypi",
-                "package": "baz",
-                "path": "another/path",
-                "requirement_file": str(build_req_file.subpath_from_root),
-                "missing_req_file_checksum": False,
-                "package_type": "sdist",
-                "index_url": pypi_simple.PYPI_SIMPLE_ENDPOINT,
-            }
+            PyPIArtifact(
+                package="baz",
+                path=Path("another/path"),
+                requirement_file=str(build_req_file.subpath_from_root),
+                missing_req_file_checksum=False,
+                build_dependency=False,
+                index_url=pypi_simple.PYPI_SIMPLE_ENDPOINT,
+                package_type="sdist",
+                _version="0.0.5",
+            )
         ],
     ]
     if custom_requirements:
@@ -1267,7 +1293,7 @@ def test_fetch_pip_source(
                 "kind": "url",
                 "requirement_file": "requirements.txt",
                 "missing_req_file_checksum": False,
-                "package_type": "",
+                "package_type": None,
             },
             {
                 "name": "baz",
@@ -1309,7 +1335,7 @@ def test_fetch_pip_source(
                 "kind": "url",
                 "requirement_file": "requirements.txt",
                 "missing_req_file_checksum": True,
-                "package_type": "",
+                "package_type": None,
             },
         ],
         "packages_containing_rust_code": [],
@@ -1575,7 +1601,7 @@ def test_fetch_pip_source_correctly_reraises_when_there_is_a_dependency_cargo_lo
                 "kind": "url",
                 "requirement_file": "requirements.txt",
                 "missing_req_file_checksum": False,
-                "package_type": "",
+                "package_type": None,
             },
             {
                 "name": "baz",
@@ -1617,7 +1643,7 @@ def test_fetch_pip_source_correctly_reraises_when_there_is_a_dependency_cargo_lo
                 "kind": "url",
                 "requirement_file": "requirements.txt",
                 "missing_req_file_checksum": True,
-                "package_type": "",
+                "package_type": None,
             },
         ],
         "packages_containing_rust_code": [CargoPackageInput(type="cargo", path=".")],

--- a/tests/unit/package_managers/pip/test_models.py
+++ b/tests/unit/package_managers/pip/test_models.py
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: GPL-3.0-only
+"""Tests for pip package manager data model."""
+
+from pathlib import Path
+
+from hermeto.core.package_managers.pip.models import (
+    URLArtifact,
+    VCSArtifact,
+)
+
+
+class TestVCSArtifact:
+    """Test VCSArtifact dataclass."""
+
+    def test_version_property(self) -> None:
+        """Test that VCS version property returns git+ format."""
+        artifact = VCSArtifact(
+            package="myproject",
+            path=Path("/tmp/myproject-gitcommit-abc123.tar.gz"),
+            requirement_file="requirements.txt",
+            missing_req_file_checksum=True,
+            build_dependency=False,
+            url="https://github.com/user/myproject.git",
+            host="github.com",
+            namespace="user",
+            repo="myproject",
+            ref="abc123",
+        )
+
+        expected_version = "git+https://github.com/user/myproject.git@abc123"
+
+        assert artifact.version == expected_version
+
+
+class TestURLArtifact:
+    """Test URLArtifact dataclass."""
+
+    def test_default_package_type_is_none(self) -> None:
+        """Test that default package_type is None."""
+        artifact = URLArtifact(
+            package="pkg",
+            path=Path("/tmp/pkg.tar.gz"),
+            requirement_file="requirements.txt",
+            missing_req_file_checksum=False,
+            build_dependency=False,
+            original_url="https://example.com/pkg.tar.gz",
+            url_with_hash="https://example.com/pkg.tar.gz#cachito_hash=sha256:abc",
+        )
+
+        assert artifact.package_type is None


### PR DESCRIPTION
Refactors Pip artifact handling to use typed dataclasses, improving code clarity

Closes [#1150](https://github.com/hermetoproject/hermeto/issues/1150)

Why:

Enhances type safety, readability, and maintainability across the Pip package manager's core logic. Currently we have an untyped, `dict[str, Any]` ("download_info"), which is never explicitly defined and is passed throughout the artifact handling. This is exceedingly difficult to work with if one has to dig deeply into the pip plumbing.

What:

Replaces untyped `dict[str, Any]` with a hierarchy of ArtifactDownload dataclasses (PyPIArtifact, VCSArtifact, URLArtifact) for representing downloaded package information. This massively simplifies many parts of the artifact-handling code.

Side-effects:

- public-facing `_resolve_pip` function maintains its dictionary-based return type
- any direct function calls internal to "hermeto/core/package_managers/pip/main.py" which previously expected `dict[str, Any]` would be effected by the new ArtifactDownload return (none that I'm aware of)
- However, further refactoring could (should) be done elsewhere (e.g. "hermeto/core/package_managers/pip/rust.py" in `filter_packages_with_rust_code()` whose `packages` arg still takes `list[dict[str, Any]]` as its type - in particular, this should be an easy fix)

How:

- New Data Models: Introduced "hermeto/core/package_managers/pip/models.py" defining `CommonArtifact` (base), `PyPIArtifact`, `VCSArtifact`, and `URLArtifact` dataclasses. These are Frozen dataclasses
- Type Signature Updates: Functions like `_process_req`, `_process_pypi_req`, `_process_vcs_req`, `_process_url_req`, `_download_dependencies`, and `_download_from_requirement_files` in "hermeto/core/package_managers/pip/main.py" now explicitly return ArtifactDownload types (or lists thereof) instead of `dict[str, Any]`
- Object Instantiation: Inside `_process_req`, dictionary manipulation has been replaced with the instantiation of the appropriate ArtifactDownload subclass based on the requirement kind
- Build Dependency Marking: Build dependencies are now marked using dataclasses.replace on immutable ArtifactDownload instances
- Output Reversion: The `_resolve_pip` function maps the properties of ArtifactDownload objects back to the original dictionary structure for its final return value, preserving external API consistency.
- Testing: New unit tests for the artifact models ("test_models.py") and updates to existing tests in "test_main.py" to reflect the new object structures are included.

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Ben Alkov <ben.alkov@redhat.com>
