### PR TITLE
Add Actionlint workflow to validate GitHub Actions workflows

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,11 +1,11 @@
 name: Lint workflows
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - ".github/workflows/*.yml"
       - ".github/workflows/*.yaml"
-
   push:
     branches:
       - main


### PR DESCRIPTION
Fixes: #1290
This PR adds a CI workflow that runs actionlint.

The goal is to catch invalid expressions or incorrect GitHub context usage for example non-existent fields like `github.event.release.latest` during PR validation, before such changes reach workflows like the release pipeline.

This PR is mainly intended to verify that this approach works. Since the workflow is newly added, it needs to run at least once before it appears in the Actions UI. Opening this PR allows the workflow to be triggered and verified. If this aligns with the intended solution, I’d be happy to refine or extend the implementation based on feedback.

Hope this approach would solve the problems mentioned in the discussion #1390.