### PR TITLE
Fix SBOM hash to use creationInfo instance instead of class

### DIFF
--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -543,6 +543,9 @@ class SPDXCreationInfo(pydantic.BaseModel):
     creators: list[str] = []
     created: ISODatetime
 
+    def __hash__(self) -> int:
+        return hash((tuple(self.creators), self.created))
+
 
 class SPDXRelation(pydantic.BaseModel):
     """SPDX Relationship.
@@ -588,7 +591,7 @@ class SPDXSbom(pydantic.BaseModel):
     def __hash__(self) -> int:
         return hash(
             hash(self.name + self.documentNamespace)
-            + hash(SPDXCreationInfo)
+            + hash(self.creationInfo)
             + sum(hash(p) for p in self.packages)
             + sum(hash(r) for r in self.relationships)
         )


### PR DESCRIPTION
This PR fixes an issue in the SBOM hashing logic where the hash calculation was using the SPDXCreationInfo class instead of the actual instance data. Because of this, SBOMs that differed only in their creation info for example, timestamps or creators could end up producing the same hash value.

This change makes the hash depend on the actual creationInfo contents by making SPDXCreationInfo hashable and using its fields in the hash calculation. This avoids unintended collisions during merge or deduplication.

This was discussed with Alexey Ovchinnikov and was confirmed to be a bug, so I’ve submitted this fix directly as a PR.

Let me know if any adjustments are needed.