### PR TITLE
tests: integration: mount source dir with shared SELinux context

### DIFF
--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -163,9 +163,9 @@ def build_image_for_test_case(
         "-f",
         str(containerfile_path),
         "-v",
-        f"{source_dir}:{source_dir_mount_point}:Z",
+        f"{source_dir}:{source_dir_mount_point}:z",  # SELinux shared mount
         "-v",
-        f"{output_dir}:{output_dir_mount_point}:Z",
+        f"{output_dir}:{output_dir_mount_point}:Z",  # SELinux exclusive mount
         "--no-cache",
         "--network",
         "none",


### PR DESCRIPTION
This is a pure correctness fix only.

Hermeto container mounts source dir already correctly with a shared context, i.e. with 'z', but the test containers were mounting it exclusively, i.e. with 'Z'. This was undetectable in sequential execution but I hit this when experimenting with parallel test execution approaches. This could in theory be hit when doing heavy advanced debugging on the integration test suite, but we shouldn't hit the problem in practice even after
https://github.com/hermetoproject/hermeto/pull/1296 because that approach replicates the source dir N times.