### PR TITLE
docs(gomod): add missing GOPROXY to generate-env example

### DIFF
--- a/docs/gomod.md
+++ b/docs/gomod.md
@@ -281,6 +281,7 @@ $ cat hermeto.env
 export GOCACHE=/tmp/hermeto-output/deps/gomod
 export GOMODCACHE=/tmp/hermeto-output/deps/gomod/pkg/mod
 export GOPATH=/tmp/hermeto-output/deps/gomod
+export GOPROXY=file:///tmp/hermeto-output/deps/gomod/pkg/mod/cache/download
 ```
 
 #### Inject project files


### PR DESCRIPTION
The hermeto generate-env command produces four env vars for gomod but the docs example was only showing three. Add the missing GOPROXY variable to the example output