### PR TITLE
fix: use prefix instead of suffix for TemporaryDirectory in resolver

### DIFF
--- a/hermeto/core/resolver.py
+++ b/hermeto/core/resolver.py
@@ -44,7 +44,7 @@ def resolve_packages(request: Request) -> RequestOutput:
     """
     original_source_dir = request.source_dir
 
-    with TemporaryDirectory(f".{APP_NAME}-source-copy", dir=".") as temp_dir:
+    with TemporaryDirectory(prefix=f".{APP_NAME}-source-copy-", dir=".") as temp_dir:
         source_backup = copy_directory(original_source_dir.path, Path(temp_dir).resolve())
 
         request.source_dir = RootedPath(source_backup)

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -115,8 +115,7 @@ def test_source_dir_copy(
 
         # assert a temporary directory is being used
         assert tmp_dir_name != tmp_path.name
-        assert tmp_dir_name.startswith("tmp")
-        assert tmp_dir_name.endswith(".hermeto-source-copy")
+        assert tmp_dir_name.startswith(".hermeto-source-copy-")
 
         return RequestOutput.empty()
 
@@ -150,7 +149,7 @@ def test_project_files_fix_for_work_copy(
     def _resolve_packages(request: Request) -> RequestOutput:
         # assert request is based on a copy of the source dir
         assert request.source_dir.path != tmp_path
-        assert request.source_dir.path.name.endswith(".hermeto-source-copy")
+        assert request.source_dir.path.name.startswith(".hermeto-source-copy-")
 
         abspath = request.source_dir.path if with_path_replacement else request.output_dir.path
         return RequestOutput(


### PR DESCRIPTION
## Summary

While reviewing the temporary directory handling in `resolver.py`, I noticed a subtle but incorrect usage of Python's `TemporaryDirectory` class. The code was passing the directory name pattern as a positional argument, which maps to the `suffix` parameter rather than `prefix`. This resulted in temp directories named like `tmpXXXXXXXX.hermeto-source-copy` instead of the intended `.hermeto-source-copy-XXXXXXXX`.

The fix is straightforward—adding the `prefix=` keyword argument—and brings this usage in line with every other `TemporaryDirectory` call in the codebase.

---

## Fix

**File:** `hermeto/core/resolver.py` (line 47)

The positional argument `f".{APP_NAME}-source-copy"` was being interpreted as a suffix. By explicitly using `prefix=`, the temp directory now gets a recognizable name that starts with `.hermeto-source-copy-` followed by the random suffix.

```python
# Before
with TemporaryDirectory(f".{APP_NAME}-source-copy", dir=".") as temp_dir:

# After  
with TemporaryDirectory(prefix=f".{APP_NAME}-source-copy-", dir=".") as temp_dir:
```

I also updated the corresponding test assertions in `tests/unit/test_resolver.py` to verify the correct prefix behavior:

```python
# Updated assertions
assert tmp_dir_name.startswith(".hermeto-source-copy-")
```

This change makes debugging easier when temp cleanup fails or when inspecting the working directory, and maintains consistency with how `TemporaryDirectory` is used elsewhere in the project (see `scm.py` and `gomod.py`).