### PR TITLE
chore(hermeto fetch-deps): simplify error message

### DIFF
--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -82,6 +82,8 @@ def _present_user_input_error(validation_error: pydantic.ValidationError) -> str
         location = " -> ".join(map(str, error["loc"]))
         if error.get("type") != "union_tag_invalid":
             message = error["msg"]
+            if location != "__root__":
+                message = f"{location}\n  {message}"
         else:
             # Handle regular union tag errors (i.e. errors which stem from
             # a missing package manager implementation). Errors in experimental
@@ -90,15 +92,16 @@ def _present_user_input_error(validation_error: pydantic.ValidationError) -> str
             raw = ctx.get("expected_tags", "")
             expected = [t.strip(" '") for t in raw.split(",")]
             quoted = ", ".join(f"'{t}'" for t in sorted(expected))
-            message = f"Requested backend type '{ctx.get('tag', '<unknown>')}' doesn't match expected ones: {quoted}"
-
-        if location != "__root__":
-            message = f"{location}\n  {message}"
+            message = f"Unknown package manager '{ctx.get('tag', '<unknown>')}' doesn't match expected ones: {quoted}"
 
         return message
 
     header = f"{n_errors} validation error{'' if n_errors == 1 else 's'} for user input"
     details = "\n".join(map(show_error, errors))
+
+    if all(e.get("type") == "union_tag_invalid" for e in errors):
+        return details
+
     return f"{header}\n{details}"
 
 

--- a/hermeto/interface/cli.py
+++ b/hermeto/interface/cli.py
@@ -120,7 +120,8 @@ Paths = list[Path]
 
 def _bail_out_with_error(e: BaseError) -> None:
     """Report and error and set correct exit code."""
-    log.error("%s: %s", type(e).__name__, str(e).replace("\n", r"\n"))
+    if not isinstance(e, InvalidInput):
+        log.error("%s: %s", type(e).__name__, str(e).replace("\n", r"\n"))
     print(f"Error: {type(e).__name__}: {e.friendly_msg()}", file=sys.stderr)
     raise typer.Exit(2 if e.is_invalid_usage else 1)
 


### PR DESCRIPTION
## Summary

resolves: #1016

Improves the user-facing error message when an unsupported package manager type is passed to `hermeto fetch-deps`.

## Problem

Previously, running `hermeto fetch-deps asdf` produced a verbose, pydantic-style error that was hard to read.

## Solution

Now, it shows the error like this:
<img width="972" height="61" alt="Screenshot from 2026-02-24 15-57-19" src="https://github.com/user-attachments/assets/97333d72-8539-4482-b16e-e59fc6f1286b" />
