### PR TITLE
fix(sbom): coerce empty Component version to None

### DIFF
--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -122,6 +122,14 @@ class Component(pydantic.BaseModel):
         """
         return self.purl
 
+    @pydantic.field_validator("version")
+    @classmethod
+    def _remove_empty_version(cls, version: str | None) -> str | None:
+        if not version:
+            return None
+
+        return version
+
     @pydantic.field_validator("properties")
     @classmethod
     def _add_found_by_property(cls, properties: list[Property]) -> list[Property]:

--- a/tests/unit/models/test_sbom.py
+++ b/tests/unit/models/test_sbom.py
@@ -1291,8 +1291,8 @@ class TestSPDXSbom:
                         SPDXPackage(
                             **{
                                 "name": "bytes",
-                                "SPDXID": "SPDXRef-Package-bytes-159a73f12ce40d92d01ba213c0ec5b442a301c842533acb3487aed9454ae17e7",
-                                "versionInfo": "",
+                                "SPDXID": "SPDXRef-Package-bytes-074b51b574e3fc5ce325ef4cb4fb463c1705e696a3e6bf4850b46ca7bd724ff4",
+                                "versionInfo": None,
                                 "externalRefs": [_gen_ref("pkg:golang/bytes")],
                                 "annotations": [STOCK_ANNOTATION],
                             }
@@ -1300,8 +1300,8 @@ class TestSPDXSbom:
                         SPDXPackage(
                             **{
                                 "name": "fmt",
-                                "SPDXID": "SPDXRef-Package-fmt-7e4d2ed76d4ea914ece19cdfb657d52dfe5c22193e31c8141497806571490439",
-                                "versionInfo": "",
+                                "SPDXID": "SPDXRef-Package-fmt-6de2ff54d8fade17788a93f13f1249fcb15d3970e74fedc3722be421ad800a0d",
+                                "versionInfo": None,
                                 "externalRefs": [_gen_ref("pkg:golang/fmt")],
                                 "annotations": [STOCK_ANNOTATION],
                             }
@@ -1356,10 +1356,10 @@ class TestSPDXSbom:
                     "relationships": [
                         DEFAULT_ROOT_RELATION,
                         _root_contains(
-                            "SPDXRef-Package-bytes-159a73f12ce40d92d01ba213c0ec5b442a301c842533acb3487aed9454ae17e7"
+                            "SPDXRef-Package-bytes-074b51b574e3fc5ce325ef4cb4fb463c1705e696a3e6bf4850b46ca7bd724ff4"
                         ),
                         _root_contains(
-                            "SPDXRef-Package-fmt-7e4d2ed76d4ea914ece19cdfb657d52dfe5c22193e31c8141497806571490439"
+                            "SPDXRef-Package-fmt-6de2ff54d8fade17788a93f13f1249fcb15d3970e74fedc3722be421ad800a0d"
                         ),
                         _root_contains(
                             "SPDXRef-Package-github.com-org-A-v1.0.0-8090f86e9eb851549de5f8391948c1df6a2c8976bfa33c3cbd82e917564ac94f"


### PR DESCRIPTION
Component used None to mean "version not specified". An empty string from package data was not normalized and could appear in the SBOM. Add a field validator that coerces empty/falsy version values to None so only None is used for unspecified versions and empty strings do not propagate.

Closes https://github.com/hermetoproject/hermeto/issues/990