### PR TITLE
bug : (related to #1290) testing GH release workflow

### DIFF
--- a/.github/workflows/release-test.yaml
+++ b/.github/workflows/release-test.yaml
@@ -1,0 +1,49 @@
+# Test the release pipeline without pushing. Use this to validate changes to
+# release.yaml or the Dockerfile before doing a real release (see issue #1290).
+#
+# Runs: same build steps as release.yaml, but with push: false.
+# Triggers: PRs that touch release workflow or Dockerfile, or manual run.
+name: Release pipeline test
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/release.yaml'
+      - '.github/workflows/release-test.yaml'
+      - 'Dockerfile'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-only:
+    name: Build only (no push)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Same metadata action as release; on PR ref we only get a test tag (no semver)
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=raw,value=release-test,enable=${{ github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' }}
+
+      - name: Build container image (no push)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,9 +49,9 @@ jobs:
       # 1. [ALWAYS] Semantic version tag:
       #    - extracts version from github.ref (must be a git tag ref)
       #
-      # 2. [CONDITIONAL] 'latest' tag to ensure latest points to stable releases only:
-      #    - release event: only for stable releases, i.e. '!github.event.release.prerelease'
-      #    - manual workflow trigger: only if 'push_latest' checkbox is checked
+      # 2. [CONDITIONAL] 'latest' tag (single rule, no duplicates):
+      #    - release event: only when the release is "latest" on GitHub and its not a "pre-release" ( it avoids overwriting latest releases when publishing older releases from maintenance branches)
+      #    - manual workflow trigger: only when 'push_latest' checkbox is checked
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
@@ -59,7 +59,7 @@ jobs:
           images: ghcr.io/${{ github.repository }}
           tags: |
             type=semver,pattern={{version}}
-            type=raw,value=latest,enable=${{ (github.event_name == 'workflow_dispatch' && inputs.push_latest) || (github.event_name == 'release' && !github.event.release.prerelease) }}
+            type=raw,value=latest,enable=${{ (github.event_name == 'workflow_dispatch' && inputs.push_latest) || (github.event_name == 'release' && github.event.release.latest && !github.event.release.prerelease) }}
 
       # Multi-arch build setup
       - name: Build and push container image


### PR DESCRIPTION
What is fixed ?

Tried to fix  #1289, #1290
the latest tag is now applied with a single rule: on release events only when the release is marked "Latest" on GitHub and is not a prerelease

Included a `Test Release workflow` , trying to run the same build as the release workflow (caution - no push) .





**What are the tests done ?**


I have tried to do the following local testing

1. Docker build Test

```bash
docker build -f Dockerfile -t hermeto:release-test .
docker run --rm hermeto:release-test --help
```

The image build happened successfully



2. Testing Yaml workflow linting with the `actionlint`

```bash
actionlint .github/workflows/release-test.yaml
```

The test has been successfully ran on all the workflow files.

<img width="1206" height="831" alt="actionlint-testing" src="https://github.com/user-attachments/assets/68a1a29c-56a9-4d69-936f-89be233957be" />



The specific release pipeline test on this Pull request is waiting for the maintainer approval . 
The result can be determined once the `release-test.yaml` is checked.

If the test `release-test` workflow succeed then we are good to go

@eskultety  Sir can you review this once.