### PR TITLE
fix(sbom): standardize __hash__ to prevent data loss and collisions.

### DIFF
--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -501,14 +501,15 @@ class SPDXPackage(pydantic.BaseModel):
 
     def __hash__(self) -> int:
         return hash(
-            hash(self.SPDXID)
-            + hash(self.name)
-            + hash(self.versionInfo)
-            + hash(self.downloadLocation)
-            + sum(hash(e) for e in self.externalRefs)
-            + sum(hash(a) for a in self.annotations)
-            # NOTE: in an exceptionally rare case there could be a slim chance of collision here.
-            + hash(self.sourceInfo)
+            (
+                self.SPDXID,
+                self.name,
+                self.versionInfo,
+                self.downloadLocation,
+                tuple(self.externalRefs),
+                tuple(self.annotations),
+                self.sourceInfo,
+            )
         )
 
     @staticmethod
@@ -556,8 +557,7 @@ class SPDXRelation(pydantic.BaseModel):
 
     def __hash__(self) -> int:
         return hash(
-            hash(self.spdxElementId + self.relatedSpdxElement + self.relationshipType)
-            + hash(self.comment)
+            (self.spdxElementId, self.relatedSpdxElement, self.relationshipType, self.comment)
         )
 
 
@@ -585,10 +585,14 @@ class SPDXSbom(pydantic.BaseModel):
 
     def __hash__(self) -> int:
         return hash(
-            hash(self.name + self.documentNamespace)
-            + hash(SPDXCreationInfo)
-            + sum(hash(p) for p in self.packages)
-            + sum(hash(r) for r in self.relationships)
+            (
+                self.name,
+                self.documentNamespace,
+                tuple(self.creationInfo.creators),
+                self.creationInfo.created,
+                tuple(self.packages),
+                tuple(self.relationships),
+            )
         )
 
     @classmethod

