### PR TITLE
[gomod] Add GOSUMDB=off to generated build-phase env vars

### DIFF
--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -538,6 +538,7 @@ def fetch_gomod_source(request: Request) -> RequestOutput:
         "GOPATH": "${output_dir}/deps/gomod",
         "GOMODCACHE": "${output_dir}/deps/gomod/pkg/mod",
         "GOPROXY": "file://${GOMODCACHE}/cache/download",
+        "GOSUMDB": "off",
     }
     env_vars_template.update(config.gomod.environment_variables)
 

--- a/tests/integration/test_data/gomod_correct_vendor_in_submodule_passes_vendor_check/.build-config.yaml
+++ b/tests/integration/test_data/gomod_correct_vendor_in_submodule_passes_vendor_check/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_correct_vendor_passes_vendor_check/.build-config.yaml
+++ b/tests/integration/test_data/gomod_correct_vendor_passes_vendor_check/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_e2e_1.18/.build-config.yaml
+++ b/tests/integration/test_data/gomod_e2e_1.18/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_e2e_1.21/.build-config.yaml
+++ b/tests/integration/test_data/gomod_e2e_1.21/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_e2e_1.21_dirty/.build-config.yaml
+++ b/tests/integration/test_data/gomod_e2e_1.21_dirty/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_e2e_1.22_workspace_vendoring/.build-config.yaml
+++ b/tests/integration/test_data/gomod_e2e_1.22_workspace_vendoring/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_e2e_multiple_modules/.build-config.yaml
+++ b/tests/integration/test_data/gomod_e2e_multiple_modules/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_e2e_vendor_nonvendor_module_mix_ordering_1/.build-config.yaml
+++ b/tests/integration/test_data/gomod_e2e_vendor_nonvendor_module_mix_ordering_1/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_e2e_vendor_nonvendor_module_mix_ordering_2/.build-config.yaml
+++ b/tests/integration/test_data/gomod_e2e_vendor_nonvendor_module_mix_ordering_2/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_empty_vendor_passes_vendor_check_in_permissive_mode/.build-config.yaml
+++ b/tests/integration/test_data/gomod_empty_vendor_passes_vendor_check_in_permissive_mode/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_generate_imported/.build-config.yaml
+++ b/tests/integration/test_data/gomod_generate_imported/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_local_deps/.build-config.yaml
+++ b/tests/integration/test_data/gomod_local_deps/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_missing_checksums/.build-config.yaml
+++ b/tests/integration/test_data/gomod_missing_checksums/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_with_deps/.build-config.yaml
+++ b/tests/integration/test_data/gomod_with_deps/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_without_deps/.build-config.yaml
+++ b/tests/integration/test_data/gomod_without_deps/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_workspaces/.build-config.yaml
+++ b/tests/integration/test_data/gomod_workspaces/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/gomod_wrong_vendor_passes_vendor_check_in_permissive_mode/.build-config.yaml
+++ b/tests/integration/test_data/gomod_wrong_vendor_passes_vendor_check_in_permissive_mode/.build-config.yaml
@@ -7,4 +7,6 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files: []

--- a/tests/integration/test_data/multiple_gomod_and_npm/.build-config.yaml
+++ b/tests/integration/test_data/multiple_gomod_and_npm/.build-config.yaml
@@ -7,6 +7,8 @@ environment_variables:
   value: ${output_dir}/deps/gomod
 - name: GOPROXY
   value: file://${GOMODCACHE}/cache/download
+- name: GOSUMDB
+  value: 'off'
 project_files:
 - abspath: ${test_case_tmp_path}/npm-package/package-lock.json
   template: |

--- a/tests/unit/extras/test_envfile.py
+++ b/tests/unit/extras/test_envfile.py
@@ -48,12 +48,12 @@ def test_cannot_determine_format(filename: str, expect_reason: str) -> None:
 def test_generate_env_as_json() -> None:
     env_vars = [
         {"name": "GOCACHE", "value": "deps/gomod", "kind": "path"},
-        {"name": "GOSUMDB", "value": "sum.golang.org", "kind": "literal"},
+        {"name": "GOSUMDB", "value": "off", "kind": "literal"},
     ]
     build_config = BuildConfig(environment_variables=env_vars, project_files=[])
 
     gocache = '{"name": "GOCACHE", "value": "/output/dir/deps/gomod"}'
