### PR TITLE
Align tests with exit codes and exception types

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -246,6 +246,12 @@ could be to manually create an internal network (but you'll need root
 privileges): `sudo podman network create --internal isolated-network; sudo
 podman build --network isolated-network ...`.
 
+## Exit codes
+
+Hermeto uses a set of exit codes to signal different error conditions. These are
+internal only and serve informational purposes and hence may change in between
+releases, please do NOT depend on them!
+
 [buildah#4227]: https://github.com/containers/buildah/issues/4227
 [CycloneDX v1.6]: https://cyclonedx.org/docs/1.6/json
 [limited set]: https://github.com/hermetoproject/hermeto/blob/main/hermeto/core/models/sbom.py#L7-L13

--- a/hermeto/core/errors.py
+++ b/hermeto/core/errors.py
@@ -1,17 +1,82 @@
 # SPDX-License-Identifier: GPL-3.0-only
 import textwrap
+from enum import IntEnum, unique
 from pathlib import Path
-from typing import ClassVar, Iterable
+from typing import Any, ClassVar, Iterable
 
 from hermeto import APP_NAME
 
 _argument_not_specified = "__argument_not_specified__"
 
 
-class BaseError(Exception):
+@unique
+class ExitError(IntEnum):
+    """Hermeto process exit codes."""
+
+    ERR_OK = 0
+    ERR_BASE = 1
+    ERR_USAGE = 2
+    ERR_PATH_OUTSIDE_ROOT = 3
+    ERR_INVALID_INPUT = 4
+    ERR_PACKAGE_REJECTED = 5
+    ERR_NOT_A_GIT_REPO = 6
+    ERR_UNEXPECTED_FORMAT = 7
+    ERR_UNSUPPORTED_FEATURE = 8
+    ERR_EXECUTABLE_NOT_FOUND = 9
+    ERR_CHECKSUM_VERIFICATION_FAILED = 10
+    ERR_INVALID_CHECKSUM = 11
+    ERR_MISSING_CHECKSUM = 12
+    ERR_LOCKFILE_NOT_FOUND = 13
+    ERR_INVALID_LOCKFILE_FORMAT = 14
+    ERR_FETCH = 15
+    ERR_PACKAGE_MANAGER = 16
+    ERR_GIT = 17
+    ERR_GIT_REMOTE_NOT_FOUND = 18
+    ERR_GIT_INVALID_REVISION = 19
+    ERR_PACKAGE_WITH_CORRUPT_LOCKFILE_REJECTED = 20
+    ERR_UNSATISFIABLE_ARCHITECTURE_FILTER = 21
+    ERR_NOT_V1_LOCKFILE = 22
+
+
+class ErrorRegistryMeta(type):
+    """Meta class for registering errors."""
+
+    registry: ClassVar[dict[ExitError, "ErrorRegistryMeta"]] = {}
+
+    def __init__(
+        cls, name: str, bases: tuple[type, ...], namespace: dict[str, Any], **kwargs: Any
+    ) -> None:
+        """Register error subclasses that declare their own exit code.
+
+        Subclasses that set ``_exit_error`` explicitly are registered and
+        checked for uniqueness.  Subclasses that omit it simply inherit
+        the parent's exit code — this is intentional for internal /
+        intermediary exceptions that are caught in code and never
+        propagated to the user.
+
+        :param name: name of the error class
+        :param bases: base classes of the error class
+        :param namespace: namespace of the error class
+        :param kwargs: keyword arguments
+        """
+        super().__init__(name, bases, namespace, **kwargs)
+        # Subclasses without _exit_error inherit their parent's code and
+        # are not registered
+        if "_exit_error" in namespace:
+            exit_error = namespace["_exit_error"]
+            if exit_error in ErrorRegistryMeta.registry:
+                raise RuntimeError(
+                    f"{name} and {ErrorRegistryMeta.registry[exit_error].__name__} "
+                    f"both use {exit_error!r}"
+                )
+            ErrorRegistryMeta.registry[exit_error] = cls
+
+
+class BaseError(Exception, metaclass=ErrorRegistryMeta):
     """Root of the error hierarchy. Don't raise this directly, use more specific error types."""
 
     is_invalid_usage: ClassVar[bool] = False
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_BASE
     default_solution: ClassVar[str | None] = None
 
     def __init__(
@@ -31,6 +96,11 @@ class BaseError(Exception):
         else:
             self.solution = solution
 
+    @property
+    def exit_code(self) -> int:
+        """Return the exit code for this error."""
+        return self._exit_error.value
+
     def friendly_msg(self) -> str:
         """Return the user-friendly representation of this error."""
         msg = str(self)
@@ -43,10 +113,13 @@ class UsageError(BaseError):
     """Generic error for "Hermeto was used incorrectly." Prefer more specific errors."""
 
     is_invalid_usage: ClassVar[bool] = True
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_USAGE
 
 
 class PathOutsideRoot(UsageError):
     """Afer joining a subpath, the result is outside the root of a rooted path."""
+
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_PATH_OUTSIDE_ROOT
 
     def __init__(
         self,
@@ -75,6 +148,8 @@ class PathOutsideRoot(UsageError):
 class InvalidInput(UsageError):
     """User input was invalid."""
 
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_INVALID_INPUT
+
 
 class PackageRejected(UsageError):
     """The Application refused to process the package the user requested.
@@ -82,6 +157,8 @@ class PackageRejected(UsageError):
     a) The package appears invalid (e.g. missing go.mod for a Go module).
     b) The package does not meet our extra requirements (e.g. missing checksums).
     """
+
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_PACKAGE_REJECTED
 
     def __init__(self, reason: str, *, solution: str | None) -> None:
         """Initialize a Package Rejected error.
@@ -97,9 +174,13 @@ class PackageRejected(UsageError):
 class NotAGitRepo(PackageRejected):
     """A package turned out to be not a git repository."""
 
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_NOT_A_GIT_REPO
+
 
 class UnexpectedFormat(UsageError):
     """The Application failed to parse a file in the user's package (e.g. requirements.txt)."""
+
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_UNEXPECTED_FORMAT
 
     default_solution = (
         "Please check if the format of your file is correct.\n"
@@ -113,6 +194,8 @@ class UnsupportedFeature(UsageError):
     The requested feature might be valid, but application doesn't implement it.
     """
 
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_UNSUPPORTED_FEATURE
+
     default_solution = (
         f"If you need {APP_NAME} to support this feature, please contact the maintainers."
     )
@@ -120,6 +203,8 @@ class UnsupportedFeature(UsageError):
 
 class ExecutableNotFound(UsageError):
     """A required executable was not found in PATH."""
+
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_EXECUTABLE_NOT_FOUND
 
     def __init__(
         self,
@@ -145,6 +230,8 @@ class ExecutableNotFound(UsageError):
 class ChecksumVerificationFailed(PackageRejected):
     """Checksum verification failed for a file."""
 
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_CHECKSUM_VERIFICATION_FAILED
+
     def __init__(
         self,
         filename: Path | str,
@@ -166,6 +253,8 @@ class ChecksumVerificationFailed(PackageRejected):
 
 class InvalidChecksum(PackageRejected):
     """Provided checksum/hash/integrity is not valid data."""
+
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_INVALID_CHECKSUM
 
     def __init__(
         self,
@@ -189,6 +278,8 @@ class InvalidChecksum(PackageRejected):
 
 class MissingChecksum(InvalidChecksum):
     """Provided checksum/hash/integrity is missing"""
+
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_MISSING_CHECKSUM
 
     def __init__(
         self,
@@ -216,6 +307,8 @@ class MissingChecksum(InvalidChecksum):
 class LockfileNotFound(PackageRejected):
     """A required lockfile was not found."""
 
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_LOCKFILE_NOT_FOUND
+
     def __init__(
         self,
         files: Path | str | Iterable[Path | str],
@@ -240,6 +333,8 @@ class LockfileNotFound(PackageRejected):
 class InvalidLockfileFormat(PackageRejected):
     """Lockfile format is invalid or cannot be parsed."""
 
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_INVALID_LOCKFILE_FORMAT
+
     def __init__(
         self,
         lockfile_path: Path | str,
@@ -262,6 +357,8 @@ class InvalidLockfileFormat(PackageRejected):
 class FetchError(BaseError):
     """The Application failed to fetch a dependency or other data needed to process a package."""
 
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_FETCH
+
     default_solution = (
         "The error might be intermittent, please try again.\n"
         f"If the issue seems to be on the {APP_NAME} side, please contact the maintainers."
@@ -274,6 +371,8 @@ class PackageManagerError(BaseError):
     Maybe some configuration is invalid, maybe the package manager was unable to fetch a dependency,
     maybe the error is intermittent. We don't really know, but we do at least log the stderr.
     """
+
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_PACKAGE_MANAGER
 
     def __init__(
         self,
@@ -304,6 +403,8 @@ class PackageManagerError(BaseError):
 
 class GitError(BaseError):
     """Base class for Git operation failures."""
+
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_GIT
 
     def __init__(
         self,
@@ -342,6 +443,10 @@ class GitError(BaseError):
 class GitRemoteNotFoundError(GitError):
     """A Git remote with the specified name does not exist."""
 
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_GIT_REMOTE_NOT_FOUND
+
 
 class GitInvalidRevisionError(GitError):
     """Invalid Git revision (commits, branches, tags, revision specifiers)."""
+
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_GIT_INVALID_REVISION

--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, ClassVar, NamedTuple
 from urllib.parse import urlparse, urlunparse
 
 import tomlkit
@@ -18,6 +18,7 @@ from hermeto import APP_NAME
 from hermeto.core.config import get_config
 from hermeto.core.constants import Mode
 from hermeto.core.errors import (
+    ExitError,
     LockfileNotFound,
     NotAGitRepo,
     PackageManagerError,
@@ -45,6 +46,8 @@ class CargoVendorResult(NamedTuple):
 
 class PackageWithCorruptLockfileRejected(PackageRejected):
     """Package lock file does not match package config."""
+
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_PACKAGE_WITH_CORRUPT_LOCKFILE_REJECTED
 
     def __init__(self, package_path: str) -> None:
         """Initialize the error."""

--- a/hermeto/core/package_managers/rpm/binary_filters.py
+++ b/hermeto/core/package_managers/rpm/binary_filters.py
@@ -1,16 +1,18 @@
 # SPDX-License-Identifier: GPL-3.0-only
 """RPM-specific binary package filtering."""
 
-from typing import Any
+from typing import Any, ClassVar
 
 from hermeto.core.binary_filters import BinaryPackageFilter
-from hermeto.core.errors import PackageRejected
+from hermeto.core.errors import ExitError, PackageRejected
 from hermeto.core.models.input import BINARY_FILTER_ALL, RpmBinaryFilters
 from hermeto.core.package_managers.rpm.redhat import LockfileArch
 
 
 class UnsatisfiableArchitectureFilter(PackageRejected):
     """RPM architecture filter constraints cannot be satisfied by lockfile architectures."""
+
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_UNSATISFIABLE_ARCHITECTURE_FILTER
 
 
 class RPMArchitectureFilter(BinaryPackageFilter):

--- a/hermeto/core/package_managers/yarn_classic/main.py
+++ b/hermeto/core/package_managers/yarn_classic/main.py
@@ -3,10 +3,15 @@ import logging
 from collections import defaultdict
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from hermeto import APP_NAME
-from hermeto.core.errors import LockfileNotFound, PackageManagerError, PackageRejected
+from hermeto.core.errors import (
+    ExitError,
+    LockfileNotFound,
+    PackageManagerError,
+    PackageRejected,
+)
 from hermeto.core.models.input import Request
 from hermeto.core.models.output import Component, EnvironmentVariable, RequestOutput
 from hermeto.core.models.property_semantics import PropertySet
@@ -40,6 +45,8 @@ _yarn_classic_pattern = "yarn lockfile v1"  # See [yarn_classic_trait].
 
 class NotV1Lockfile(PackageRejected):
     """Indicate that a lockfile is of wrong tyrpoe."""
+
+    _exit_error: ClassVar[ExitError] = ExitError.ERR_NOT_V1_LOCKFILE
 
     def __init__(self, package_path: Any) -> None:
         """Initialize a Missing Lockfile error."""

--- a/hermeto/interface/cli.py
+++ b/hermeto/interface/cli.py
@@ -123,7 +123,7 @@ def _bail_out_with_error(e: BaseError) -> None:
     """Report and error and set correct exit code."""
     log.error("%s: %s", type(e).__name__, str(e).replace("\n", r"\n"))
     print(f"Error: {type(e).__name__}: {e.friendly_msg()}", file=sys.stderr)
-    raise typer.Exit(2 if e.is_invalid_usage else 1)
+    raise typer.Exit(e.exit_code)
 
 
 def handle_errors(cmd: Callable[..., None]) -> Callable[..., None]:

--- a/tests/integration/test_bundler.py
+++ b/tests/integration/test_bundler.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from hermeto.core.errors import ExitError
+
 from . import utils
 
 log = logging.getLogger(__name__)
@@ -18,7 +20,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "bundler"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_LOCKFILE_NOT_FOUND,
                 expected_output="Required files not found:",
             ),
             id="bundler_missing_gemfile",
@@ -29,7 +31,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "bundler"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_LOCKFILE_NOT_FOUND,
                 expected_output="Required files not found:",
             ),
             id="bundler_missing_lockfile",
@@ -40,7 +42,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "bundler"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=1,
+                expected_error=ExitError.ERR_PACKAGE_MANAGER,
                 expected_output="Failed to parse",
             ),
             id="bundler_missing_git_revision",
@@ -72,8 +74,6 @@ def test_bundler_packages(
                 packages=({"path": ".", "type": "bundler", "binary": {}},),
                 check_output=True,
                 check_deps_checksums=False,
-                expected_exit_code=0,
-                expected_output="",
             ),
             [],  # No additional commands are run to verify the build
             [],
@@ -85,8 +85,6 @@ def test_bundler_packages(
                 packages=({"path": ".", "type": "bundler", "binary": {}},),
                 check_output=True,
                 check_deps_checksums=False,
-                expected_exit_code=0,
-                expected_output="",
             ),
             [],  # No additional commands are run to verify the build
             [],

--- a/tests/integration/test_cargo.py
+++ b/tests/integration/test_cargo.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from hermeto.core.errors import ExitError
+
 from . import utils
 
 log = logging.getLogger(__name__)
@@ -18,8 +20,6 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "cargo"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=0,
-                expected_output="",
             ),
             id="cargo_just_a_crate_dependency",
         ),
@@ -29,8 +29,6 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "cargo"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=0,
-                expected_output="",
             ),
             id="cargo_just_a_git_dependency",
         ),
