### PR TITLE
Normalize pip dependency versions in PURLs

### DIFF
--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -10,7 +10,8 @@ from urllib import parse as urlparse
 
 import pypi_simple
 from packageurl import PackageURL
-from packaging.utils import canonicalize_name
+from packaging.utils import canonicalize_name, canonicalize_version
+from packaging.version import InvalidVersion
 
 from hermeto.core.checksum import ChecksumInfo, must_match_any_checksum
 from hermeto.core.config import get_config
@@ -156,7 +157,16 @@ def _generate_purl_dependency(package: dict[str, Any]) -> str:
     qualifiers: dict[str, str] | None = None
 
     if dependency_kind == "pypi":
-        version = package["version"]
+        raw_version = package["version"]
+        try:
+            version = canonicalize_version(raw_version)
+        except InvalidVersion:
+            log.warning(
+                "Cannot canonicalize version %r for dependency %s, keeping raw value",
+                raw_version,
+                name,
+            )
+            version = raw_version
         index_url = package["index_url"]
         if index_url.rstrip("/") != pypi_simple.PYPI_SIMPLE_ENDPOINT.rstrip("/"):
             qualifiers = {"repository_url": index_url}

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -1430,7 +1430,7 @@ def test_fetch_pip_source(
                 "kind": "pypi",
                 "index_url": pypi_simple.PYPI_SIMPLE_ENDPOINT,
             },
-            "pkg:pypi/pypi-package@1.0.0",
+            "pkg:pypi/pypi-package@1",
         ),
         (
             {
@@ -1441,7 +1441,7 @@ def test_fetch_pip_source(
                 "kind": "pypi",
                 "index_url": CUSTOM_PYPI_ENDPOINT,
             },
-            f"pkg:pypi/mypypi-package@2.0.0?repository_url={CUSTOM_PYPI_ENDPOINT}",
+            f"pkg:pypi/mypypi-package@2?repository_url={CUSTOM_PYPI_ENDPOINT}",
         ),
         (
             {
@@ -1494,12 +1494,42 @@ def test_fetch_pip_source(
             },
             f"pkg:pypi/https-dependency?checksum=sha256:de526c1&download_url=https://github.com/my-org/https_dependency/{'a' * 40}/file.tar.gz",
         ),
+        (
+            {
+                "name": "version_variants",
+                "version": "1.0",
+                "type": "pip",
+                "dev": False,
+                "kind": "pypi",
+                "index_url": pypi_simple.PYPI_SIMPLE_ENDPOINT,
+            },
+            "pkg:pypi/version-variants@1",
+        ),
     ],
 )
 def test_generate_purl_dependencies(dependency: dict[str, Any], expected_purl: str) -> None:
     purl = pip._generate_purl_dependency(dependency)
 
     assert purl == expected_purl
+
+
+def test_generate_purl_dependencies_version_normalization() -> None:
+    """Different textual versions should canonicalize to the same PURL for PyPI deps."""
+    base_dep = {
+        "name": "normpkg",
+        "type": "pip",
+        "dev": False,
+        "kind": "pypi",
+        "index_url": pypi_simple.PYPI_SIMPLE_ENDPOINT,
+    }
+
+    versions = ["1.0", "1.0.0", "1.00", "01.0"]
+    purls = {
+        v: pip._generate_purl_dependency({**base_dep, "version": v}) for v in versions
+    }
+
+    # All variants should yield the same PURL after canonicalization
+    assert len(set(purls.values())) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

This PR normalizes pip dependency versions before constructing PURLs so that different textual representations of the same version (e.g. `1.0`, `1.0.0`, `1.00`, `01.0`) no longer produce distinct PURLs and duplicate SBOM components.

## Details

- Update `_generate_purl_dependency` for `kind == "pypi"` to:
  - Use `canonicalize_version(package["version"])` for the PURL `version` field.
  - Fall back to the raw version and log a warning if `InvalidVersion` is raised.
- Leave VCS and URL dependencies unchanged (still use the raw `version` string).
- Adjust existing PURL unit tests to expect canonicalized versions in PyPI PURLs.
- Add a unit test that verifies all of `["1.0", "1.0.0", "1.00", "01.0"]` yield the same PURL.

This addresses the behavior described in #1406, where SBOM deduplication based on `Component.key()` (PURL) treated these variants as different components.

## Testing

- `pytest tests/unit/package_managers/pip/test_main.py`
- `pytest tests/unit`
- (Full `pytest` run also performed; integration errors are unrelated to this change and due to missing integration environment.)