### PR TITLE
chore: Adds license information to Python modules

### DIFF
--- a/hermeto/__init__.py
+++ b/hermeto/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import importlib.util as imputil
 import sys
 from pathlib import Path

--- a/hermeto/core/binary_filters.py
+++ b/hermeto/core/binary_filters.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 """Base classes for binary package filtering."""
 
 from abc import ABC, abstractmethod

--- a/hermeto/core/checksum.py
+++ b/hermeto/core/checksum.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import base64
 import binascii
 import hashlib

--- a/hermeto/core/config.py
+++ b/hermeto/core/config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 from pathlib import Path
 from typing import Annotated, Any

--- a/hermeto/core/errors.py
+++ b/hermeto/core/errors.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import textwrap
 from pathlib import Path
 from typing import ClassVar, Iterable

--- a/hermeto/core/extras/envfile.py
+++ b/hermeto/core/extras/envfile.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import json
 import shlex
 from enum import Enum

--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import enum
 import logging
 import re

--- a/hermeto/core/models/output.py
+++ b/hermeto/core/models/output.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 import string
 from copy import deepcopy

--- a/hermeto/core/models/property_semantics.py
+++ b/hermeto/core/models/property_semantics.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from enum import Enum

--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import hashlib
 import json
 import logging

--- a/hermeto/core/models/validators.py
+++ b/hermeto/core/models/validators.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import os
 from collections.abc import Callable, Iterable
 from pathlib import Path

--- a/hermeto/core/package_managers/bundler/__init__.py
+++ b/hermeto/core/package_managers/bundler/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from hermeto.core.package_managers.bundler.main import fetch_bundler_source
 
 __all__ = ["fetch_bundler_source"]

--- a/hermeto/core/package_managers/bundler/gem_models.py
+++ b/hermeto/core/package_managers/bundler/gem_models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 from functools import cached_property
 from pathlib import Path

--- a/hermeto/core/package_managers/bundler/main.py
+++ b/hermeto/core/package_managers/bundler/main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 import os
 from pathlib import Path

--- a/hermeto/core/package_managers/bundler/parser.py
+++ b/hermeto/core/package_managers/bundler/parser.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import json
 import logging
 import subprocess

--- a/hermeto/core/package_managers/cargo/__init__.py
+++ b/hermeto/core/package_managers/cargo/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from hermeto.core.package_managers.cargo.main import fetch_cargo_source
 
 __all__ = ["fetch_cargo_source"]

--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 import os
 import subprocess

--- a/hermeto/core/package_managers/generic/__init__.py
+++ b/hermeto/core/package_managers/generic/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from hermeto.core.package_managers.generic.main import fetch_generic_source
 
 __all__ = ["fetch_generic_source"]

--- a/hermeto/core/package_managers/generic/main.py
+++ b/hermeto/core/package_managers/generic/main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import asyncio
 import logging
 import os

--- a/hermeto/core/package_managers/generic/models.py
+++ b/hermeto/core/package_managers/generic/models.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import re
 from abc import ABC, abstractmethod
 from collections import Counter

--- a/hermeto/core/package_managers/gomod.py
+++ b/hermeto/core/package_managers/gomod.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import dataclasses
 import logging
 import os

--- a/hermeto/core/package_managers/metayarn.py
+++ b/hermeto/core/package_managers/metayarn.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from hermeto.core.config import get_config
 from hermeto.core.errors import LockfileNotFound
 from hermeto.core.models.input import Request

--- a/hermeto/core/package_managers/npm.py
+++ b/hermeto/core/package_managers/npm.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import asyncio
 import copy
 import fnmatch

--- a/hermeto/core/package_managers/pip/__init__.py
+++ b/hermeto/core/package_managers/pip/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from hermeto.core.package_managers.pip.main import fetch_pip_source
 
 __all__ = ["fetch_pip_source"]

--- a/hermeto/core/package_managers/pip/package_distributions.py
+++ b/hermeto/core/package_managers/pip/package_distributions.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 """This module provides functionality to process package distributions from PyPI (sdist and wheel)."""
 
 import logging