@@ -40,8 +38,6 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "cargo"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=0,
-                expected_output="",
             ),
             id="cargo_mixed_git_crate_dependency",
         ),
@@ -51,8 +47,6 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "cargo"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=0,
-                expected_output="",
             ),
             id="cargo_uses_resolver_v3",
         ),
@@ -62,7 +56,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "cargo"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_LOCKFILE_NOT_FOUND,
                 expected_output="Cargo.lock not found",
             ),
             id="cargo_missing_lockfile",
@@ -74,7 +68,6 @@ log = logging.getLogger(__name__)
                 global_flags=["--mode", "permissive"],
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="cargo_missing_lockfile_permissive_mode",
@@ -106,8 +99,6 @@ def test_cargo_packages(
                 packages=({"path": ".", "type": "cargo"},),
                 check_output=True,
                 check_deps_checksums=False,
-                expected_exit_code=0,
-                expected_output="",
             ),
             [],  # No additional commands are run to verify the build
             [],
@@ -119,7 +110,6 @@ def test_cargo_packages(
                 packages=({"path": ".", "type": "cargo"},),
                 check_output=True,
                 check_deps_checksums=False,
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             ["foo"],

--- a/tests/integration/test_generic.py
+++ b/tests/integration/test_generic.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 import pytest
 
+from hermeto.core.errors import ExitError
+
 from . import utils
 
 
@@ -15,7 +17,7 @@ from . import utils
                 packages=({"path": ".", "type": "generic"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=1,
+                expected_error=ExitError.ERR_FETCH,
                 expected_output="Unsuccessful download",
             ),
             id="generic_file_not_reachable",
@@ -52,7 +54,6 @@ def test_generic_fetcher(
                 packages=({"path": ".", "type": "generic"},),
                 check_output=True,
                 check_deps_checksums=True,
-                expected_exit_code=0,
             ),
             ["ls", "/deps"],
             ["archive.zip\nv1.0.0.zip\n"],
@@ -64,7 +65,6 @@ def test_generic_fetcher(
                 packages=({"path": ".", "type": "generic"},),
                 check_output=True,
                 check_deps_checksums=True,
-                expected_exit_code=0,
             ),
             [],
             ["Apache Ant(TM) version 1.10.14"],

--- a/tests/integration/test_gomod.py
+++ b/tests/integration/test_gomod.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from hermeto.core.errors import ExitError
+
 from . import utils
 
 log = logging.getLogger(__name__)
@@ -17,7 +19,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="gomod/with-deps",
                 packages=({"path": ".", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="gomod_with_deps",
@@ -26,7 +27,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="gomod/without-deps",
                 packages=({"path": ".", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="gomod_without_deps",
@@ -37,7 +37,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="gomod/correct-vendor-passes-vendor-check",
                 packages=({"path": ".", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="gomod_correct_vendor_passes_vendor_check",
@@ -47,7 +46,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="gomod/correct-vendor-in-submodule-passes-vendor-check",
                 packages=({"path": "integration-tests", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="gomod_correct_vendor_in_submodule_passes_vendor_check",
@@ -59,7 +57,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "gomod"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_PACKAGE_REJECTED,
                 expected_output=(
                     "PackageRejected: The content of the vendor directory is not "
                     "consistent with go.mod. Please check the logs for more details"
@@ -74,7 +72,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": "integration-tests", "type": "gomod"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_PACKAGE_REJECTED,
                 expected_output=(
                     "PackageRejected: The content of the vendor directory is not "
                     "consistent with go.mod. Please check the logs for more details"
@@ -87,7 +85,6 @@ log = logging.getLogger(__name__)
                 branch="gomod/wrong-vendor-fails-vendor-check",
                 global_flags=["--mode=permissive"],
                 packages=({"path": ".", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="gomod_wrong_vendor_passes_vendor_check_in_permissive_mode",
@@ -99,7 +96,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "gomod"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_PACKAGE_REJECTED,
                 expected_output=(
                     "PackageRejected: The content of the vendor directory is not "
                     "consistent with go.mod. Please check the logs for more details"
@@ -112,7 +109,6 @@ log = logging.getLogger(__name__)
                 branch="gomod/empty-vendor-fails-vendor-check",
                 global_flags=["--mode=permissive"],
                 packages=({"path": ".", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="gomod_empty_vendor_passes_vendor_check_in_permissive_mode",
@@ -122,7 +118,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="gomod/local-deps",
                 packages=({"path": ".", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="gomod_local_deps",
@@ -135,7 +130,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="gomod/generate-imported",
                 packages=({"path": ".", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="gomod_generate_imported",
@@ -150,7 +144,6 @@ log = logging.getLogger(__name__)
                     {"path": "spam-module", "type": "gomod"},
                     {"path": "eggs-module", "type": "gomod"},
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="gomod_missing_checksums",
@@ -160,7 +153,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="gomod/workspaces",
                 packages=({"path": "./workspace_modules/hello", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="gomod_workspaces",
@@ -198,7 +190,6 @@ def test_gomod_packages(
             utils.TestParameters(
                 branch="gomod/e2e-1.18",
                 packages=({"path": ".", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             ["retrodep", "--help"],
@@ -212,7 +203,6 @@ def test_gomod_packages(
             utils.TestParameters(
                 branch="gomod/e2e-1.21",
                 packages=({"path": ".", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             ["retrodep", "--help"],
@@ -229,7 +219,6 @@ def test_gomod_packages(
                     {"path": "spam-module", "type": "gomod"},
                     {"path": "eggs-module", "type": "gomod"},
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             [],  # check using CMD defined in Dockerfile
@@ -242,7 +231,6 @@ def test_gomod_packages(
             utils.TestParameters(
                 branch="gomod/e2e-1.21-dirty",
                 packages=({"path": "twenty", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             [],  # check using CMD defined in Dockerfile
@@ -256,7 +244,6 @@ def test_gomod_packages(
             utils.TestParameters(
                 branch="gomod/e2e-1.22-workspace-vendoring",
                 packages=({"path": "hi/hiii", "type": "gomod"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             [],  # check using CMD defined in Dockerfile
@@ -271,7 +258,6 @@ def test_gomod_packages(
                     {"path": "vendored-module", "type": "gomod"},
                     {"path": "non-vendored-module", "type": "gomod"},
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             [],  # check using CMD defined in Dockerfile
@@ -286,7 +272,6 @@ def test_gomod_packages(
                     {"path": "non-vendored-module", "type": "gomod"},
                     {"path": "vendored-module", "type": "gomod"},
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             [],  # check using CMD defined in Dockerfile

--- a/tests/integration/test_legacy.py
+++ b/tests/integration/test_legacy.py
@@ -38,8 +38,6 @@ def test_help(hermeto_image: utils.HermetoImage, tmp_path: Path) -> None:
                 packages=({"path": ".", "type": "cargo"},),
                 check_output=True,
                 check_deps_checksums=False,
-                expected_exit_code=0,
-                expected_output="",
             ),
             [],  # No additional commands are run to verify the build
             [],

--- a/tests/integration/test_multiple.py
+++ b/tests/integration/test_multiple.py
@@ -19,7 +19,6 @@ from . import utils
                     {"type": "rpm"},
                 ),
                 flags=[],
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             [],

--- a/tests/integration/test_pip.py
+++ b/tests/integration/test_pip.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 from hermeto import APP_NAME
+from hermeto.core.errors import ExitError
 
 from . import utils
 
@@ -19,7 +20,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="pip/without-deps",
                 packages=({"path": ".", "type": "pip"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="pip_without_deps",
@@ -28,7 +28,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="pip/full-hashes",
                 packages=({"path": ".", "type": "pip"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="pip_full_hashes",
@@ -37,7 +36,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="pip/missing-hashes",
                 packages=({"path": ".", "type": "pip"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="pip_missing_hashes",
@@ -49,7 +47,6 @@ log = logging.getLogger(__name__)
                     {"path": "first", "type": "pip"},
                     {"path": "second", "type": "pip"},
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="pip_multiple_packages",
@@ -61,7 +58,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "pip"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_UNSUPPORTED_FEATURE,
                 expected_output=(
                     "UnsupportedFeature: Direct references with 'file' scheme are not supported, "
                     "'file:///tmp/packages.zip'\n  "
@@ -77,7 +74,6 @@ log = logging.getLogger(__name__)
                     {"path": ".", "type": "pip"},
                     {"path": "subpath1/subpath2", "type": "pip"},
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="pip_no_metadata",
@@ -86,7 +82,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="pip/yanked",
                 packages=({"path": ".", "type": "pip"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="pip_yanked",
@@ -95,7 +90,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="pip/no-wheels",
                 packages=({"path": ".", "type": "pip", "binary": {}},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="pip_no_wheels",
@@ -106,7 +100,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "pip"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_PACKAGE_REJECTED,
                 expected_output="Error: PackageRejected: No distributions found",
             ),
             id="pip_no_sdists",
@@ -115,7 +109,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="pip/custom-index",
                 packages=({"path": ".", "type": "pip", "binary": {}},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
                 netrc_content="machine 127.0.0.1 login hermeto-user password hermeto-pass",
             ),
@@ -132,7 +125,6 @@ log = logging.getLogger(__name__)
                 global_flags=["--mode", "permissive"],
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="pip_rust_extension_lock_and_config_mismatch_permissive",
@@ -144,7 +136,7 @@ log = logging.getLogger(__name__)
                 global_flags=["--mode", "strict"],
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_PACKAGE_WITH_CORRUPT_LOCKFILE_REJECTED,
                 expected_output="PackageWithCorruptLockfileRejected",
             ),
             id="pip_rust_extension_lock_and_config_mismatch_strict",
@@ -153,7 +145,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="pip/rust_dependency_unusual_cargo_toml_location",
                 packages=({"path": ".", "type": "pip"},),
-                expected_exit_code=0,
                 check_output=False,
                 check_deps_checksums=False,
                 expected_output="All dependencies fetched successfully",
@@ -199,7 +190,6 @@ def test_pip_packages(
                         "requirements_build_files": ["requirements-build.txt"],
                     },
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             ["python3", "/app/src/test_package_cachi2/main.py"],
@@ -217,7 +207,6 @@ def test_pip_packages(
                         "binary": {"py_version": 312, "platform": "^(any|manylinux.*)$"},
                     },
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             ["python3", "/app/package/main.py"],
@@ -235,8 +224,6 @@ def test_pip_packages(
                 flags=[],
                 check_output=True,
                 check_deps_checksums=False,
-                expected_exit_code=0,
-                expected_output="",
             ),
             # Invocation will fail if there was a failure to build the dependencies.
             ["python3", "/app/src/test_package_cachi2/main.py"],

--- a/tests/integration/test_rpm.py
+++ b/tests/integration/test_rpm.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from hermeto.core.errors import ExitError
 from hermeto.interface.cli import DEFAULT_OUTPUT
 
 from . import utils
@@ -20,7 +21,6 @@ from . import utils
                 packages=({"path": ".", "type": "rpm"},),
                 check_output=True,
                 check_deps_checksums=False,
-                expected_exit_code=0,
             ),
             id="rpm_missing_checksum",
         ),
@@ -30,7 +30,7 @@ from . import utils
                 packages=({"path": ".", "type": "rpm"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_CHECKSUM_VERIFICATION_FAILED,
                 expected_output="Unmatched checksum",
             ),
             id="rpm_unmatched_checksum",
@@ -41,7 +41,7 @@ from . import utils
                 packages=({"path": ".", "type": "rpm"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_CHECKSUM_VERIFICATION_FAILED,
                 expected_output="Unexpected file size",
             ),
             id="rpm_unexpected_size",
@@ -55,7 +55,6 @@ from . import utils
                 ),
                 check_output=True,
                 check_deps_checksums=False,
-                expected_exit_code=0,
             ),
             id="rpm_multiple_packages",
         ),
@@ -65,7 +64,6 @@ from . import utils
                 packages=({"path": ".", "type": "rpm"},),
                 check_output=True,
                 check_deps_checksums=False,
-                expected_exit_code=0,
             ),
             id="rpm_multiple_archs",
         ),
@@ -75,7 +73,6 @@ from . import utils
                 packages=({"path": ".", "type": "rpm", "binary": {"arch": "x86_64"}},),
                 check_output=True,
                 check_deps_checksums=False,
-                expected_exit_code=0,
             ),
             id="rpm_multiple_archs_with_filtering",
         ),
@@ -98,7 +95,6 @@ from . import utils
                 ),
                 check_output=True,
                 check_deps_checksums=False,
-                expected_exit_code=0,
             ),
             id="rpm_dnf_tls_client_auth",
             marks=pytest.mark.skipif(
@@ -115,7 +111,6 @@ from . import utils
                 ),
                 check_output=True,
                 check_deps_checksums=False,
-                expected_exit_code=0,
             ),
             id="rpm_multiple_packages_summary",
         ),
@@ -158,7 +153,6 @@ def test_rpm_packages(
                 packages=({"path": ".", "type": "rpm"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=0,
             ),
             id="rpm_repo_file",
         ),
@@ -235,7 +229,6 @@ def test_repo_files(
                         },
                     },
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             ["vim", "--version"],
@@ -253,7 +246,6 @@ def test_repo_files(
                         "type": "rpm",
                     },
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             ["vim", "--version"],
@@ -271,7 +263,6 @@ def test_repo_files(
                         "type": "rpm",
                     },
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             ["ab", "-V"],

--- a/tests/integration/test_yarn.py
+++ b/tests/integration/test_yarn.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from hermeto.core.errors import ExitError
+
 from . import utils
 
 log = logging.getLogger(__name__)
@@ -18,7 +20,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "yarn"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_PACKAGE_REJECTED,
                 expected_output="PackageRejected: Yarn zero install detected, PnP zero installs are unsupported by hermeto",
             ),
             id="yarn_zero_installs",
@@ -29,7 +31,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "yarn"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_UNSUPPORTED_FEATURE,
                 expected_output="UnsupportedFeature: Found 8 unsupported dependencies, more details in the logs.",
             ),
             id="yarn_disallowed_protocols",
@@ -38,7 +40,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="yarn/correct-version-is-installed-by-corepack",
                 packages=({"path": ".", "type": "yarn"},),
-                expected_exit_code=0,
                 expected_output="Processing the request using yarn@3.6.1",
             ),
             id="yarn_correct_version_is_installed_by_corepack",
@@ -47,7 +48,6 @@ log = logging.getLogger(__name__)
             utils.TestParameters(
                 branch="yarn/v4",
                 packages=({"path": ".", "type": "yarn"},),
-                expected_exit_code=0,
                 expected_output="Processing the request using yarn@4.5.2",
             ),
             id="yarn_v4",
@@ -58,7 +58,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "yarn"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=1,
+                expected_error=ExitError.ERR_PACKAGE_MANAGER,
                 expected_output="The lockfile would have been modified by this install, which is explicitly forbidden.",
             ),
             id="yarn_immutable_installs",
@@ -69,7 +69,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "yarn"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=1,
+                expected_error=ExitError.ERR_PACKAGE_MANAGER,
                 expected_output="typescript@npm:5.3.3: The remote archive doesn't match the expected checksum",
             ),
             id="yarn_incorrect_checksum",
@@ -80,7 +80,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "yarn"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=2,
+                expected_error=ExitError.ERR_LOCKFILE_NOT_FOUND,
                 expected_output="Required files not found:",
             ),
             id="yarn_missing_lockfile",
@@ -115,7 +115,6 @@ def test_yarn_packages(
             utils.TestParameters(
                 branch="yarn/e2e",
                 packages=({"path": ".", "type": "yarn"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             ["yarn", "berryscary"],
@@ -129,7 +128,6 @@ def test_yarn_packages(
                     {"path": "first-pkg", "type": "yarn"},
                     {"path": "second-pkg", "type": "yarn"},
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             ["yarn", "node", "index.js"],

--- a/tests/integration/test_yarn_classic.py
+++ b/tests/integration/test_yarn_classic.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import pytest
 
+from hermeto.core.errors import ExitError
+
 from . import utils
 
 log = logging.getLogger(__name__)
@@ -18,7 +20,6 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "yarn"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=0,
                 expected_output="Processing the request using yarn@1.22.",
             ),
             id="yarn_classic_corepack_ignored",
@@ -29,7 +30,6 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "yarn"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=0,
                 expected_output="Processing the request using yarn@1.22.",
             ),
             id="yarn_classic_yarn_path_ignored",
@@ -40,7 +40,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "yarn"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=1,
+                expected_error=ExitError.ERR_PACKAGE_MANAGER,
                 expected_output='Integrity check failed for "@colors/colors"',
             ),
             id="yarn_classic_invalid_checksum",
@@ -51,7 +51,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "yarn"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=1,
+                expected_error=ExitError.ERR_PACKAGE_MANAGER,
                 expected_output="Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.",
             ),
             id="yarn_classic_updating_frozen_lockfile_fails",
@@ -62,7 +62,6 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "yarn"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             id="yarn_classic_lifecycle_scripts",
@@ -73,7 +72,7 @@ log = logging.getLogger(__name__)
                 packages=({"path": ".", "type": "yarn"},),
                 check_output=False,
                 check_deps_checksums=False,
-                expected_exit_code=1,
+                expected_error=ExitError.ERR_PACKAGE_MANAGER,
                 expected_output="Tarball collision in the offline mirror",
             ),
             id="yarn_classic_offline_mirror_collision",
@@ -108,7 +107,6 @@ def test_yarn_classic_packages(
             utils.TestParameters(
                 branch="yarn-classic/e2e",
                 packages=({"path": ".", "type": "yarn"},),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             ["yarn", "node", "index.js"],
@@ -122,7 +120,6 @@ def test_yarn_classic_packages(
                     {"path": "first-pkg", "type": "yarn"},
                     {"path": "second-pkg", "type": "yarn"},
                 ),
-                expected_exit_code=0,
                 expected_output="All dependencies fetched successfully",
             ),
             ["yarn", "node", "index.js"],

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -18,6 +18,7 @@ import requests
 import yaml
 
 from hermeto import APP_NAME
+from hermeto.core.errors import ExitError
 from hermeto.core.scm import GitRepo
 from hermeto.core.type_aliases import StrPath
 from hermeto.interface.cli import DEFAULT_OUTPUT
@@ -92,7 +93,7 @@ class TestParameters:
     packages: tuple[dict[str, Any], ...]
     check_output: bool = True
     check_deps_checksums: bool = True
-    expected_exit_code: int = 0
+    expected_error: ExitError = ExitError.ERR_OK
     expected_output: str = ""
     global_flags: list[str] = field(default_factory=list)
     flags: list[str] = field(default_factory=list)
@@ -468,13 +469,23 @@ def fetch_deps_and_check_output(
         podman_flags=(podman_flags or []) + _env_to_engine_flags(merged_env),
         netrc_content=test_params.netrc_content,
     )
-    assert exit_code == test_params.expected_exit_code, (
-        f"Fetching deps ended with unexpected exitcode: {exit_code} != "
-        f"{test_params.expected_exit_code}, output-cmd: {output}"
+
+    def _fmt(code: int) -> str:
+        if code == 0:
+            return "0"
+        try:
+            return f"{code} ({ExitError(code).name})"
+        except ValueError:
+            return f"{code} (unknown exit code)"
+
+    assert exit_code == test_params.expected_error.value, (
+        f"Fetching deps ended with unexpected exitcode: {_fmt(exit_code)}"
+        f" != {_fmt(test_params.expected_error.value)}, output-cmd: {output}"
     )
-    assert test_params.expected_output in str(output), (
-        f"Expected msg {test_params.expected_output} was not found in cmd output: {output}"
-    )
+    if test_params.expected_output:
+        assert test_params.expected_output in str(output), (
+            f"Expected msg {test_params.expected_output} was not found in cmd output: {output}"
+        )
 
     if test_params.check_output:
         build_config = _load_json_or_yaml(output_dir.joinpath(".build-config.json"))

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -20,6 +20,7 @@ import yaml
 import hermeto.core.config as config_file
 from hermeto import APP_NAME
 from hermeto.core.constants import Mode
+from hermeto.core.errors import ExitError
 from hermeto.core.models.input import Request
 from hermeto.core.models.output import (
     BuildConfig,
@@ -68,10 +69,12 @@ def invoke_expecting_sucess(app: typer.Typer, args: list[str]) -> typer.testing.
     return result
 
 
-def invoke_expecting_invalid_usage(app: typer.Typer, args: list[str]) -> typer.testing.Result:
+def invoke_expecting_invalid_usage(
+    app: typer.Typer, args: list[str], expected_error: ExitError
+) -> typer.testing.Result:
     result = runner.invoke(app, args)
-    assert result.exit_code == 2, (
-        f"expected exit_code=2, got exit_code={result.exit_code}\ncommand output:\n{result.output}"
+    assert result.exit_code == expected_error.value, (
+        f"expected exit_code={expected_error.value}, got exit_code={result.exit_code}\ncommand output:\n{result.output}"
     )
     return result
 
@@ -148,25 +151,28 @@ class TestTopLevelOpts:
             invoke_expecting_sucess(app, args)
 
     @pytest.mark.parametrize(
-        "file_create, file, file_text, error_expectation",
+        "file_create, file, file_text, error_expectation, expected_error",
         [
             (
                 True,
                 "config.yaml",
                 "goproxy_url",
                 "Error: InvalidInput: 1 validation error in Hermeto configuration:\n: Input should be a valid dictionary or instance of Config",
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 True,
                 "config.yaml",
                 "non_existing_option: True",
                 "Error: InvalidInput: 1 validation error in Hermeto configuration:\nnon_existing_option: Extra inputs are not permitted\n",
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 False,
                 "config.yaml",
                 "",
                 "Invalid value for '--config-file': File 'config.yaml' does not exist.",
+                ExitError.ERR_USAGE,
             ),
         ],
     )
@@ -176,6 +182,7 @@ class TestTopLevelOpts:
         file: str,
         file_text: str,
         error_expectation: str,
+        expected_error: ExitError,
         tmp_cwd: Path,
     ) -> None:
         if file_create:
@@ -184,7 +191,7 @@ class TestTopLevelOpts:
 
         args = ["--config-file", file, "fetch-deps", "gomod"]
         with mock_fetch_deps():
-            result = invoke_expecting_invalid_usage(app, args)
+            result = invoke_expecting_invalid_usage(app, args, expected_error)
             assert error_expectation in result.output
 
     @pytest.mark.parametrize(
@@ -220,7 +227,7 @@ class TestTopLevelOpts:
     def test_mode_option_is_not_valid(self, mode: str) -> None:
         args = ["--mode", mode, "fetch-deps", "gomod"]
         with mock_fetch_deps():
-            result = invoke_expecting_invalid_usage(app, args)
+            result = invoke_expecting_invalid_usage(app, args, ExitError.ERR_USAGE)
             assert f"Invalid value for '--mode': '{mode}' is not one of" in result.output
 
     @pytest.mark.parametrize(
@@ -248,7 +255,7 @@ class TestTopLevelOpts:
 
     def test_unknown_loglevel(self, tmp_cwd: Path) -> None:
         args = ["--log-level=unknown", "fetch-deps", "gomod"]
-        result = invoke_expecting_invalid_usage(app, args)
+        result = invoke_expecting_invalid_usage(app, args, ExitError.ERR_USAGE)
         assert "Invalid value for '--log-level': 'unknown' is not one of" in result.output
 
 
@@ -319,11 +326,13 @@ class TestFetchDeps:
     def test_invalid_paths(self, path_args: list[str], expect_error: str, tmp_cwd: Path) -> None:
         tmp_cwd.joinpath("not-a-directory").touch()
 
-        result = invoke_expecting_invalid_usage(app, ["fetch-deps", *path_args])
+        result = invoke_expecting_invalid_usage(
+            app, ["fetch-deps", *path_args], ExitError.ERR_USAGE
+        )
         assert expect_error in result.output
 
     def test_no_packages(self) -> None:
-        result = invoke_expecting_invalid_usage(app, ["fetch-deps"])
+        result = invoke_expecting_invalid_usage(app, ["fetch-deps"], ExitError.ERR_USAGE)
         assert "Missing argument 'PKG'" in result.output
 
     @pytest.mark.parametrize(
@@ -467,16 +476,18 @@ class TestFetchDeps:
             invoke_expecting_sucess(app, ["fetch-deps", str(input_file)])
 
     @pytest.mark.parametrize(
-        "package_arg, expect_error_lines",
+        "package_arg, expect_error_lines, expected_error",
         [
             # Invalid JSON
             (
                 "{notjson}",
                 ["'PKG': Looks like JSON but is not valid JSON: '{notjson}'"],
+                ExitError.ERR_USAGE,
             ),
             (
                 "[notjson]",
                 ["'PKG': Looks like JSON but is not valid JSON: '[notjson]'"],
+                ExitError.ERR_USAGE,
             ),
             # Invalid package type
             (
@@ -486,6 +497,7 @@ class TestFetchDeps:
                     "packages -> 0",
                     "Requested backend type 'idk' doesn't match expected ones: 'bundler', 'cargo', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn'",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 '[{"type": "idk"}]',
@@ -494,6 +506,7 @@ class TestFetchDeps:
                     "packages -> 0",
                     "Requested backend type 'idk' doesn't match expected ones: 'bundler', 'cargo', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn'",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 '{"packages": [{"type": "idk"}]}',
@@ -502,6 +515,7 @@ class TestFetchDeps:
                     "packages -> 0",
                     "Requested backend type 'idk' doesn't match expected ones: 'bundler', 'cargo', 'generic', 'gomod', 'npm', 'pip', 'rpm', 'yarn'",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             # Missing package type
             (
@@ -511,6 +525,7 @@ class TestFetchDeps:
                     "packages -> 0",
                     "Unable to extract tag using discriminator 'type'",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 '[{"type": "gomod"}, {}]',
@@ -519,6 +534,7 @@ class TestFetchDeps:
                     "packages -> 1",
                     "Unable to extract tag using discriminator 'type'",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 '{"packages": [{}]}',
@@ -527,6 +543,7 @@ class TestFetchDeps:
                     "packages -> 0",
                     "Unable to extract tag using discriminator 'type'",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             # Invalid path
             (
@@ -536,6 +553,7 @@ class TestFetchDeps:
                     "packages -> 0 -> gomod -> path",
                     "Value error, path must be relative: /absolute",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 '{"type": "gomod", "path": "weird/../subpath"}',
@@ -544,6 +562,7 @@ class TestFetchDeps:
                     "packages -> 0 -> gomod -> path",
                     "Value error, path contains ..: weird/../subpath",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 '{"type": "gomod", "path": "suspicious-symlink"}',
@@ -552,6 +571,7 @@ class TestFetchDeps:
                     "packages",
                     "Value error, package path (a symlink?) leads outside source directory: suspicious-symlink",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 '{"type": "gomod", "path": "no-such-dir"}',
@@ -560,6 +580,7 @@ class TestFetchDeps:
                     "packages",
                     "Value error, package path does not exist (or is not a directory): no-such-dir",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             # Extra fields
             (
@@ -569,6 +590,7 @@ class TestFetchDeps:
                     "packages -> 0 -> gomod -> what",
                     "Extra inputs are not permitted",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             # Invalid format using 'packages' key
             (
@@ -578,6 +600,7 @@ class TestFetchDeps:
                     "packages",
                     "Input should be a valid list",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 '{"packages": {"type":"gomod"}}',
@@ -586,6 +609,7 @@ class TestFetchDeps:
                     "packages",
                     "Input should be a valid list",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 '{"packages": ["gomod"]}',
@@ -594,6 +618,7 @@ class TestFetchDeps:
                     "packages -> 0",
                     "Input should be a valid dictionary or object to extract fields from",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 '{"packages": [{"type": "gomod"}], "what": "dunno"}',
@@ -602,15 +627,20 @@ class TestFetchDeps:
                     "what",
                     "Extra inputs are not permitted",
                 ],
+                ExitError.ERR_INVALID_INPUT,
             ),
         ],
     )
     def test_invalid_packages(
-        self, package_arg: str, expect_error_lines: list[str], tmp_cwd: Path
+        self,
+        package_arg: str,
+        expect_error_lines: list[str],
+        expected_error: ExitError,
+        tmp_cwd: Path,
     ) -> None:
         tmp_cwd.joinpath("suspicious-symlink").symlink_to("..")
 
-        result = invoke_expecting_invalid_usage(app, ["fetch-deps", package_arg])
+        result = invoke_expecting_invalid_usage(app, ["fetch-deps", package_arg], expected_error)
 
         for pattern in expect_error_lines:
             assert_pattern_in_output(pattern, result.output)
@@ -619,7 +649,9 @@ class TestFetchDeps:
         input_file = tmp_cwd.joinpath("input.json")
         input_file.write_text("}abc{")
 
-        result = invoke_expecting_invalid_usage(app, ["fetch-deps", str(input_file)])
+        result = invoke_expecting_invalid_usage(
+            app, ["fetch-deps", str(input_file)], ExitError.ERR_USAGE
+        )
         assert_pattern_in_output(
             "'PKG': Looks like JSON file but is not valid JSON file", result.output
         )
@@ -690,25 +722,30 @@ class TestFetchDeps:
             invoke_expecting_sucess(app, ["fetch-deps", *cli_args])
 
     @pytest.mark.parametrize(
-        "cli_args, expect_error",
+        "cli_args, expect_error, expected_error",
         [
-            (["gomod", "--no-such-flag"], "No such option: --no-such-flag"),
+            (["gomod", "--no-such-flag"], "No such option: --no-such-flag", ExitError.ERR_USAGE),
             (
                 ['{"packages": [{"type": "gomod"}], "flags": "not-a-list"}'],
                 "Input should be a valid list",
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 ['{"packages": [{"type": "gomod"}], "flags": {"dict": "no-such-flag"}}'],
                 "Input should be a valid list",
+                ExitError.ERR_INVALID_INPUT,
             ),
             (
                 ['{"packages": [{"type": "gomod"}], "flags": ["no-such-flag"]}'],
                 "Input should be 'cgo-disable', 'dev-package-managers', 'force-gomod-tidy', 'gomod-vendor' or 'gomod-vendor-check'",
+                ExitError.ERR_INVALID_INPUT,
             ),
         ],
     )
-    def test_invalid_flags(self, cli_args: list[str], expect_error: str) -> None:
-        result = invoke_expecting_invalid_usage(app, ["fetch-deps", *cli_args])
+    def test_invalid_flags(
+        self, cli_args: list[str], expect_error: str, expected_error: ExitError
+    ) -> None:
+        result = invoke_expecting_invalid_usage(app, ["fetch-deps", *cli_args], expected_error)
         assert_pattern_in_output(expect_error, result.output)
 
     @pytest.mark.parametrize(
@@ -905,11 +942,15 @@ class TestGenerateEnv:
 
     def test_invalid_format(self) -> None:
         # Note: .sh is a recognized suffix, but the --format option accepts only 'json' and 'env'
-        result = invoke_expecting_invalid_usage(app, ["generate-env", ".", "-f", "sh"])
+        result = invoke_expecting_invalid_usage(
+            app, ["generate-env", ".", "-f", "sh"], ExitError.ERR_USAGE
+        )
         assert "Invalid value for '-f' / '--format': 'sh' is not one of" in result.output
 
     def test_unsupported_suffix(self, caplog: pytest.LogCaptureFixture) -> None:
-        result = invoke_expecting_invalid_usage(app, ["generate-env", ".", "-o", "env.yaml"])
+        result = invoke_expecting_invalid_usage(
+            app, ["generate-env", ".", "-o", "env.yaml"], ExitError.ERR_UNSUPPORTED_FEATURE
+        )
 
         msg = "Cannot determine envfile format, unsupported suffix: yaml"
         assert msg in result.output
@@ -1007,16 +1048,21 @@ class TestMergeSboms:
     #             | two valid file names        |
     #             | three valid file names      |
     @pytest.mark.parametrize(
-        "sbom_files_to_merge, pattern",
+        "sbom_files_to_merge, pattern, expected_error",
         [
-            ([], "Missing argument"),
-            (["./tests/unit/data/sboms/hermeto.bom.json"], "Need at least two"),
+            ([], "Missing argument", ExitError.ERR_USAGE),
+            (
+                ["./tests/unit/data/sboms/hermeto.bom.json"],
+                "Need at least two",
+                ExitError.ERR_INVALID_INPUT,
+            ),
             (
                 [
                     "./tests/unit/data/sboms/hermeto.bom.json",
                     "./tests/unit/data/sboms/hermeto.bom.json",
                 ],
                 "Need at least two",
+                ExitError.ERR_INVALID_INPUT,
             ),
         ],
     )
@@ -1024,8 +1070,11 @@ class TestMergeSboms:
         self,
         sbom_files_to_merge: list[str],
         pattern: str,
+        expected_error: ExitError,
     ) -> None:
-        result = invoke_expecting_invalid_usage(app, ["merge-sboms", *sbom_files_to_merge])
+        result = invoke_expecting_invalid_usage(
+            app, ["merge-sboms", *sbom_files_to_merge], expected_error
+        )
         assert pattern in result.output
 
     @pytest.mark.parametrize(
@@ -1039,7 +1088,9 @@ class TestMergeSboms:
         sbom_files_to_merge: list[str],
         pattern: str,
     ) -> None:
-        result = invoke_expecting_invalid_usage(app, ["merge-sboms", *sbom_files_to_merge])
+        result = invoke_expecting_invalid_usage(
+            app, ["merge-sboms", *sbom_files_to_merge], ExitError.ERR_UNEXPECTED_FORMAT
+        )
         assert pattern in result.output
 
     @pytest.mark.parametrize(
@@ -1059,7 +1110,9 @@ class TestMergeSboms:
         sbom_files_to_merge: list[str],
         pattern: str,
     ) -> None:
-        result = invoke_expecting_invalid_usage(app, ["merge-sboms", *sbom_files_to_merge])
+        result = invoke_expecting_invalid_usage(
+            app, ["merge-sboms", *sbom_files_to_merge], ExitError.ERR_UNEXPECTED_FORMAT
+        )
         assert pattern in result.output
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Exit codes were previously 0, 1, or 2 (usage error), so callers had to parse
stderr to tell failure reasons apart.

Assign each error type a dedicated exit code (1–22), centralize the mapping in
errors.py with validation, and have the CLI use e.exit_code. Scripts and CI can
rely on specific codes (e.g. LockfileNotFound=13, PackageRejected=5) without
parsing output.

Integration and unit tests now assert by error type (expected_error=...) instead
of expected_exit_code and fragile output snippets, so tests stay stable and
failures show the error name.

Closes https://github.com/hermetoproject/hermeto/issues/1250