-    gosumdb = '{"name": "GOSUMDB", "value": "sum.golang.org"}'
+    gosumdb = '{"name": "GOSUMDB", "value": "off"}'
     expect_content = f"[{gocache}, {gosumdb}]"
 
     content = generate_envfile(build_config, EnvFormat.json, relative_to_path=Path("/output/dir"))
@@ -63,7 +63,7 @@ def test_generate_env_as_json() -> None:
 def test_generate_env_as_env() -> None:
     env_vars = [
         {"name": "GOCACHE", "value": "deps/gomod", "kind": "path"},
-        {"name": "GOSUMDB", "value": "sum.golang.org", "kind": "literal"},
+        {"name": "GOSUMDB", "value": "off", "kind": "literal"},
         {"name": "SNEAKY", "value": "foo; echo hello there", "kind": "literal"},
     ]
     build_config = BuildConfig(environment_variables=env_vars, project_files=[])
@@ -71,7 +71,7 @@ def test_generate_env_as_env() -> None:
     expect_content = dedent(
         """
         export GOCACHE=/output/dir/deps/gomod
-        export GOSUMDB=sum.golang.org
+        export GOSUMDB=off
         export SNEAKY='foo; echo hello there'
         """
     ).strip()

--- a/tests/unit/package_managers/gomod/test_main.py
+++ b/tests/unit/package_managers/gomod/test_main.py
@@ -97,6 +97,7 @@ def env_variables() -> list[EnvironmentVariable]:
         EnvironmentVariable(name="GOMODCACHE", value="${output_dir}/deps/gomod/pkg/mod"),
         EnvironmentVariable(name="GOPATH", value="${output_dir}/deps/gomod"),
         EnvironmentVariable(name="GOPROXY", value="file://${GOMODCACHE}/cache/download"),
+        EnvironmentVariable(name="GOSUMDB", value="off"),
     ]
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -845,7 +845,7 @@ class TestFetchDeps:
 
 def env_file_as_json(for_output_dir: Path) -> str:
     gocache = f'{{"name": "GOCACHE", "value": "{for_output_dir}/deps/gomod"}}'
-    gosumdb = '{"name": "GOSUMDB", "value": "sum.golang.org"}'
+    gosumdb = '{"name": "GOSUMDB", "value": "off"}'
     return f"[{gocache}, {gosumdb}]\n"
 
 
@@ -853,7 +853,7 @@ def env_file_as_env(for_output_dir: Path) -> str:
     return dedent(
         f"""
         export GOCACHE={for_output_dir}/deps/gomod
-        export GOSUMDB=sum.golang.org
+        export GOSUMDB=off
         """
     ).lstrip()
 
@@ -861,7 +861,7 @@ def env_file_as_env(for_output_dir: Path) -> str:
 class TestGenerateEnv:
     ENV_VARS = [
         {"name": "GOCACHE", "value": "${output_dir}/deps/gomod"},
-        {"name": "GOSUMDB", "value": "sum.golang.org"},
+        {"name": "GOSUMDB", "value": "off"},
     ]
 
     @pytest.fixture


### PR DESCRIPTION
Fixes #1187

**Problem**

I looked into the issue with the openstack-operator 18.0-fr4 branch where Go sometimes tries to hit sum.golang.org during the hermetic build. It's not 100% reproducible, but when it happens, the build fails because there's no network access.

The reason is that we never set GOSUMDB in the generated build-phase env vars, so Go just uses its default and tries to reach the sumdb.

**What I found**

We already set GOSUMDB=sum.golang.org in _resolve_gomod() for the fetch phase — that part is fine, checksums get verified when we download modules. But the env_vars_template that gets written out for the build phase doesn't include GOSUMDB at all. Since the build uses GOPROXY=file://... and everything is already cached locally, Go shouldn't need to contact the sumdb at that point.

**Fix**

Added GOSUMDB=off to env_vars_template so the build phase explicitly skips sumdb lookups. The fetch phase stays as-is.

**Testing**

Unit tests pass (nox -s python — 1382 passed)
Lint passes (nox -s lint)
Validate against openstack-operator build (18.0-fr4 branch with go.work)