### PR TITLE
Add GitHub Actions workflow linting using actionlint

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,17 @@
+name: Lint GitHub Actions
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.11
+        with:
+          args: -color

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.10"
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
+      - run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
       - uses: actions/cache@v5
         with:
           key: mkdocs-material-${{ env.cache_id }}
@@ -34,9 +34,9 @@ jobs:
         run: |
           LATEST_TAG=$(gh release view --json tagName -q .tagName)
           if [ "$LATEST_TAG" = "${{ github.event.release.tag_name }}" ]; then
-            echo "is_latest=true" >> $GITHUB_OUTPUT
+            echo "is_latest=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is_latest=false" >> $GITHUB_OUTPUT
+            echo "is_latest=false" >> "$GITHUB_OUTPUT"
           fi
       - run: mkdocs gh-deploy --force --strict
         if: steps.latest.outputs.is_latest == 'true'

--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -20,28 +20,28 @@ jobs:
       image: python:${{ matrix.python-version }}-slim
 
     steps:
-    - name: Install dependencies
-      run: |
-        # We need to install git inside the container otherwise the checkout action will use Git
-        # REST API and the .git directory won't be present which fails due to setuptools-scm
-        apt-get update && apt-get install --no-install-recommends --no-install-suggests -y git
-        pip install --upgrade pip nox
+      - name: Install dependencies
+        run: |
+          # We need to install git inside the container otherwise the checkout action will use Git
+          # REST API and the .git directory won't be present which fails due to setuptools-scm
+          apt-get update && apt-get install --no-install-recommends --no-install-suggests -y git
+          pip install --upgrade pip nox
 
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-    - name: Test with nox
-      run: |
-        # Disable Git's safe.directory mechanism as some unit tests do clone repositories
-        git config --global --add safe.directory '*'
-        nox -s python-${{ matrix.python-version }}
+      - name: Test with nox
+        run: |
+          # Disable Git's safe.directory mechanism as some unit tests do clone repositories
+          git config --global --add safe.directory '*'
+          nox -s "python-${{ matrix.python-version }}"
 
-    - name: Upload coverage reports to Codecov
-      if: matrix.python-version == '3.12'
-      uses: codecov/codecov-action@v4
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Upload coverage reports to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   linters:
     name: Linters
@@ -53,32 +53,32 @@ jobs:
       image: python:3.10-slim
 
     steps:
-    - name: Install dependencies
-      run: |
-        # We need to install git inside the container otherwise the checkout action will use Git
-        # REST API and the .git directory won't be present which fails due to setuptools-scm
-        apt-get update && apt-get install --no-install-recommends --no-install-suggests -y git
-        pip install --upgrade pip nox
+      - name: Install dependencies
+        run: |
+          # We need to install git inside the container otherwise the checkout action will use Git
+          # REST API and the .git directory won't be present which fails due to setuptools-scm
+          apt-get update && apt-get install --no-install-recommends --no-install-suggests -y git
+          pip install --upgrade pip nox
 
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 0
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-    - name: Run linters
-      run: nox -s lint
+      - name: Run linters
+        run: nox -s lint
 
   hadolint:
     name: Hadolint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
-    - uses: hadolint/hadolint-action@v3.3.0
-      with:
-        dockerfile: Dockerfile
-        # Ignore list:
-        # * DL3041 - Specify version with dnf install -y <package>-<version>
-        ignore: DL3041
-        failure-threshold: warning
+      - uses: actions/checkout@v6
+      - uses: hadolint/hadolint-action@v3.3.0
+        with:
+          dockerfile: Dockerfile
+          # Ignore list:
+          # * DL3041 - Specify version with dnf install -y <package>-<version>
+          ignore: DL3041
+          failure-threshold: warning
 
   markdownlint:
     name: Markdownlint
@@ -91,7 +91,7 @@ jobs:
       - uses: tj-actions/changed-files@v47
         id: changed-files
         with:
