### PR TITLE
feat(npm): detect prebuilt binaries and gate them behind binary/allow_binary field

### DIFF
--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -27,8 +27,8 @@ ModelT = TypeVar("ModelT", bound=pydantic.BaseModel)
 
 
 def _handle_legacy_allow_binary(
-    instance: Union["PipPackageInput", "BundlerPackageInput"],
-    binary_filter_class: type["PipBinaryFilters"] | type["BundlerBinaryFilters"],
+    instance: Union["PipPackageInput", "BundlerPackageInput", "NpmPackageInput"],
+    binary_filter_class: type["PipBinaryFilters"] | type["BundlerBinaryFilters"] | type["NpmBinaryFilters"],
 ) -> None:
     """Handle backward compatibility for allow_binary field.
 
@@ -270,6 +270,15 @@ class RpmBinaryFilters(pydantic.BaseModel, extra="forbid"):
     arch: BinaryFilterStr = BINARY_FILTER_ALL
 
 
+class NpmBinaryFilters(BinaryModeOptions):
+    """Binary filters specific to npm packages."""
+
+    @classmethod
+    def with_allow_binary_behavior(cls) -> Self:
+        """Create filters that mimic the old allow_binary=True behavior."""
+        return cls()
+
+
 class BundlerPackageInput(_PackageInputBase):
     """Accepted input for a bundler package."""
 
@@ -307,6 +316,14 @@ class NpmPackageInput(_PackageInputBase):
     """Accepted input for a npm package."""
 
     type: Literal["npm"]
+    allow_binary: bool = False
+    binary: NpmBinaryFilters | None = None
+
+    @pydantic.model_validator(mode="after")
+    def _handle_legacy_allow_binary_field(self) -> Self:
+        """Handle backward compatibility for allow_binary field."""
+        _handle_legacy_allow_binary(self, NpmBinaryFilters)
+        return self
 
 
 class PipPackageInput(_PackageInputBase):

--- a/hermeto/core/package_managers/npm.py
+++ b/hermeto/core/package_managers/npm.py
@@ -5,6 +5,7 @@ import fnmatch
 import functools
 import json
 import logging
+import tarfile
 from functools import partial
 from pathlib import Path
 from typing import Any, Literal, NewType, TypedDict
@@ -22,8 +23,8 @@ from hermeto.core.errors import (
     UnexpectedFormat,
     UnsupportedFeature,
 )
-from hermeto.core.models.input import Request
-from hermeto.core.models.output import ProjectFile, RequestOutput
+from hermeto.core.models.input import NpmBinaryFilters, Request
+from hermeto.core.models.output import EnvironmentVariable, ProjectFile, RequestOutput
 from hermeto.core.models.property_semantics import PropertySet
 from hermeto.core.models.sbom import (
     PROXY_COMMENT,
@@ -610,6 +611,57 @@ def _get_npm_dependencies(
     return download_paths
 
 
+def _detect_prebuilt_binaries(
+    download_paths: dict[NormalizedUrl, RootedPath],
+    binary_filters: NpmBinaryFilters | None,
+) -> None:
+    """Scan downloaded tarballs for prebuilt .node binaries.
+
+    Prebuildify packages ship platform-specific .node binaries under a
+    ``prebuilds/`` directory inside the npm tarball. This function detects
+    such binaries and either rejects or allows them based on the user's
+    ``binary`` configuration.
+
+    :param download_paths: mapping of resolved URLs to downloaded tarball paths
+    :param binary_filters: user-provided binary filters, or None if not set
+    :raises PackageRejected: if prebuilt binaries are found and binary_filters is None
+    """
+    for url, path in download_paths.items():
+        if not path.path.suffix == ".tgz" or not path.path.exists():
+            continue
+
+        try:
+            with tarfile.open(path.path, "r:gz") as tar:
+                prebuilt_files = [
+                    m.name for m in tar.getmembers()
+                    if m.name.endswith(".node") and "prebuilds/" in m.name
+                ]
+        except (tarfile.TarError, OSError):
+            continue
+
+        if not prebuilt_files:
+            continue
+
+        pkg_name = path.path.stem.removesuffix(".tgz")
+        log.info("Found prebuilt binaries in %s: %s", pkg_name, prebuilt_files)
+
+        if binary_filters is not None:
+            log.warning(
+                "Allowing prebuilt binaries in %s because 'binary' field is set",
+                pkg_name,
+            )
+        else:
+            raise PackageRejected(
+                f"Package '{pkg_name}' contains prebuilt binaries: {prebuilt_files}",
+                solution=(
+                    "Prebuilt binaries were found in this npm package. "
+                    "To allow them, set 'binary': {} in your package input. "
+                    "Alternatively, the npm_config_build_from_source=true environment "
+                    "variable is already set to compile from source at build time."
+                ),
+            )
+
+
 def _should_replace_dependency(dependency_version: str) -> bool:
     """Check if dependency must be updated in package(-lock).json.
 
