### PR TITLE
refactor: use more-itertools utilities for iterable manipulations

### DIFF
--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -7,18 +7,18 @@ from collections import defaultdict
 from collections.abc import Iterable
 from datetime import datetime, timezone
 from functools import cached_property, partial, reduce
-from itertools import chain, groupby
+from itertools import groupby
 from pathlib import Path
 from typing import Annotated, Any, Literal, Union
 from urllib.parse import urlparse
 
 import pydantic
+from more_itertools import first_true, flatten
 from packageurl import PackageURL
 from typing_extensions import Self
 
 from hermeto import APP_NAME
 from hermeto.core.models.property_semantics import Property, PropertyEnum, PropertySet
-from hermeto.core.utils import first_for
 
 log = logging.getLogger(__name__)
 
@@ -233,9 +233,7 @@ class Sbom(pydantic.BaseModel):
                 # in the future. It is a very rare corner case, though, and it only matters when
                 # merging multiple CycloneDX SBOMs.
                 annotations=self.annotations + other.annotations,
-                components=merge_component_properties(
-                    chain.from_iterable(s.components for s in [self, other])
-                ),
+                components=merge_component_properties([*self.components, *other.components]),
             )
         else:
             return self + other.to_cyclonedx()
@@ -354,7 +352,7 @@ class Sbom(pydantic.BaseModel):
             relationships=relationships,
             documentNamespace=doc_namespace,
             creationInfo=SPDXCreationInfo(
-                creators=sum([creator(tool) for tool in self.metadata.tools], []),
+                creators=list(flatten(creator(tool) for tool in self.metadata.tools)),
                 created=spdx_now(),
             ),
         )
@@ -652,7 +650,9 @@ class SPDXSbom(pydantic.BaseModel):
         unidirectionally_related_package = lambda p: inverse_relationships.get(p) == self.SPDXID
         # Note: defaulting to top-level SPDXID is inherited from the original implementation.
         # It is unclear if it is really needed, but is left around to match the precedent.
-        root_id = first_for(unidirectionally_related_package, direct_relationships, self.SPDXID)
+        root_id = first_true(
+            direct_relationships, pred=unidirectionally_related_package, default=self.SPDXID
+        )
         return root_id
 
     # NOTE: having this as cached will cause trouble when sequentially

--- a/hermeto/core/package_managers/gomod/go.py
+++ b/hermeto/core/package_managers/gomod/go.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 import pydantic
+from more_itertools import first
 from packaging import version
 from pydantic.alias_generators import to_pascal
 from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
