### PR TITLE
Allow testing release workflow without requiring a release tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
     inputs:
       push_latest:
-        description: 'Also push as latest tag'
+        description: "Also push as latest tag"
         required: true
         type: boolean
         default: false
@@ -60,6 +60,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest,enable=${{ (github.event_name == 'workflow_dispatch' && inputs.push_latest) || (github.event_name == 'release' && !github.event.release.prerelease) }}
+            type=raw,value=test,enable=${{ github.event_name == 'workflow_dispatch' }}
 
       # Multi-arch build setup
       - name: Build and push container image
@@ -68,6 +69,6 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.event_name == 'release' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Fixes: #1290
Tested the release workflow using workflow_dispatch and reproduced the failure where the build step errored because no tag was generated without a release tag.

docker/metadata-action produces no tags outside a release event while docker/build-push-action still attempts to push an image.

Changed push: true to `push: ${{ github.event_name == 'release' }}` and added a fallback test tag for manual runs.

This allows the same workflow to be executed for testing without requiring a release.

Verified by running the workflow manually and confirming the build succeeds with a test tag and no image push.