### PR TITLE
docs(cargo): fix incorrect CLI option name 

### DIFF
--- a/docs/cargo.md
+++ b/docs/cargo.md
@@ -18,7 +18,7 @@ hermeto fetch-deps cargo
 ```
 
 The default output directory is `hermeto-output`. You can change it by passing
-the `--output-dir` option for the `fetch-deps` command. See the help message
+the `--output` option for the `fetch-deps` command. See the help message
 for more information.
 
 After prefetching the dependencies, you can use the `hermeto inject-files`


### PR DESCRIPTION
  ## Summary
  - Fixed incorrect CLI option name `--output-dir` to `--output` in `docs/cargo.md`
  - The actual option is defined as `--output` in `hermeto/interface/cli.py:260-264`
  - 
<img width="836" height="302" alt="Screenshot from 2026-03-01 04-40-38" src="https://github.com/user-attachments/assets/15782fe5-4e99-481c-ab59-65662a7725b2" />


  ## Test plan
  - [x] Verified the correct option name in CLI source code