@@ -464,7 +465,7 @@ def _select_toolchain(go_mod_file: RootedPath, installed_toolchains: Iterable[Go
             log.debug("Installing Go toolchain version '%s'", target_version)
             release_str = f"go{str(target_version)}"
             try:
-                work_toolchain = next(iter(installed_toolchains))
+                work_toolchain = first(installed_toolchains)
                 go = Go.from_missing_toolchain(release_str, work_toolchain.binary)
                 log.debug("Using Go toolchain version '%s'", go.version)
             except Exception as ex:

--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NoReturn, Optional
 
 import git
 import semver
+from more_itertools import unique_everseen
 from packageurl import PackageURL
 
 from hermeto import APP_NAME
@@ -923,14 +924,8 @@ def _deduplicate_resolved_modules(
     package_modules: Iterable[ParsedModule],
     downloaded_modules: Iterable[ParsedModule],
 ) -> Iterable[ParsedModule]:
-    modules_by_name_and_version: dict[ModuleID, ParsedModule] = {}
-
     # package_modules have the replace data, so they should take precedence in the deduplication
-    for module in chain(package_modules, downloaded_modules):
-        # get the module for this name+version or create a new one
-        modules_by_name_and_version.setdefault(_get_module_id(module), module)
-
-    return modules_by_name_and_version.values()
+    return list(unique_everseen(chain(package_modules, downloaded_modules), key=_get_module_id))
 
 
 class GoCacheTemporaryDirectory(tempfile.TemporaryDirectory):

--- a/hermeto/core/package_managers/yarn_classic/main.py
+++ b/hermeto/core/package_managers/yarn_classic/main.py
@@ -5,6 +5,8 @@ from collections.abc import Iterable
 from pathlib import Path
 from typing import Any, ClassVar
 
+from more_itertools import all_equal
+
 from hermeto import APP_NAME
 from hermeto.core.errors import (
     ExitError,
@@ -267,7 +269,7 @@ def _verify_no_offline_mirror_collisions(packages: Iterable[YarnClassicPackage])
         tarball_collisions[tarball_name].append(p)
 
     for tarball_name, packages in tarball_collisions.items():
-        if all(pkg == packages[0] for pkg in packages):
+        if all_equal(packages):
             continue
 
         raise PackageManagerError(

--- a/hermeto/core/package_managers/yarn_classic/workspaces.py
+++ b/hermeto/core/package_managers/yarn_classic/workspaces.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: GPL-3.0-only
 import logging
 from collections.abc import Generator, Iterable
-from itertools import chain
 from pathlib import Path
 from typing import Any
 
 import pydantic
+from more_itertools import flatten
 
 from hermeto.core.package_managers.yarn_classic.project import PackageJson
 from hermeto.core.rooted_path import RootedPath
@@ -52,7 +52,7 @@ def _get_workspace_paths(workspaces_globs: list[str], source_dir: RootedPath) ->
     def all_paths_matching(glob: str) -> Generator[Path, None, None]:
         return (path.resolve() for path in source_dir.path.glob(glob) if path.is_dir())
 
-    return list(chain.from_iterable(map(all_paths_matching, workspaces_globs)))
+    return list(flatten(map(all_paths_matching, workspaces_globs)))
 
 
 def _extract_workspaces_globs(package: dict[str, Any]) -> list[str]:

--- a/hermeto/core/utils.py
+++ b/hermeto/core/utils.py
@@ -7,11 +7,9 @@ import re
 import shutil
 import subprocess
 import sys
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Sequence
 from functools import cache
-from itertools import filterfalse, tee
 from pathlib import Path
-from typing import Any
 
 from hermeto import APP_NAME
 from hermeto.core.config import get_config
@@ -207,14 +205,3 @@ def get_cache_dir() -> Path:
     except KeyError:
         cache_dir = Path.home().joinpath(".cache")
     return cache_dir.joinpath(f"{APP_NAME}")
-
-
-def first_for(predicate: Callable, iterable: Iterable, fallback: Any) -> Any:
-    """Return the first match of predicate in iterable or fallback value."""
-    return next((x for x in iterable if predicate(x)), fallback)
-
-
-def partition_by(predicate: Callable, iterable: Iterable) -> tuple[Iterable, Iterable]:
-    """Partition iterable in two by predicate."""
-    i1, i2 = tee(iterable)
-    return filterfalse(predicate, i1), filter(predicate, i2)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "aiohttp-retry",
   "createrepo-c ; sys_platform == 'linux'",
   "gitpython",
+  "more-itertools",
   "packageurl-python",
   "packaging",
   "pyarn",

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -877,6 +877,10 @@ mkdocs-material-extensions==1.3.1 \
     --hash=sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443 \
     --hash=sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31
     # via mkdocs-material
+more-itertools==10.8.0 \
+    --hash=sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b \
+    --hash=sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd
+    # via hermeto (pyproject.toml)
 multidict==6.7.1 \
     --hash=sha256:026d264228bcd637d4e060844e39cdc60f86c479e463d49075dedc21b18fbbe0 \
     --hash=sha256:03ede2a6ffbe8ef936b92cb4529f27f42be7f56afcdab5ab739cd5f27fb1cbf9 \

--- a/requirements.txt
+++ b/requirements.txt
@@ -472,6 +472,10 @@ mdurl==0.1.2 \
     --hash=sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8 \
     --hash=sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba
     # via markdown-it-py
+more-itertools==10.8.0 \
+    --hash=sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b \
+    --hash=sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd
+    # via hermeto (pyproject.toml)
 multidict==6.7.1 \
     --hash=sha256:026d264228bcd637d4e060844e39cdc60f86c479e463d49075dedc21b18fbbe0 \
     --hash=sha256:03ede2a6ffbe8ef936b92cb4529f27f42be7f56afcdab5ab739cd5f27fb1cbf9 \


### PR DESCRIPTION
### Summary
Refactors iterable manipulation logic using utilities from `more-itertools`.

### Changes
- Added `more-itertools` dependency
- Replaced manual iterable patterns with:
  - `flatten()`
  - `unique_everseen()`
  - `partition()`
  - `first_true()`
  - `first()`
- Removed unused helper functions from `utils.py`

### Issue
Closes #1355

### AI Disclosure
Used Claude Sonnet 4.6 for assistance.