--- a/hermeto/core/package_managers/pip/project_files.py
+++ b/hermeto/core/package_managers/pip/project_files.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 """
 This module provides classes for parsing and extracting metadata from Python project files.
 

--- a/hermeto/core/package_managers/pip/requirements.py
+++ b/hermeto/core/package_managers/pip/requirements.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 """This module provides functionality to parse and validate requirements.txt files."""
 
 import functools

--- a/hermeto/core/package_managers/pip/rust.py
+++ b/hermeto/core/package_managers/pip/rust.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 """This module provides functionality to handle Rust extensions in Python packages."""
 
 import logging

--- a/hermeto/core/package_managers/rpm/__init__.py
+++ b/hermeto/core/package_managers/rpm/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from hermeto.core.package_managers.rpm.main import fetch_rpm_source, inject_files_post
 
 __all__ = ["fetch_rpm_source", "inject_files_post"]

--- a/hermeto/core/package_managers/rpm/binary_filters.py
+++ b/hermeto/core/package_managers/rpm/binary_filters.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 """RPM-specific binary package filtering."""
 
 from typing import Any

--- a/hermeto/core/package_managers/rpm/main.py
+++ b/hermeto/core/package_managers/rpm/main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import asyncio
 import hashlib
 import itertools

--- a/hermeto/core/package_managers/rpm/redhat.py
+++ b/hermeto/core/package_managers/rpm/redhat.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 import uuid
 from functools import cached_property

--- a/hermeto/core/package_managers/yarn/__init__.py
+++ b/hermeto/core/package_managers/yarn/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from hermeto.core.package_managers.yarn.main import fetch_yarn_source
 
 __all__ = ["fetch_yarn_source"]

--- a/hermeto/core/package_managers/yarn/locators.py
+++ b/hermeto/core/package_managers/yarn/locators.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass

--- a/hermeto/core/package_managers/yarn/main.py
+++ b/hermeto/core/package_managers/yarn/main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 
 import semver

--- a/hermeto/core/package_managers/yarn/project.py
+++ b/hermeto/core/package_managers/yarn/project.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 """
 Parse the relevant files of a yarn project.
 

--- a/hermeto/core/package_managers/yarn/resolver.py
+++ b/hermeto/core/package_managers/yarn/resolver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 """
 Resolve the dependency list for a yarn project.
 

--- a/hermeto/core/package_managers/yarn/utils.py
+++ b/hermeto/core/package_managers/yarn/utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import os
 import subprocess
 

--- a/hermeto/core/package_managers/yarn_classic/__init__.py
+++ b/hermeto/core/package_managers/yarn_classic/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from hermeto.core.package_managers.yarn_classic.main import fetch_yarn_source
 
 __all__ = ["fetch_yarn_source"]

--- a/hermeto/core/package_managers/yarn_classic/main.py
+++ b/hermeto/core/package_managers/yarn_classic/main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 from collections import defaultdict
 from collections.abc import Iterable

--- a/hermeto/core/package_managers/yarn_classic/project.py
+++ b/hermeto/core/package_managers/yarn_classic/project.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 """
 Parse the relevant files of a yarn project.
 

--- a/hermeto/core/package_managers/yarn_classic/resolver.py
+++ b/hermeto/core/package_managers/yarn_classic/resolver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import json
 import re
 import tarfile

--- a/hermeto/core/package_managers/yarn_classic/utils.py
+++ b/hermeto/core/package_managers/yarn_classic/utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import re
 from collections import deque
 from pathlib import Path

--- a/hermeto/core/package_managers/yarn_classic/workspaces.py
+++ b/hermeto/core/package_managers/yarn_classic/workspaces.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 from collections.abc import Generator, Iterable
 from itertools import chain

--- a/hermeto/core/resolver.py
+++ b/hermeto/core/resolver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from collections.abc import Callable
 from pathlib import Path
 from tempfile import TemporaryDirectory

--- a/hermeto/core/rooted_path.py
+++ b/hermeto/core/rooted_path.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import os
 from pathlib import Path
 from typing import Any, TypeVar