--- a/tests/unit/models/test_sbom.py
+++ b/tests/unit/models/test_sbom.py
@@ -17,6 +17,7 @@ from hermeto.core.models.sbom import (
     Metadata,
     Property,
     Sbom,
+    SPDXCreationInfo,
     SPDXPackage,
     SPDXPackageAnnotation,
     SPDXPackageExternalRefPackageManagerPURL,
@@ -1516,3 +1517,96 @@ def test_deduplicate_spdx_packages() -> None:
 
     assert len(deduped_packages) == len(expected_packages)
     assert deduped_packages == expected_packages
+
+
+class TestSPDXHashingLogic:
+    """Regression tests to ensure mathematically distinct objects produce distinct hashes, and identical objects produce identical hashes."""
+
+    def test_spdx_relation_hash_prevents_concatenation_collision(self) -> None:
+        rel_a = SPDXRelation(
+            spdxElementId="pkg-a", relatedSpdxElement="1", relationshipType="DEPENDS_ON"
+        )
+        rel_b = SPDXRelation(
+            spdxElementId="pkg-", relatedSpdxElement="a1", relationshipType="DEPENDS_ON"
+        )
+        rel_a_clone = SPDXRelation(
+            spdxElementId="pkg-a", relatedSpdxElement="1", relationshipType="DEPENDS_ON"
+        )
+
+        assert rel_a == rel_a_clone
+        assert hash(rel_a) == hash(rel_a_clone)
+
+        assert rel_a != rel_b
+        assert hash(rel_a) != hash(rel_b)
+
+    def test_spdx_package_hash_prevents_commutative_order_collision(self) -> None:
+        ann_1 = SPDXPackageAnnotation(
+            annotator="Tool A",
+            annotationDate=SPDX_EPOCH_STRFTIME,
+            annotationType="OTHER",
+            comment="1",
+        )
+        ann_2 = SPDXPackageAnnotation(
+            annotator="Tool B",
+            annotationDate=SPDX_EPOCH_STRFTIME,
+            annotationType="OTHER",
+            comment="2",
+        )
+
+        pkg_a = SPDXPackage(
+            SPDXID="SPDXRef-1",
+            name="lib",
+            versionInfo="1",
+            annotations=[ann_1, ann_2],
+            externalRefs=[],
+            downloadLocation="NOASSERTION",
+        )
+        pkg_a_clone = SPDXPackage(
+            SPDXID="SPDXRef-1",
+            name="lib",
+            versionInfo="1",
+            annotations=[ann_1, ann_2],
+            externalRefs=[],
+            downloadLocation="NOASSERTION",
+        )
+        pkg_b = SPDXPackage(
+            SPDXID="SPDXRef-1",
+            name="lib",
+            versionInfo="1",
+            annotations=[ann_2, ann_1],
+            externalRefs=[],
+            downloadLocation="NOASSERTION",
+        )
+
+        assert pkg_a == pkg_a_clone
+        assert hash(pkg_a) == hash(pkg_a_clone)
+
+        assert pkg_a != pkg_b
+        assert hash(pkg_a) != hash(pkg_b)
+
+    def test_spdx_sbom_hash_respects_creation_info(self) -> None:
+        info_1 = SPDXCreationInfo(created="2026-01-01T10:00:00Z", creators=["Tool: Builder"])
+        info_1_clone = SPDXCreationInfo(created="2026-01-01T10:00:00Z", creators=["Tool: Builder"])
+        info_2 = SPDXCreationInfo(created="2026-01-01T10:05:00Z", creators=["Tool: Builder"])
+
+        sbom_1 = SPDXSbom(
+            SPDXID="SPDXRef-DOCUMENT",
+            documentNamespace="https://example.com/1",
+            creationInfo=info_1,
+        )
+        sbom_1_clone = SPDXSbom(
+            SPDXID="SPDXRef-DOCUMENT",
+            documentNamespace="https://example.com/1",
+            creationInfo=info_1_clone,
+        )
+        sbom_2 = SPDXSbom(
+            SPDXID="SPDXRef-DOCUMENT",
+            documentNamespace="https://example.com/1",
+            creationInfo=info_2,
+        )
+
+        assert sbom_1 == sbom_1_clone
+        assert hash(sbom_1) == hash(sbom_1_clone)
+
+        assert sbom_1 != sbom_2
+        assert hash(sbom_1) != hash(sbom_2)


### PR DESCRIPTION
### Description
While reviewing the SPDX models, I identified several unsafe `__hash__` implementations that cause silent hash collisions. Because Hermeto uses `set()` operations to merge relationships and deduplicate data (e.g., `list(set(self.relationships + processed_other))`), these collisions lead to silent data loss of valid dependency information.

This PR standardizes `SPDXPackage`, `SPDXRelation`, and `SPDXSbom` to use native Python tuple hashing (aligning them with the existing correct implementation already used in `SPDXPackageExternalRef`).

### Specific Fixes
1. **String Concatenation Collisions (`SPDXRelation` and `SPDXSbom`)**
   Hashing concatenated strings erases variable boundaries. For example, `pkg-a` + `123` yields the same hash as `pkg-a123` + `""`. If both exist in a merged SBOM, `set()` will silently delete one.
2. **Class Hashing Bug (`SPDXSbom`)**
   The method called `hash(SPDXCreationInfo)` instead of hashing the instance data. This means two SBOMs generated at different times evaluated to the exact same hash, completely ignoring timestamps and creators. 
3. **Commutative Addition Erasure (`SPDXPackage`)**
   Summing integer hashes (`hash(a) + hash(b)`) destroys list ordering and drastically increases collision risk.

<details>
<summary>Proof of Concept: Silent Data Loss in SPDXRelation</summary>

Here is a minimal reproduction showing how the previous concatenation method silently drops dependencies during a `set()` merge due to boundary erasure:

```python
class SPDXRelation:
    def __init__(self, spdxElementId, relatedSpdxElement, relationshipType, comment=""):
        self.spdxElementId = spdxElementId
        self.relatedSpdxElement = relatedSpdxElement
        self.relationshipType = relationshipType
        self.comment = comment

    # Previous broken implementation
    def __hash__(self) -> int:
        return hash(
            hash(self.spdxElementId + self.relatedSpdxElement + self.relationshipType)
            + hash(self.comment)
        )

    def __eq__(self, other):
        return type(self) == type(other) and hash(self) == hash(other)

# Two fundamentally different dependencies
rel_A = SPDXRelation("SPDXRef-Package-X", "-v1", "DEPENDS_ON")
rel_B = SPDXRelation("SPDXRef-Package-X-v", "1", "DEPENDS_ON")

# Simulate Hermeto merging the SBOMs using a set (like line 699 of sbom.py)
merged_relationships = list(set([rel_A, rel_B]))

print(f"Total relationships after merge: {len(merged_relationships)}")
# Output: 1  <--- FATAL: Data Loss! The second dependency was silently erased.