### PR TITLE
pyproject.toml: pytest: Set test data retention to 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,3 +146,4 @@ log_date_format = "%Y-%m-%d %H:%M:%S"
 markers = [
   "no_proxy_mode: marks tests that are incompatible with HERMETO_TEST_LOCAL_NEXUS_PROXY=1",
 ]
+tmp_path_retention_count = 1


### PR DESCRIPTION
The test suite generates quite a large chunk of data which is now even more accentuated with parallel execution (commit b396643a) and per-worker data (however small). Configure pytest to only keep the last test run for inspection purposes [1].

[1] https://docs.pytest.org/en/stable/reference/reference.html#confval-tmp_path_retention_count