### PR TITLE
feat: indicate experimental features usage globally and per-component

### DIFF
--- a/hermeto/core/models/output.py
+++ b/hermeto/core/models/output.py
@@ -7,7 +7,9 @@ from typing import Any, Literal
 
 import pydantic
 
+from hermeto import APP_NAME
 from hermeto.core.errors import BaseError
+from hermeto.core.models.property_semantics import Property, PropertyEnum
 from hermeto.core.models.sbom import Annotation, Component, Sbom, merge_component_properties
 from hermeto.core.models.validators import unique_sorted
 
@@ -126,7 +128,7 @@ class ProjectFile(pydantic.BaseModel):
             baz==1.0.0  # comment with $ invalid placeholder
         """
         template = string.Template(self.template)
-        return template.safe_substitute(output_dir=output_dir)
+        return template.safe_substitute(output_dir=output_dir.as_posix())
 
 
 class BuildConfig(pydantic.BaseModel):
@@ -162,9 +164,29 @@ class RequestOutput(pydantic.BaseModel):
         Note that RequestOutput may contain duplicated components, we de-duplicate them here
         while merging their `properties`.
         """
-        return Sbom(
+        sbom = Sbom(
             annotations=self.annotations, components=merge_component_properties(self.components)
         )
+        experimental_subjects = set()
+        has_experimental_anno = False
+        for anno in self.annotations:
+            if anno.text.startswith(f"{APP_NAME}:backend:experimental:"):
+                has_experimental_anno = True
+                experimental_subjects.update(anno.subjects)
+
+        if has_experimental_anno:
+            sbom.metadata.properties.append(
+                Property(name=PropertyEnum.PROP_EXPERIMENTAL, value="true")
+            )
+
+            for comp in sbom.components:
+                if comp.bom_ref in experimental_subjects:
+                    if not any(p.name == PropertyEnum.PROP_EXPERIMENTAL for p in comp.properties):
+                        comp.properties.append(
+                            Property(name=PropertyEnum.PROP_EXPERIMENTAL, value="true")
+                        )
+
+        return sbom
 
     def __add__(self, other: "RequestOutput") -> "RequestOutput":
         if not isinstance(other, self.__class__):

--- a/hermeto/core/models/property_semantics.py
+++ b/hermeto/core/models/property_semantics.py
@@ -18,6 +18,7 @@ class PropertyEnum(str, Enum):
     PROP_BUNDLER_PACKAGE_BINARY = f"{APP_NAME}:bundler:package:binary"
     PROP_CDX_NPM_PACKAGE_BUNDLED = "cdx:npm:package:bundled"
     PROP_CDX_NPM_PACKAGE_DEVELOPMENT = "cdx:npm:package:development"
+    PROP_EXPERIMENTAL = f"{APP_NAME}:experimental"
     PROP_FOUND_BY = f"{APP_NAME}:found_by"
     PROP_MISSING_HASH_IN_FILE = f"{APP_NAME}:missing_hash:in_file"
     PROP_PIP_PACKAGE_BINARY = f"{APP_NAME}:pip:package:binary"
@@ -41,6 +42,7 @@ class PropertySet:
     """Represents the semantic meaning of the set of Properties of a single Component."""
 
     bundler_package_binary: bool = False
+    experimental: bool = False
     found_by: str | None = None
     missing_hash_in_file: frozenset[str] = field(default_factory=frozenset)
     npm_bundled: bool = False
@@ -54,6 +56,7 @@ class PropertySet:
     def from_properties(cls, props: Iterable[Property]) -> "Self":
         """Convert a list of SBOM component properties to a PropertySet."""
         bundler_package_binary = False
+        experimental = False
         found_by = None
         missing_hash_in_file = []
         npm_bundled = False
@@ -66,6 +69,8 @@ class PropertySet:
         for prop in props:
             if prop.name == PropertyEnum.PROP_BUNDLER_PACKAGE_BINARY:
                 bundler_package_binary = True
+            elif prop.name == PropertyEnum.PROP_EXPERIMENTAL:
+                experimental = True
             elif prop.name == PropertyEnum.PROP_CDX_NPM_PACKAGE_BUNDLED:
                 npm_bundled = True
             elif prop.name == PropertyEnum.PROP_CDX_NPM_PACKAGE_DEVELOPMENT:
@@ -87,6 +92,7 @@ class PropertySet:
 
         return cls(
             bundler_package_binary,
+            experimental,
             found_by,
             frozenset(missing_hash_in_file),
             npm_bundled,
@@ -102,6 +108,8 @@ class PropertySet:
         props = []
         if self.bundler_package_binary:
             props.append(Property(name=PropertyEnum.PROP_BUNDLER_PACKAGE_BINARY, value="true"))
+        if self.experimental:
+            props.append(Property(name=PropertyEnum.PROP_EXPERIMENTAL, value="true"))
         if self.found_by:
             props.append(Property(name=PropertyEnum.PROP_FOUND_BY, value=self.found_by))
         props.extend(
@@ -134,6 +142,7 @@ class PropertySet:
         cls = type(self)
         return cls(
             bundler_package_binary=self.bundler_package_binary or other.bundler_package_binary,
+            experimental=self.experimental or other.experimental,
             found_by=self.found_by or other.found_by,
             missing_hash_in_file=self.missing_hash_in_file | other.missing_hash_in_file,
             npm_bundled=self.npm_bundled and other.npm_bundled,

--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -150,6 +150,7 @@ class Metadata(pydantic.BaseModel):
     """Metadata field in a SBOM."""
 
     tools: list[Tool] = [Tool(vendor="red hat", name=f"{APP_NAME}")]
+    properties: list[Property] = pydantic.Field(default_factory=list)
 
 
 def spdx_now() -> datetime:
@@ -226,6 +227,9 @@ class Sbom(pydantic.BaseModel):
 
     def __add__(self, other: Union["Sbom", "SPDXSbom"]) -> "Sbom":
         if isinstance(other, self.__class__):
+            # deduplicate properties by name, let `other` overwrite `self`
+            props = {p.name: p for p in self.metadata.properties}
+            props.update({p.name: p for p in other.metadata.properties})
             return Sbom(
                 # NOTE: We might consider deduplicating annotations based on the annotation text
                 # in the future. It is a very rare corner case, though, and it only matters when
@@ -233,6 +237,10 @@ class Sbom(pydantic.BaseModel):
                 annotations=self.annotations + other.annotations,
                 components=merge_component_properties(
                     chain.from_iterable(s.components for s in [self, other])
+                ),
+                metadata=Metadata(
+                    tools=self.metadata.tools,
+                    properties=list(props.values()),
                 ),
             )
         else:
@@ -259,7 +267,22 @@ class Sbom(pydantic.BaseModel):
         """
 
         def create_document_root() -> SPDXPackage:
-            return SPDXPackage(name="", versionInfo="", SPDXID="SPDXRef-DocumentRoot-File-")
+            now = spdx_now()
+            annotations = [
+                SPDXPackageAnnotation(
+                    annotator=f"Tool: {APP_NAME}:jsonencoded",
+                    annotationDate=now,
+                    annotationType="OTHER",
+                    comment=json.dumps({"name": prop.name, "value": prop.value}),
+                )
+                for prop in self.metadata.properties
+            ]
+            return SPDXPackage(
+                name="",
+                versionInfo="",
+                SPDXID="SPDXRef-DocumentRoot-File-",
+                annotations=annotations,
+            )
 
         def create_root_relationship() -> SPDXRelation:
             return SPDXRelation(
@@ -769,9 +792,18 @@ class SPDXSbom(pydantic.BaseModel):
                 tools.append(Tool(vendor=vendor, name=name))
                 name, vendor = None, None
 
+        properties = []
+        root_package = next((p for p in self.packages if p.SPDXID == self.root_id), None)
+        if root_package:
+            properties = [
+                Property(**json.loads(an.comment))
+                for an in root_package.annotations
+                if an.annotator.endswith(":jsonencoded")
+            ]
+
         return Sbom(
             components=components,
-            metadata=Metadata(tools=tools),
+            metadata=Metadata(tools=tools, properties=properties),
         )
 
 

--- a/tests/unit/models/test_output.py
+++ b/tests/unit/models/test_output.py
@@ -65,7 +65,9 @@ class TestBuildConfig:
         ]
 
     def test_conflicting_project_files(self) -> None:
-        expect_error = "conflict by /some/path:"
+        import re
+
+        expect_error = re.escape(f"conflict by {Path('/some/path')}:")
         with pytest.raises(pydantic.ValidationError, match=expect_error):
             BuildConfig(
                 environment_variables=[],
@@ -205,3 +207,35 @@ class TestEnvironmentVariable:
         err_msg = f"Detected a cycle in environment variable expansion of '{envs[0].name}'"
         with pytest.raises(BaseError, match=err_msg):
             envs[0].resolve_value(mappings)
+
+
+class TestRequestOutputExperimental:
+    @pytest.mark.parametrize(
+        ("annotation_text_template", "expect_flag"),
+        [
+            ("{app_name}:backend:experimental:x-foo", True),
+            ("{app_name}:backend:pip", False),
+        ],
+    )
+    def test_generate_sbom_experimental_flag(
+        self, annotation_text_template: str, expect_flag: bool
+    ) -> None:
+        from datetime import datetime, timezone
+
+        from hermeto import APP_NAME
+        from hermeto.core.models.property_semantics import PropertyEnum
+        from hermeto.core.models.sbom import Annotation
+
+        anno = Annotation(
+            subjects=set(),
+            annotator={"organization": {"name": "red hat"}},
+            timestamp=datetime.now(timezone.utc),
+            text=annotation_text_template.format(app_name=APP_NAME),
+        )
+        ro = RequestOutput(annotations=[anno], components=[], build_config=BuildConfig())
+        sbom = ro.generate_sbom()
+        has_flag = any(
+            p.name == PropertyEnum.PROP_EXPERIMENTAL and p.value == "true"
+            for p in sbom.metadata.properties
+        )
+        assert has_flag is expect_flag


### PR DESCRIPTION
Resolves #614 

### Description
This PR addresses the remaining requirement from #614 (reopened) to definitively state when experimental features were used during generation, and exactly which components were produced by them.

Previously, experimental backend usage mapped to document annotations but lacked an explicit global boolean flag and didn't directly tag the origin of individual components directly via properties.

### Changes
1.  Added `PROP_EXPERIMENTAL` (`hermeto:experimental`) to the [PropertyEnum](cci:2://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/property_semantics.py:14:0-29:25) validation registry in [property_semantics.py](cci:7://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/property_semantics.py:0:0-0:0).
2.  Added support for [properties](cci:1://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/property_semantics.py:100:4-130:61) on the [Metadata](cci:2://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/sbom.py:148:0-152:69) model in [sbom.py](cci:7://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/sbom.py:0:0-0:0), including proper merging logic in `Sbom.__add__`.
3.  Updated [SPDX](cci:2://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/sbom.py:586:0-804:9) conversion logic in [sbom.py](cci:7://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/sbom.py:0:0-0:0) so that global `metadata.properties` correctly propagate to and parse from `SPDXPackageAnnotations` on the DocumentRoot package.
4.  Updated `RequestOutput.generate_sbom` in [output.py](cci:7://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/output.py:0:0-0:0) to append `PROP_EXPERIMENTAL = "true"` to the global `Sbom.metadata.properties` when experimental backend annotations are present.
5.  Updated `RequestOutput.generate_sbom` to extract the [bom_ref](cci:1://file:///c:/Users/Ajay%20Rajera/Desktop/hermeto/hermeto/core/models/sbom.py:111:4-115:19) subjects from experimental backend annotations and append the exact same `PROP_EXPERIMENTAL` property to those specific individual components. 
6.  Added dedicated unit tests in `test_output.py` to verify the property injection logic for both experimental and standard package managers.
