### PR TITLE
fix: ignore dev flag in offline mirror collision check

### DIFF
--- a/hermeto/core/package_managers/yarn_classic/main.py
+++ b/hermeto/core/package_managers/yarn_classic/main.py
@@ -2,6 +2,7 @@
 import logging
 from collections import defaultdict
 from collections.abc import Iterable
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -260,7 +261,8 @@ def _verify_no_offline_mirror_collisions(packages: Iterable[YarnClassicPackage])
         tarball_collisions[tarball_name].append(p)
 
     for tarball_name, packages in tarball_collisions.items():
-        if all(pkg == packages[0] for pkg in packages):
+        first = packages[0]
+        if all(replace(pkg, dev=first.dev) == first for pkg in packages):
             continue
 
         raise PackageManagerError(

--- a/tests/unit/package_managers/yarn_classic/test_main.py
+++ b/tests/unit/package_managers/yarn_classic/test_main.py
@@ -345,6 +345,23 @@ def test_verify_corepack_yarn_version_invalid_version(
         ),
         pytest.param(
             [
+                RegistryPackage(
+                    name="esbuild-wasm",
+                    version="0.25.3",
+                    url="https://registry.yarnpkg.com/esbuild-wasm/-/esbuild-wasm-0.25.3.tgz",
+                    dev=False,
+                ),
+                RegistryPackage(
+                    name="esbuild-wasm",
+                    version="0.25.3",
+                    url="https://registry.yarnpkg.com/esbuild-wasm/-/esbuild-wasm-0.25.3.tgz",
+                    dev=True,
+                ),
+            ],
+            id="alias_resolution_same_tarball_different_dev",
+        ),
+        pytest.param(
+            [
                 LinkPackage(name="foo", version="1.0.0", path=RootedPath("/path/to/foo")),
                 FilePackage(name="bar", version="1.0.0", path=RootedPath("/path/to/bar")),
             ],


### PR DESCRIPTION
Fixes #927

  When `yarn.lock` contains both a dependency and a resolution for the same
  package under an aliased name, pyarn produces two `RegistryPackage` objects
  that are identical except for the `dev` flag. The strict dataclass equality
  check in `_verify_no_offline_mirror_collisions()` treated these as different
  packages and incorrectly raised a `PackageManagerError`.

  Uses `dataclasses.replace()` to normalize the `dev` field before comparing
  so that packages differing only in dev classification are recognized as the
  same tarball.

AI disclosure: Used Claude Opus 4.6 to do the implementation only