### PR TITLE
fix(gomod): preserve symlink names in toolchain detection

### DIFF
--- a/hermeto/core/package_managers/gomod.py
+++ b/hermeto/core/package_managers/gomod.py
@@ -1809,9 +1809,16 @@ def _list_installed_toolchains() -> set[Go]:
     for path in (HERMETO_GO_INSTALL_DIR, get_cache_dir()):
         paths |= {p.resolve().parent for p in Path(path).rglob("bin/go")}
 
-    # filter out symlinked paths
-    go_binary_paths = set([Path(p, "go").resolve() for p in paths if Path(p, "go").exists()])
-    for bin_path in go_binary_paths:
+    # Resolve paths for deduplication only; preserve original symlink names for the binary.
+    # Tools like snap rely on argv[0] for dispatch, resolving /snap/bin/go into /usr/bin/snap
+    # which breaks Go execution.
+    go_binary_paths: dict[Path, Path] = {}
+    for p in paths:
+        bin_path = Path(p, "go")
+        if bin_path.exists():
+            go_binary_paths.setdefault(bin_path.resolve(), bin_path)
+
+    for bin_path in go_binary_paths.values():
         try:
             log.debug("Probing %s toolchain...", bin_path)
             ret.add(Go(binary=bin_path.as_posix()))


### PR DESCRIPTION
 Description:                                                                                                                                   
  Resolves: #1372                                  
                                                                                                                                                 
  ### Problem                              
                                                                                                                                                 
  `_get_available_go_toolchains()` uses `Path.resolve()` on Go binary paths to  filter out duplicates. On systems where Go is installed via snap, this resolves  `/snap/bin/go` → `/usr/bin/snap`, since snap binaries are symlinks to the snap                                                                 
  dispatcher.                                                                                                                                    
                                                                                                                                                 
  Snap determines which application to run based on `argv[0]` (the symlink name).                                                                
  Once resolved, the binary name is lost and hermeto ends up executing                                                                           
  `/usr/bin/snap env GOVERSION`, which snap does not recognize as a valid command.                                                               
                                                                                                                                                 
  ### Fix

  Resolved paths are now used only as deduplication keys. The original (unresolved)  path is preserved and passed to the `Go` constructor, so snap dispatch continues  to work correctly.

  ### Testing

<img width="1765" height="311" alt="Screenshot from 2026-03-09 15-19-49" src="https://github.com/user-attachments/assets/fc35886b-10ad-462e-a8c9-896b6dfdf798" />

  - Verified the fix locally on Ubuntu with snap-installed Go (1.25.7)
  - Tested against [junegunn/fzf](https://github.com/junegunn/fzf) and  [hashicorp/terraform](https://github.com/hashicorp/terraform) both complete successfully after the change
  - All 1391 unit tests pass, including the existing `filter_symlinked_path`    deduplication test
  - Linter (ruff + mypy) passes
