### PR TITLE
fix(pip): identify wheel package type on URLs with fragments

### DIFF
--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -356,7 +356,8 @@ def _process_url_req(
         download_info=_download_url_package(req, pip_deps_dir, trusted_hosts),
         **kwargs,
     )
-    if req.url.endswith(WHEEL_FILE_EXTENSION):
+    parsed_url = urlparse.urlparse(req.url)
+    if parsed_url.path.endswith(WHEEL_FILE_EXTENSION):
         result["package_type"] = "wheel"
 
     return result

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -1643,3 +1643,27 @@ def test_fetch_pip_source_correctly_reraises_when_there_is_a_dependency_cargo_lo
 
     with pytest.raises(PackageWithCorruptLockfileRejected):
         pip.fetch_pip_source(request)
+
+
+@pytest.mark.parametrize(
+    ("test_url", "expected_type"),
+    [
+        ("https://example.com/pkg-1.0-py3-none-any.whl", "wheel"),
+        ("https://example.com/pkg-1.0-py3-none-any.whl#cachito_hash=sha256:123", "wheel"),
+        ("https://example.com/pkg-1.0.tar.gz", ""),
+        ("https://example.com/pkg-1.0.tar.gz#cachito_hash=sha256:123", ""),
+    ],
+)
+@mock.patch("hermeto.core.package_managers.pip.main._download_url_package")
+@mock.patch("hermeto.core.package_managers.pip.main._process_req")
+def test_process_url_req(
+    mock_process_req: mock.Mock,
+    mock_download_url_package: mock.Mock,
+    test_url: str,
+    expected_type: str,
+) -> None:
+    """Ensure wheel packages are correctly identified even with URL fragments."""
+    req = mock_requirement("pkg", "url", url=test_url)
+    mock_process_req.return_value = {"package_type": ""}
+    result = pip._process_url_req(req, pip_deps_dir=mock.Mock(), trusted_hosts=set())
+    assert result.get("package_type") == expected_type


### PR DESCRIPTION
<h1>Summary:</h1>
Found a small bug where direct URLs for wheels aren't being identified if they have a # hash at the end.

<h2>The Bug</h2>

 _process_url_req function uses .endswith() to check the URL. If a user attaches a hash fragment along with the url, the check fails because the string ends with the hash value, not .whl.

Broken URL: https://.../pkg.whl#cachito_hash=sha256:123...

Result: The binary flag is doesnt who on the SBOM.

<h2>Reproduction</h2>
Add a direct URL with a hash to requirements.txt:

colorama @ https://.../colorama-0.4.6-py2.py3-none-any.whl#cachito_hash=sha256:...
eg:
requirements.txt:
<img width="1008" height="234" alt="image" src="https://github.com/user-attachments/assets/cc90c54b-fe54-426a-bec0-414f8a4b7584" />

Run hermeto fetch-deps.

Check the bom.json. The hermeto:pip:package:binary property won't be there.


<img width="816" height="256" alt="Screenshot 2026-03-11 221958" src="https://github.com/user-attachments/assets/7c9692a6-65e3-44cb-a7e2-b6f90ab350a1" />

<h2>The Fix</h2>

Swapped the raw string check for urlparse.urlparse(req.url).path. This matching the logic used in other places in the backend asw.

After:
<img width="877" height="301" alt="Screenshot 2026-03-11 222005" src="https://github.com/user-attachments/assets/123e767b-3c84-4e9f-9a4f-833148a8eb86" />

