### PR TITLE
Report outdated Cargo.lock in permissive mode

### DIFF
--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -13,10 +13,11 @@ import tomlkit
 import tomlkit.exceptions
 from packageurl import PackageURL
 
+from hermeto import APP_NAME
 from hermeto.core.errors import LockfileNotFound, NotAGitRepo, PackageRejected, UnexpectedFormat
 from hermeto.core.models.input import Mode, Request
-from hermeto.core.models.output import Component, EnvironmentVariable, ProjectFile, RequestOutput
-from hermeto.core.models.sbom import create_backend_annotation
+from hermeto.core.models.output import Annotation, Component, ProjectFile, RequestOutput
+from hermeto.core.models.sbom import create_backend_annotation, spdx_now
 from hermeto.core.rooted_path import RootedPath
 from hermeto.core.scm import get_repo_id
 from hermeto.core.utils import run_cmd
@@ -123,8 +124,8 @@ class LocalCargoPackage:
 def fetch_cargo_source(request: Request) -> RequestOutput:
     """Fetch the source code for all cargo packages specified in a request."""
     components: list[Component] = []
-    environment_variables: list[EnvironmentVariable] = []
     project_files: list[ProjectFile] = []
+    annotations: list[Annotation] = []
 
     for package in request.cargo_packages:
         package_dir = request.source_dir.join_within_root(package.path)
@@ -137,16 +138,41 @@ def fetch_cargo_source(request: Request) -> RequestOutput:
             vendor_result.config_template
         )
         project_files.append(_use_vendored_sources(package_dir, config_template))
-        components.extend(_generate_sbom_components(package_dir))
+        package_components = _generate_sbom_components(package_dir)
 
-    annotations = []
+        if vendor_result.lockfile_was_generated:
+            _update_permissive_mode_annotation(annotations, package_components)
+
+        components.extend(package_components)
+
     if backend_annotation := create_backend_annotation(components, "cargo"):
         annotations.append(backend_annotation)
     return RequestOutput.from_obj_list(
         components=components,
-        environment_variables=environment_variables,
         project_files=project_files,
         annotations=annotations,
+    )
+
+
+def _update_permissive_mode_annotation(
+    annotations: list[Annotation],
+    components: list[Component],
+) -> None:
+    """Update permissive mode SBOM annotation with subjects from the provided components."""
+    text = f"{APP_NAME}:permissive-mode:cargo:generated-lockfile"
+    subjects = set(c.bom_ref for c in components)
+    for annotation in annotations:
+        if annotation.text == text:
+            annotation.subjects.update(subjects)
+            return
+
+    annotations.append(
+        Annotation(
+            subjects=subjects,
+            annotator={"organization": {"name": "red hat"}},
+            timestamp=spdx_now(),
+            text=text,
+        )
     )
 
 


### PR DESCRIPTION
One of the two use cases for permissive mode is a lockfile mismatch, e.g., an out-of-sync Cargo.lock with Cargo.toml.

Taint the SBOM with annotations as we did for gomod (https://github.com/hermetoproject/hermeto/pull/1204).