### PR TITLE
fix(pip): support URL fragments in wheel detection

### DIFF
--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -356,7 +356,8 @@ def _process_url_req(
         download_info=_download_url_package(req, pip_deps_dir, trusted_hosts),
         **kwargs,
     )
-    if req.url.endswith(WHEEL_FILE_EXTENSION):
+    parsed_url = urlparse.urlparse(req.url)
+    if parsed_url.path.endswith(WHEEL_FILE_EXTENSION):
         result["package_type"] = "wheel"
 
     return result

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -1643,3 +1643,29 @@ def test_fetch_pip_source_correctly_reraises_when_there_is_a_dependency_cargo_lo
 
     with pytest.raises(PackageWithCorruptLockfileRejected):
         pip.fetch_pip_source(request)
+
+
+@pytest.mark.parametrize(
+    ("test_url", "expected_type"),
+    [
+        ("https://example.com/pkg-1.0-py3-none-any.whl", "wheel"),
+        ("https://example.com/pkg-1.0-py3-none-any.whl#sha256=08695f5ad7", "wheel"),
+        ("https://example.com/pkg-1.0-py3-none-any.whl?v=1.0#sha256=08695f5ad7", "wheel"),
+        ("https://example.com/pkg-1.0.tar.gz", ""),
+        ("https://example.com/pkg-1.0.tar.gz#sha256=08695f5ad7", ""),
+        ("https://example.com/pkg-1.0.tar.gz?v=1.0#sha256=08695f5ad7", ""),
+    ],
+)
+@mock.patch("hermeto.core.package_managers.pip.main._download_url_package")
+@mock.patch("hermeto.core.package_managers.pip.main._process_req")
+def test_process_url_req(
+    mock_process_req: mock.Mock,
+    mock_download_url_package: mock.Mock,
+    test_url: str,
+    expected_type: str,
+) -> None:
+    """Ensure wheel packages are correctly identified even with URL fragments."""
+    req = mock_requirement("pkg", "url", url=test_url)
+    mock_process_req.return_value = {"package_type": ""}
+    result = pip._process_url_req(req, pip_deps_dir=mock.Mock(), trusted_hosts=set())
+    assert result.get("package_type") == expected_type


### PR DESCRIPTION
This PR ensures that pip wheel packages are correctly identified even when the requirement URL contains a fragment (e.g., #sha256=...).

The current logic uses .endswith(".whl") on the full URL string. While #cachito_hash was recently deprecated (as noted in #1387), standard PEP-compliant URLs frequently use fragments for integrity checks (e.g., #sha256=...).

Currently, any URL with a fragment causes the wheel detection to fail, because it misidentifies the package as a source distribution (sdist) and fails to set the binary flag in the SBOM.

The Fix
Refactored _process_url_req in hermeto/core/package_managers/pip/main.py to use urlparse(url).path instead of a raw string check. This isolates the filename from any query parameters or fragments.

Updated unit tests in tests/unit/package_managers/pip/test_main.py to use standard #sha256 fragments.

Related Issues
Supersedes #1387.