### PR TITLE
 fix(cargo): wrap generic subprocess errors in PackageManagerError

### DIFF
--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -15,7 +15,13 @@ import tomlkit.exceptions
 from packageurl import PackageURL
 
 from hermeto import APP_NAME
-from hermeto.core.errors import LockfileNotFound, NotAGitRepo, PackageRejected, UnexpectedFormat
+from hermeto.core.errors import (
+    LockfileNotFound,
+    NotAGitRepo,
+    PackageManagerError,
+    PackageRejected,
+    UnexpectedFormat,
+)
 from hermeto.core.models.input import Mode, Request
 from hermeto.core.models.output import Annotation, Component, ProjectFile, RequestOutput
 from hermeto.core.models.sbom import create_backend_annotation, spdx_now
@@ -377,7 +383,10 @@ def _run_cmd_watching_out_for_lock_mismatch(
             else:
                 raise PackageWithCorruptLockfileRejected(str(package_dir))
         else:
-            raise
+            raise PackageManagerError(
+                f"Cargo execution failed: `{' '.join(cmd)}` failed with rc={e.returncode}",
+                stderr=e.stderr,
+            ) from e
 
 
 def _find_local_packages(package_dir: RootedPath) -> dict[str, str]:


### PR DESCRIPTION
- When `cargo vendor` fails for reasons other than a lockfile mismatch, the cargo backend re-raises the raw `CalledProcessError`, leaking a  Python traceback to the user
  - Other backends (gomod, yarn, bundler) wrap all subprocess errors in `PackageManagerError` consistently
  - This change applies the same pattern to the cargo backend's fallback error path

  Resolves: https://github.com/hermetoproject/hermeto/issues/1376
  ## Changes

  - Added `PackageManagerError` to the imports in `cargo/main.py`
  - Replaced the bare `raise` with `PackageManagerError` wrapping, including the command, return code, and stderr (same pattern as gomod/yarn)

  ## Testing

  - Tested on [rust-lang/mdBook](https://github.com/rust-lang/mdBook)  before: raw traceback, after: clean `PackageManagerError`

<img width="1836" height="733" alt="Screenshot from 2026-03-10 15-00-29" src="https://github.com/user-attachments/assets/1a1a0307-7bb5-4197-b9ba-b198df4c6893" />

  - All cargo unit tests pass (16/16)
  - Linting and type checking clean