@@ -730,7 +782,11 @@ def fetch_npm_source(request: Request) -> RequestOutput:
     npm_deps_dir.path.mkdir(parents=True, exist_ok=True)
 
     for package in request.npm_packages:
-        info = _resolve_npm(request.source_dir.join_within_root(package.path), npm_deps_dir)
+        info = _resolve_npm(
+            request.source_dir.join_within_root(package.path),
+            npm_deps_dir,
+            binary_filters=package.binary,
+        )
         component_info.append(info["package"])
 
         for dependency in info["dependencies"]:
@@ -751,7 +807,11 @@ def fetch_npm_source(request: Request) -> RequestOutput:
     )
 
 
-def _resolve_npm(pkg_path: RootedPath, npm_deps_dir: RootedPath) -> ResolvedNpmPackage:
+def _resolve_npm(
+    pkg_path: RootedPath,
+    npm_deps_dir: RootedPath,
+    binary_filters: NpmBinaryFilters | None = None,
+) -> ResolvedNpmPackage:
     """Resolve and fetch npm dependencies for the given package.
 
     :param pkg_path: the path to the directory containing npm-shrinkwrap.json or package-lock.json
@@ -792,6 +852,9 @@ def _resolve_npm(pkg_path: RootedPath, npm_deps_dir: RootedPath) -> ResolvedNpmP
     download_paths = _get_npm_dependencies(
         npm_deps_dir, package_lock.get_dependencies_to_download()
     )
+
+    # Scan downloaded tarballs for prebuilt .node binaries
+    _detect_prebuilt_binaries(download_paths, binary_filters)
 
     # Update package-lock.json, package.json(s) files with local paths to dependencies and store them as ProjectFiles
     _update_package_lock_with_local_paths(download_paths, package_lock)

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -14,6 +14,7 @@ from hermeto.core.models.input import (
     BundlerPackageInput,
     GomodPackageInput,
     Mode,
+    NpmBinaryFilters,
     NpmPackageInput,
     PackageInput,
     PipBinaryFilters,
@@ -400,8 +401,8 @@ class TestRequest:
             "packages": [
                 {"type": "gomod", "path": Path(".")},
                 {"type": "gomod", "path": Path("subpath")},
-                {"type": "npm", "path": Path(".")},
-                {"type": "npm", "path": Path("subpath")},
+                {"type": "npm", "path": Path("."), "allow_binary": False, "binary": None},
+                {"type": "npm", "path": Path("subpath"), "allow_binary": False, "binary": None},
                 {
                     "type": "pip",
                     "path": Path("."),
@@ -535,12 +536,13 @@ class TestLegacyAllowBinary:
         [
             pytest.param(PipPackageInput, "pip", id="pip"),
             pytest.param(BundlerPackageInput, "bundler", id="bundler"),
+            pytest.param(NpmPackageInput, "npm", id="npm"),
         ],
     )
     def test_no_migration_when_allow_binary_false(
         self,
-        package_class: type[PipPackageInput | BundlerPackageInput],
-        package_type: Literal["pip", "bundler"],
+        package_class: type[PipPackageInput | BundlerPackageInput | NpmPackageInput],
+        package_type: Literal["pip", "bundler", "npm"],
     ) -> None:
         """Test early return when allow_binary=False."""
         package = package_class(type=package_type, allow_binary=False)
@@ -552,13 +554,14 @@ class TestLegacyAllowBinary:
         [
             pytest.param(PipPackageInput, "pip", PipBinaryFilters, id="pip"),
             pytest.param(BundlerPackageInput, "bundler", BundlerBinaryFilters, id="bundler"),
+            pytest.param(NpmPackageInput, "npm", NpmBinaryFilters, id="npm"),
         ],
     )
     def test_migration_when_allow_binary_true(
         self,
-        package_class: type[PipPackageInput | BundlerPackageInput],
-        package_type: Literal["pip", "bundler"],
-        binary_filter_class: type[PipBinaryFilters | BundlerBinaryFilters],
+        package_class: type[PipPackageInput | BundlerPackageInput | NpmPackageInput],
+        package_type: Literal["pip", "bundler", "npm"],
+        binary_filter_class: type[PipBinaryFilters | BundlerBinaryFilters | NpmBinaryFilters],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Test allow_binary=True migrates to binary filters."""
@@ -573,12 +576,13 @@ class TestLegacyAllowBinary:
         [
             pytest.param(PipPackageInput, "pip", id="pip"),
             pytest.param(BundlerPackageInput, "bundler", id="bundler"),
+            pytest.param(NpmPackageInput, "npm", id="npm"),
         ],
     )
     def test_both_fields_binary_unchanged(
         self,
-        package_class: type[PipPackageInput | BundlerPackageInput],
-        package_type: Literal["pip", "bundler"],
+        package_class: type[PipPackageInput | BundlerPackageInput | NpmPackageInput],
+        package_type: Literal["pip", "bundler", "npm"],
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         """Test binary field unchanged when both fields specified."""

--- a/tests/unit/package_managers/test_npm.py
+++ b/tests/unit/package_managers/test_npm.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: GPL-3.0-only
+import io
 import json
 import os
+import tarfile
 import urllib.parse
 from collections.abc import Iterator
 from pathlib import Path
@@ -19,8 +21,8 @@ from hermeto.core.errors import (
     UnexpectedFormat,
     UnsupportedFeature,
 )
-from hermeto.core.models.input import Request
-from hermeto.core.models.output import ProjectFile, RequestOutput
+from hermeto.core.models.input import NpmBinaryFilters, Request
+from hermeto.core.models.output import EnvironmentVariable, ProjectFile, RequestOutput
 from hermeto.core.models.sbom import Annotation, Component, Property
 from hermeto.core.package_managers.npm import (
     NormalizedUrl,
@@ -38,6 +40,7 @@ from hermeto.core.package_managers.npm import (
     _update_package_json_files,
     _update_package_lock_with_local_paths,
     _update_vcs_url_with_full_hostname,
+    _detect_prebuilt_binaries,
     fetch_npm_source,
 )
 from hermeto.core.rooted_path import RootedPath
@@ -2073,3 +2076,85 @@ def test_npm_proxy_url_gets_substituted_for_registry_hosts(
     for call in mock_async_download_files.mock_calls:
         location = next(iter(call.kwargs["files_to_download"].keys()))
         assert location.startswith(proxy_url), msg
+
+
+def _create_tgz_with_files(path: Path, filenames: list[str]) -> None:
+    """Helper to create a .tgz archive containing the given filenames."""
+    with tarfile.open(path, "w:gz") as tar:
+        for filename in filenames:
+            data = b"fake binary content"
+            info = tarfile.TarInfo(name=filename)
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+
+
+def test_detect_prebuilt_binaries_rejects_when_no_binary_field(
+    tmp_path: Path,
+) -> None:
+    """Test that prebuilt .node binaries cause PackageRejected when binary is not set."""
+    tgz_path = tmp_path / "bufferutil-4.0.9.tgz"
+    _create_tgz_with_files(
+        tgz_path,
+        [
+            "package/prebuilds/linux-x64/node.napi.node",
+            "package/prebuilds/darwin-x64/node.napi.node",
+            "package/index.js",
+        ],
+    )
+
+    download_paths: dict[NormalizedUrl, RootedPath] = {
+        NormalizedUrl("https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz"): RootedPath(
+            tgz_path
+        ),
+    }
+
+    with pytest.raises(PackageRejected, match="contains prebuilt binaries"):
+        _detect_prebuilt_binaries(download_paths, binary_filters=None)
+
+
+def test_detect_prebuilt_binaries_allows_when_binary_field_set(
+    tmp_path: Path,
+) -> None:
+    """Test that prebuilt .node binaries are allowed when binary field is set."""
+    tgz_path = tmp_path / "bufferutil-4.0.9.tgz"
+    _create_tgz_with_files(
+        tgz_path,
+        [
+            "package/prebuilds/linux-x64/node.napi.node",
+            "package/index.js",
+        ],
+    )
+
+    download_paths: dict[NormalizedUrl, RootedPath] = {
+        NormalizedUrl("https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz"): RootedPath(
+            tgz_path
+        ),
+    }
+
+    # Should NOT raise when binary_filters is set
+    _detect_prebuilt_binaries(download_paths, binary_filters=NpmBinaryFilters())
+
+
+def test_detect_prebuilt_binaries_passes_when_no_prebuilds(
+    tmp_path: Path,
+) -> None:
+    """Test that tarballs without prebuilt .node binaries pass regardless."""
+    tgz_path = tmp_path / "lodash-4.17.21.tgz"
+    _create_tgz_with_files(
+        tgz_path,
+        [
+            "package/index.js",
+            "package/package.json",
+            "package/lib/utils.js",
+        ],
+    )
+
+    download_paths: dict[NormalizedUrl, RootedPath] = {
+        NormalizedUrl("https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"): RootedPath(
+            tgz_path
+        ),
+    }
+
+    # Should NOT raise for any binary_filters value
+    _detect_prebuilt_binaries(download_paths, binary_filters=None)
+    _detect_prebuilt_binaries(download_paths, binary_filters=NpmBinaryFilters())


### PR DESCRIPTION
### Description:
This PR implements Solution 2 for issue #1015 by detecting npm packages that ship with prebuilt `.node` binaries (such as those generated by `prebuildify`) and gating their installation based on the [binary](cci:1://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/input.py:275:4-278:20) input field. 

here is the solution 1 : #1392 

Previously, some modules containing `.node` binaries were bypassing the hermetic build-from-source process. This implementation ensures that:
- Npm input models now accept [binary](cci:1://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/input.py:275:4-278:20) filters (via [NpmBinaryFilters](cci:2://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/input.py:272:0-278:20)) and migrate legacy [allow_binary](cci:1://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/input.py:275:4-278:20) inputs.
- During [_resolve_npm](cci:1://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/package_managers/npm.py:809:0-867:5), downloaded `.tgz` tarballs are scanned for `.node` files within [prebuilds/](cci:1://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/tests/unit/package_managers/test_npm.py:2137:0-2159:80) directories.
- If prebuilt binaries are detected, the package is rejected with a `PackageRejected` error unless the user has explicitly configured the [binary](cci:1://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/input.py:275:4-278:20) field for that package.
- It seamlessly mimics the existing binary filtering pattern used across the codebase (e.g., for bundler packages).

