### PR TITLE
fix(cargo): handle workspace-inherited versions in PURL generation

### DIFF
--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -218,17 +218,16 @@ def _resolve_main_package(package_dir: RootedPath) -> tuple[str, str | None]:
     parsed_toml = _parse_toml_project_file(package_dir.path / "Cargo.toml")
 
     package_info = parsed_toml.get("package", {})
-    workspace_info = parsed_toml.get("workspace", {})
+    workspace_package_info = parsed_toml.get("workspace", {}).get("package", {})
 
     # use default values if the project is a virtual workspace without any package information
     name = package_info.get("name", package_dir.path.stem)
-    version = package_info.get("version", None)
+    version = package_info.get("version")
 
     # check for a workspace package version
     # https://doc.rust-lang.org/cargo/reference/workspaces.html#the-package-table
-    if version is None:
-        version = workspace_info.get("package", {}).get("version")
-
+    if isinstance(version, dict) or version is None:
+        version = workspace_package_info.get("version")
     return name, version
 
 

--- a/tests/unit/package_managers/cargo/test_main.py
+++ b/tests/unit/package_managers/cargo/test_main.py
@@ -34,22 +34,61 @@ def test_standard_package_with_name_and_version(rooted_tmp_path: RootedPath) -> 
     assert version == "1.2.3"
 
 
-def test_virtual_workspace_with_workspace_package_version(rooted_tmp_path: RootedPath) -> None:
-    write_cargo_toml(
-        rooted_tmp_path,
-        """
-        [workspace]
-        members = ["a", "b", "c"]
+@pytest.mark.parametrize(
+    "toml_content, expected_name, expected_version",
+    [
+        pytest.param(
+            """
+            [workspace]
+            members = ["a", "b", "c"]
 
-        [workspace.package]
-        version = "1.2.3"
-        """,
-    )
+            [workspace.package]
+            version = "1.2.3"
+            """,
+            None,
+            "1.2.3",
+            id="workspace_package_version",
+        ),
+        pytest.param(
+            """
+            [workspace.package]
+            version = "2.5.0"
 
-    expected_name = rooted_tmp_path.path.name
+            [package]
+            name = "inherited-pkg"
+            version.workspace = true
+            """,
+            "inherited-pkg",
+            "2.5.0",
+            id="workspace_inheritance_shorthand",
+        ),
+        pytest.param(
+            """
+            [workspace]
+            members = ["a"]
+
+            [package]
+            name = "orphaned-pkg"
+            version.workspace = true
+            """,
+            "orphaned-pkg",
+            None,
+            id="workspace_inheritance_missing_root_version",
+        ),
+    ],
+)
+def test_virtual_workspace_with_workspace_package_version(
+    rooted_tmp_path: RootedPath,
+    toml_content: str,
+    expected_name: str | None,
+    expected_version: str | None,
+) -> None:
+    write_cargo_toml(rooted_tmp_path, toml_content)
+
     name, version = _resolve_main_package(rooted_tmp_path)
-    assert name == expected_name
-    assert version == "1.2.3"
+
+    assert name == (expected_name or rooted_tmp_path.path.name)
+    assert version == expected_version
 
 
 def test_virtual_workspace_without_workspace_version(rooted_tmp_path: RootedPath) -> None:


### PR DESCRIPTION
# Summary
Fixed a fatal error where the Cargo backend crashed when encountering workspace-inherited versions during PURL generation.

**Workspace Crash (ValueError: Invalid purl)**
* **The issue:** Modern Rust monorepos frequently use `version.workspace = true`. `tomlkit` parses this as a dictionary (`{'workspace': True}`) instead of a string. Passing this dictionary directly to the PURL generator causes a `ValueError` and crashes Hermeto.
* **The fix:** Updated the parser logic to safely detect dictionary-valued versions using `isinstance(version, dict)` and correctly fall back to the actual version defined in the `[workspace.package]` root (or handle missing/orphaned versions gracefully).

## Steps to Reproduce 

```bash
mkdir -p workspace-crash/src
cd workspace-crash

cat << 'EOF' > Cargo.toml
[workspace]
[workspace.package]
version = "2.0.0"

[package]
name = "workspace-crash"
version.workspace = true
edition = "2021"

[dependencies]
#Remote dependency included to bypass the KeyError and isolate the PURL crash
log = "0.4"
EOF

echo 'fn main() {}' > src/main.rs
cargo generate-lockfile
hermeto fetch-deps --source . --output ./hermeto-output cargo
```

Output:
<img width="1038" height="717" alt="image" src="https://github.com/user-attachments/assets/bb9b4e88-613f-4bc9-89fa-9a4b40b58dfd" />
