### PR TITLE
fix(gomod): correct Go version regex typo in go.mod parsing

### DIFF
--- a/hermeto/core/package_managers/gomod.py
+++ b/hermeto/core/package_managers/gomod.py
@@ -862,7 +862,7 @@ def _get_gomod_version(go_mod_file: RootedPath) -> tuple[str | None, str | None]
     # - 'go 1.21.0'
     # - '   go 1.21.0rc4'
     # - 'go 1.21beta1//commentary'
-    version_str_regex = r"(?P<ver>\d+\.\d+(:?\.\d+)?(?:[a-zA-Z]+\d+)?)"
+    version_str_regex = r"(?P<ver>\d+\.\d+(?:\.\d+)?(?:[a-zA-Z]+\d+)?)"
     post_version_chars_regex = r"\s*(?:\/\/.*)?"
     go_version_regex = rf"^\s*go\s+{version_str_regex}{post_version_chars_regex}$"
     toolchain_version_regex = rf"^\s*toolchain\s+go{version_str_regex}{post_version_chars_regex}$"

--- a/tests/unit/package_managers/test_gomod.py
+++ b/tests/unit/package_managers/test_gomod.py
@@ -1973,6 +1973,7 @@ INVALID_VERSION_STRINGS = [
     "go 1.21prerelease",  # pre-release with no number
     "go 1.21prerelease_4",  # pre-release with non-alphanum character
     "toolchain 1.21",  # missing 'go' prefix for the toolchain spec
+    "go 1.21:.0",  # colon before patch component (was wrongly accepted due to :? vs (?:)
 ]
 
 


### PR DESCRIPTION
**Description**
The version parsing regex in [gomod.py](cci:7://file:///c:/Users/abhay/hemerto/hermeto/tests/integration/test_gomod.py:0:0-0:0) for `go.mod` and `go.work` files contained a character typo: `(:?\.\d+)` instead of the intended non-capturing group `(?:\.\d+)`. 
The former syntax inaccurately defined an optional capturing group that expects an optional colon character, inadvertently allowing malformed Go version strings (like `1.21:.0`) to be accepted.

This PR corrects the regex by properly defining a non-capturing group (`(?:\.\d+)`), ensuring malformed version components are correctly rejected.

**Changes**
* Fixed the `version_str_regex` assignment in [hermeto/core/package_managers/gomod.py](cci:7://file:///c:/Users/abhay/hemerto/hermeto/hermeto/core/package_managers/gomod.py:0:0-0:0) (Line 865).
* Added a new negative test case (`"go 1.21:.0"`) to `INVALID_VERSION_STRINGS` in [tests/unit/package_managers/test_gomod.py](cci:7://file:///c:/Users/abhay/hemerto/hermeto/tests/unit/package_managers/test_gomod.py/c:/Users/abhay/hemerto/hermeto/tests/unit/package_managers/test_gomod.py:0:0-0:0).

**Testing**
* Explictly verified the negative test case guarantees `go 1.21:.0` now throws a failure as expected.
* Verified that all previous valid baseline tests run successfully with zero regressions (`nox -s python` / `pytest`).
