### PR TITLE
fix(npm): handle missing version field in workspace lockfiles

### DIFF
--- a/hermeto/core/package_managers/npm.py
+++ b/hermeto/core/package_managers/npm.py
@@ -263,8 +263,10 @@ class PackageLock:
 
     def get_main_package(self) -> NpmComponentInfo:
         """Return a dict with sbom component data for the main package."""
-        name = self._lockfile_data["name"]
-        version = self._lockfile_data["version"]
+        name = self._lockfile_data.get("name")
+        if not name:
+            raise UnexpectedFormat("The main package in package-lock.json is missing a 'name'.")
+        version = self._lockfile_data.get("version")
         purl = self._purlifier.get_purl(name, version, "file:.", integrity=None)
         return {
             "name": name,


### PR DESCRIPTION
 ## Summary                                                                                                                                     
  - Fix `KeyError: 'version'` crash when processing npm workspace projects where root `package-lock.json` lacks a `version` field
  - Use `.get()` instead of direct key access in `get_main_package()`, consistent with existing `_get_packages()` pattern                        
                                                                                                                                                 
  ## Test plan                                                                                                                                   
  - [x] Reproduced crash on [wixplosives/sample-monorepo](https://github.com/wixplosives/sample-monorepo) (npm workspace without root version)
  - [x] Verified fix: all dependencies fetched successfully after change
  - [x] All 1384 unit tests pass

  Resolves: https://github.com/hermetoproject/hermeto/issues/1382
