### PR TITLE
docs: add overview of uv.lock format and potential Hermeto integration

### DIFF
--- a/docs/uv-lock.md
+++ b/docs/uv-lock.md
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
 # uv.lock Overview and Potential Hermeto Integration
 
 ## Introduction


### PR DESCRIPTION
This PR adds documentation describing the structure of uv.lock files and how they could potentially integrate with Hermeto.

While Hermeto currently supports Python dependency fetching via pip requirements files, uv is a growing Python package manager that produces a lockfile containing fully resolved dependencies with artifact URLs and hashes.

Understanding this format may help guide future work on supporting uv-based projects.

The document briefly explains:

- uv and its lockfile format
- structure of uv.lock
- artifact metadata (sdist, wheels)
- environment markers