-          files: '**/*.md'
+          files: "**/*.md"
           separator: ","
       - uses: DavidAnson/markdownlint-cli2-action@v22
         if: steps.changed-files.outputs.any_changed == 'true'
@@ -134,12 +134,12 @@ jobs:
           # Testing basic HTTP request
           status=$(curl -sSI \
                         --output /dev/null \
-                        --write-out %{http_code} \
+                        --write-out "%{http_code}" \
                         --retry-delay 1 \
                         --retry 60 \
                         --retry-all-errors \
                         http://127.0.0.1:8080)
-          [[ ${status} == "200" ]] || exit 1
+          [[ "${status}" == "200" ]] || exit 1
 
       - name: DNF test server start
         run: |
@@ -148,45 +148,45 @@ jobs:
           # Testing basic HTTP request
           status=$(curl -sSI \
                         --output /dev/null \
-                        --write-out %{http_code} \
+                        --write-out "%{http_code}" \
                         --retry-delay 1 \
                         --retry 60 \
                         --retry-all-errors \
                         http://127.0.0.1:8081)
-          [[ ${status} == "200" ]] || exit 1
+          [[ "${status}" == "200" ]] || exit 1
 
           # Testing expected error on unauthenticated TLS access
           status=$(curl -ssI \
                         --output /dev/null \
-                        --write-out %{http_code} \
+                        --write-out "%{http_code}" \
                         --insecure \
                         https://127.0.0.1:8443)
-          [[ ${status} == "400" ]] || exit 1
+          [[ "${status}" == "400" ]] || exit 1
 
           # Testing TLS client authentication
           status=$(curl -sSI \
                         --output /dev/null \
-                        --write-out %{http_code} \
+                        --write-out "%{http_code}" \
                         --cacert tests/dnfserver/certificates/CA.crt \
                         --key tests/dnfserver/certificates/client.key \
                         --cert tests/dnfserver/certificates/client.crt \
                         https://127.0.0.1:8443/pkg/redhat-release-9.4-0.5.el9.x86_64.rpm)
-          [[ ${status} == "200" ]] || exit 1
+          [[ "${status}" == "200" ]] || exit 1
 
       - name: Build container image
         run: |
-          podman build -t hermeto:${{ github.sha }} .
+          podman build -t "hermeto:${{ github.sha }}" .
 
       - name: Check image created and application version
         run: |
           podman images | grep 'hermeto'
-          podman run -t hermeto:${{ github.sha }} --version
+          podman run -t "hermeto:${{ github.sha }}" --version
 
       - name: Run integration tests on built image
         env:
           HERMETO_TEST_IMAGE: localhost/hermeto:${{ github.sha }}
-          HERMETO_TEST_LOCAL_PYPISERVER: '1'
-          HERMETO_TEST_LOCAL_DNF_SERVER: '1'
+          HERMETO_TEST_LOCAL_PYPISERVER: "1"
+          HERMETO_TEST_LOCAL_DNF_SERVER: "1"
         run: |
           git config --global --add safe.directory "*"
           /var/tmp/venv/bin/nox -s integration-tests -- -n auto


### PR DESCRIPTION
Fixes: #1404

I looked into a few options for linting GitHub Actions workflows, including Super-Linter, zizmor, and actionlint.
Super-Linter felt too heavy for this use case, and zizmor focuses more on security analysis than workflow linting. Since the issue already suggested actionlint, and it is lightweight, actively maintained, and purpose-built for GitHub Actions, it seemed like the best one I could find.

I implemented a workflow that installs and runs actionlint, the workflow downloads the official binary directly instead of relying on additional wrapper actions.

I tested this locally by running actionlint against the existing workflows to ensure they pass, and also verified that it correctly detects errors using a deliberately broken workflow file.

I Hope that this satisfies the requirements of the issue by adding lightweight CI linting for GitHub Actions workflows while keeping the dependency surface small.