### PR TITLE
fix(build): container image reporting wrong version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,27 @@
-*
+# Python cache
+__pycache__/
+*.pyc
 
-!.git/
-!.git_archival.txt
-!hermeto/
-!pyproject.toml
-!requirements.txt
-!MANIFEST.in
+# Environments
+venv/
+.venv/
+.env
+*.env
+
+# Distribution / packaging
+*.egg-info/
+build/
+dist/
+site/
+
+# Test and tool caches
+.nox/
+.pytest_cache/
+.mypy_cache/
+.coverage
+coverage.xml
+
+# Project outputs
+dest/
+hermeto-output/
+cachi2-output/


### PR DESCRIPTION
Ensure the image reports the actual image tag (e.g. 0.20.0) instead of a generic or post-release version string when running --version inside the container.

closes https://github.com/hermetoproject/hermeto/issues/822