### PR TITLE
fix(bundler): preserve original platform strings for gem downloads

### DIFF
--- a/hermeto/core/package_managers/bundler/parser.py
+++ b/hermeto/core/package_managers/bundler/parser.py
@@ -57,7 +57,7 @@ def parse_lockfile(
     result: ParseResult = []
     for dep in dependencies:
         if dep["type"] == "rubygems":
-            for platform in dep["platforms"]:
+            for platform, original_platform in zip(dep["platforms"], dep["original_platforms"]):
                 if platform == "ruby":
                     result.append(GemDependency(**dep))
                 else:
@@ -68,7 +68,12 @@ def parse_lockfile(
                             "Will download binary dependency %s because 'binary' field is set",
                             full_name,
                         )
-                        result.append(GemPlatformSpecificDependency(platform=platform, **dep))
+                        result.append(
+                            GemPlatformSpecificDependency(
+                                platform=original_platform,
+                                **dep,
+                            )
+                        )
                     else:
                         # No need to force a platform if we skip the packages.
                         log.warning(


### PR DESCRIPTION
Hermeto was using normalized platform strings from Gem::Platform when constructing download URLs for platform-specific gems. This caused downloads to fail because gems are published with their original platform names (e.g., "aarch64-linux-gnu" vs normalized "aarch64-linux").

The lockfile parser now tracks both the normalized platform (for matching) and the original platform string (for downloads), matching Bundler's RemoteSpecification behavior.

Fixes: https://github.com/hermetoproject/hermeto/issues/1208