--- a/hermeto/core/type_aliases.py
+++ b/hermeto/core/type_aliases.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import os
 
 from semver import Version

--- a/hermeto/core/utils.py
+++ b/hermeto/core/utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import errno
 import json
 import logging

--- a/hermeto/interface/cli.py
+++ b/hermeto/interface/cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import enum
 import functools
 import importlib.metadata

--- a/hermeto/interface/logging.py
+++ b/hermeto/interface/logging.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import enum
 import logging
 from collections.abc import Iterable

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import pytest
 
 pytest.register_assert_rewrite(

--- a/tests/common_utils/__init__.py
+++ b/tests/common_utils/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import os
 from pathlib import Path
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import contextlib
 import logging
 import os

--- a/tests/integration/container_engine.py
+++ b/tests/integration/container_engine.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import json
 import logging
 import os

--- a/tests/integration/test_bundler.py
+++ b/tests/integration/test_bundler.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 from pathlib import Path
 

--- a/tests/integration/test_cargo.py
+++ b/tests/integration/test_cargo.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 from pathlib import Path
 

--- a/tests/integration/test_generic.py
+++ b/tests/integration/test_generic.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 
 import pytest

--- a/tests/integration/test_legacy.py
+++ b/tests/integration/test_legacy.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 from pathlib import Path
 

--- a/tests/integration/test_multiple.py
+++ b/tests/integration/test_multiple.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 
 import pytest

--- a/tests/integration/test_npm.py
+++ b/tests/integration/test_npm.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 from pathlib import Path
 

--- a/tests/integration/test_pip.py
+++ b/tests/integration/test_pip.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 import os
 from pathlib import Path

--- a/tests/integration/test_rpm.py
+++ b/tests/integration/test_rpm.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import os
 import re
 from configparser import ConfigParser

--- a/tests/integration/test_yarn.py
+++ b/tests/integration/test_yarn.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 from pathlib import Path
 

--- a/tests/integration/test_yarn_classic.py
+++ b/tests/integration/test_yarn_classic.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import logging
 from pathlib import Path
 

--- a/tests/nexusserver/__init__.py
+++ b/tests/nexusserver/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 """Nexus Repository Server for integration tests."""
 
 from tests.nexusserver.start import DEFAULT_NEXUS_HOST, DEFAULT_NEXUS_PORT, initialize_nexus

--- a/tests/nexusserver/repositories.py
+++ b/tests/nexusserver/repositories.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 """Repository configuration for Nexus server."""
 
 from dataclasses import dataclass, field

--- a/tests/nexusserver/start.py
+++ b/tests/nexusserver/start.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 #!/usr/bin/env python3
 """Start and initialize a Nexus Repository Server for integration tests."""
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import sys
 import tarfile
 from pathlib import Path

--- a/tests/unit/extras/test_envfile.py
+++ b/tests/unit/extras/test_envfile.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 from textwrap import dedent
 

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import re
 from pathlib import Path
 from typing import Any, Literal, cast

--- a/tests/unit/models/test_output.py
+++ b/tests/unit/models/test_output.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 from textwrap import dedent
 from typing import Any

--- a/tests/unit/models/test_property_semantics.py
+++ b/tests/unit/models/test_property_semantics.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import pytest
 
 from hermeto import APP_NAME

--- a/tests/unit/models/test_sbom.py
+++ b/tests/unit/models/test_sbom.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import datetime
 import json
 from unittest import mock

--- a/tests/unit/models/test_validators.py
+++ b/tests/unit/models/test_validators.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from typing import Any
 
 import pytest

--- a/tests/unit/package_managers/bundler/test_main.py
+++ b/tests/unit/package_managers/bundler/test_main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from textwrap import dedent
 from unittest import mock
 

--- a/tests/unit/package_managers/bundler/test_parser.py
+++ b/tests/unit/package_managers/bundler/test_parser.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import json
 import re
 import subprocess

--- a/tests/unit/package_managers/cargo/test_main.py
+++ b/tests/unit/package_managers/cargo/test_main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import textwrap
 from typing import Any
 

--- a/tests/unit/package_managers/pip/test_package_distributions.py
+++ b/tests/unit/package_managers/pip/test_package_distributions.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from unittest import mock
 
 import pypi_simple

--- a/tests/unit/package_managers/pip/test_project_files.py
+++ b/tests/unit/package_managers/pip/test_project_files.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Literal

--- a/tests/unit/package_managers/pip/test_requirements.py
+++ b/tests/unit/package_managers/pip/test_requirements.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import re
 from textwrap import dedent
 from typing import Any

--- a/tests/unit/package_managers/pip/test_rust.py
+++ b/tests/unit/package_managers/pip/test_rust.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 
 import pytest

--- a/tests/unit/package_managers/rpm/test_binary_filters.py
+++ b/tests/unit/package_managers/rpm/test_binary_filters.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from unittest import mock
 
 import pytest

--- a/tests/unit/package_managers/rpm/test_main.py
+++ b/tests/unit/package_managers/rpm/test_main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import ssl
 from configparser import ConfigParser
 from pathlib import Path

--- a/tests/unit/package_managers/test_generic.py
+++ b/tests/unit/package_managers/test_generic.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 from typing import Any
 from unittest import mock

--- a/tests/unit/package_managers/test_metayarn.py
+++ b/tests/unit/package_managers/test_metayarn.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from unittest import mock
 
 import pytest

--- a/tests/unit/package_managers/test_npm.py
+++ b/tests/unit/package_managers/test_npm.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import json
 import os
 import urllib.parse

--- a/tests/unit/package_managers/yarn/test_locators.py
+++ b/tests/unit/package_managers/yarn/test_locators.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import re
 from itertools import zip_longest
 from pathlib import Path

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import itertools
 import re
 from enum import Enum

--- a/tests/unit/package_managers/yarn/test_project.py
+++ b/tests/unit/package_managers/yarn/test_project.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import re
 import textwrap
 

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import json
 import re
 import zipfile

--- a/tests/unit/package_managers/yarn/test_utils.py
+++ b/tests/unit/package_managers/yarn/test_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import os
 from subprocess import CalledProcessError
 from unittest import mock

--- a/tests/unit/package_managers/yarn_classic/test_main.py
+++ b/tests/unit/package_managers/yarn_classic/test_main.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import itertools
 import json
 from collections.abc import Iterable

--- a/tests/unit/package_managers/yarn_classic/test_project.py
+++ b/tests/unit/package_managers/yarn_classic/test_project.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import json
 
 import pytest

--- a/tests/unit/package_managers/yarn_classic/test_resolver.py
+++ b/tests/unit/package_managers/yarn_classic/test_resolver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import io
 import json
 import re

--- a/tests/unit/package_managers/yarn_classic/test_utils.py
+++ b/tests/unit/package_managers/yarn_classic/test_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from unittest import mock
 
 from hermeto.core.package_managers.yarn_classic.project import PackageJson

--- a/tests/unit/package_managers/yarn_classic/test_workspaces.py
+++ b/tests/unit/package_managers/yarn_classic/test_workspaces.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 from unittest import mock
 

--- a/tests/unit/test_checksum.py
+++ b/tests/unit/test_checksum.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 from typing import Literal
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import datetime
 import importlib.metadata
 import json

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 from typing import Any, Generator
 

--- a/tests/unit/test_errors.py
+++ b/tests/unit/test_errors.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from textwrap import dedent
 
 from hermeto import APP_NAME

--- a/tests/unit/test_merge_spdx.py
+++ b/tests/unit/test_merge_spdx.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from collections import defaultdict
 from functools import reduce
 from operator import add

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 from unittest import mock
 

--- a/tests/unit/test_rooted_path.py
+++ b/tests/unit/test_rooted_path.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 from pathlib import Path
 from typing import Literal
 

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import filecmp
 import sys
 import tarfile

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 import errno
 import io
 import subprocess


### PR DESCRIPTION
Style guide for code assitants demands SPDX license header for all new files, however existing files lack this information. This commit adds license information as suggested in the style guide to all existing *.py modules in hermeto/ and tests/ directories.

This change is generated with a trivial sed script.