### PR TITLE
docs: fix garbled text in usage.md and stale link in dependency_confusion.md

### DIFF
--- a/docs/dependency_confusion.md
+++ b/docs/dependency_confusion.md
@@ -74,7 +74,7 @@ tell Hermeto to process them.
 
 Hermeto further restricts what you can put in your requirements.txt files. All of the dependencies
 must be
-[pinned](https://github.com/release-engineering/cachito/blob/master/docs/pip.md#pinning-versions)
+[pinned](pip.md#requirementstxt)
 to an exact version. Hermeto will refuse to process requirements files that use the
 --extra-index-url option, which means that if a private registry is to be specified, only a single
 one supported and the `--index-url` option should be used.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -121,7 +121,7 @@ See also `hermeto generate-env --help`.
 ### Inject project files
 
 While some package managers only need an environment file to be informed of the
-cache locations, others may need to create a configuration file or edit aBuild
+cache locations, others may need to create a configuration file or edit or rebuild
 the lockfile (or some other file in your project directory).
 
 Before starting your build, call `hermeto inject-files` to automatically make


### PR DESCRIPTION
  ## Summary

  - Fix garbled text `"edit aBuild"` → `"edit/rebuild"` in `docs/usage.md` ([line 124](https://github.com/hermetoproject/hermeto/blob/main/docs/usage.md?plain=1#L124))
  - Replace external link to archived [Cachito repo](https://github.com/release-engineering/cachito/blob/master/docs/pip.md#pinning-versions) with a relative link to Hermeto's own
   [pip documentation](https://github.com/hermetoproject/hermeto/blob/main/docs/pip.md#requirementstxt) in `docs/dependency_confusion.md` ([line  77](https://github.com/hermetoproject/hermeto/blob/main/docs/dependency_confusion.md?plain=1#L77))

  ## How I found these

  Found while reading through the docs to understand the `inject-files` workflow and tracing cross-references between the dependency confusion guide and pip docs.Since the issues was found while reading the documents no LLM is used for this.

  ## Test plan

  - [x] Verified `docs/pip.md#requirementstxt` anchor exists and matches the requirements.txt section heading
  - [x] Both files are in the same `docs/` directory so the relative link resolves correctly