### PR TITLE
feat: add more-itertools dependency and refactor first_for usage

### DIFF
--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -13,12 +13,12 @@ from typing import Annotated, Any, Literal, Union
 from urllib.parse import urlparse
 
 import pydantic
+from more_itertools import first
 from packageurl import PackageURL
 from typing_extensions import Self
 
 from hermeto import APP_NAME
 from hermeto.core.models.property_semantics import Property, PropertyEnum, PropertySet
-from hermeto.core.utils import first_for
 
 log = logging.getLogger(__name__)
 
@@ -647,7 +647,10 @@ class SPDXSbom(pydantic.BaseModel):
         unidirectionally_related_package = lambda p: inverse_relationships.get(p) == self.SPDXID
         # Note: defaulting to top-level SPDXID is inherited from the original implementation.
         # It is unclear if it is really needed, but is left around to match the precedent.
-        root_id = first_for(unidirectionally_related_package, direct_relationships, self.SPDXID)
+        root_id = first(
+            (k for k in direct_relationships if unidirectionally_related_package(k)),
+            default=self.SPDXID,
+        )
         return root_id
 
     # NOTE: having this as cached will cause trouble when sequentially

--- a/hermeto/core/utils.py
+++ b/hermeto/core/utils.py
@@ -7,11 +7,9 @@ import re
 import shutil
 import subprocess
 import sys
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from functools import cache
-from itertools import filterfalse, tee
 from pathlib import Path
-from typing import Any
 
 from hermeto import APP_NAME
 from hermeto.core.config import get_config
@@ -207,14 +205,3 @@ def get_cache_dir() -> Path:
     except KeyError:
         cache_dir = Path.home().joinpath(".cache")
     return cache_dir.joinpath(f"{APP_NAME}")
-
-
-def first_for(predicate: Callable, iterable: Iterable, fallback: Any) -> Any:
-    """Return the first match of predicate in iterable or fallback value."""
-    return next((x for x in iterable if predicate(x)), fallback)
-
-
-def partition_by(predicate: Callable, iterable: Iterable) -> tuple[Iterable, Iterable]:
-    """Partition iterable in two by predicate."""
-    i1, i2 = tee(iterable)
-    return filterfalse(predicate, i1), filter(predicate, i2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "aiohttp-retry",
   "createrepo-c ; sys_platform == 'linux'",
   "gitpython",
+  "more-itertools",
   "packageurl-python",
   "packaging",
   "pyarn",


### PR DESCRIPTION
Add more-itertools as a project dependency and replace the custom first_for() utility with more_itertools.first(). Also remove the unused partition_by() function and clean up now-unused imports.

Closes #1355
This pull request refactors how the code finds the first matching element in an iterable by replacing a custom utility function with a standard library function from `more-itertools`. It also removes unused utility code and updates dependencies accordingly.

**Refactoring and dependency updates:**

* Replaced the custom `first_for` function in `hermeto/core/models/sbom.py` with the `first` function from the `more-itertools` library for finding the first matching element in an iterable, simplifying the code and reducing custom utilities. [[1]](diffhunk://#diff-85b72f18b536009030e84b20b188d109a51007eaf91e9b859b82a8c1e9b7e6cfR16-L21) [[2]](diffhunk://#diff-85b72f18b536009030e84b20b188d109a51007eaf91e9b859b82a8c1e9b7e6cfL650-R653)
* Added `more-itertools` to the dependencies in `pyproject.toml` to support this change.

**Code cleanup:**

* Removed the now-unused `first_for` and `partition_by` utility functions, as well as some unused imports, from `hermeto/core/utils.py`. [[1]](diffhunk://#diff-9b19e9d1381492d1235b22cd65625cac8c6b921e7257ecef4ac8bab6f2a41409L10-L14) [[2]](diffhunk://#diff-9b19e9d1381492d1235b22cd65625cac8c6b921e7257ecef4ac8bab6f2a41409L210-L220)

AI Disclosure: Used Claude Opus 4.6.