### PR TITLE
fix: improve error messages in pip requirements

### DIFF
--- a/hermeto/core/package_managers/pip/requirements.py
+++ b/hermeto/core/package_managers/pip/requirements.py
@@ -636,7 +636,7 @@ def validate_requirements(requirements: list[PipRequirement]) -> None:
                 raise InvalidChecksum(
                     checksum=req.hashes,
                     solution=(
-                        f"URL requirement must specify exactly one hash, but specifies {n_hashes}"
+                        f"URL requirement must specify exactly one hash, but specifies {n_hashes}\n"
                         "Please specify the expected hashes for all plain URLs using "
                         "--hash options (one --hash for each)"
                     ),
@@ -664,14 +664,23 @@ def validate_requirements_hashes(requirements: list[PipRequirement], require_has
         hashes = req.hashes
 
         if require_hashes and not hashes:
-            # We shouldn't get here, but it's a definite error if we do.
             # VCS reqs *cannot* be hashed, so we'll always hit
             # this for any VCS req in a 'requirements.txt' which has *any* hash.
             # For URL requirements, having a hash is required to pass *basic* validation.
+            if req.kind == "vcs":
+                raise MissingChecksum(
+                    req.download_line,
+                    solution=(
+                        "Git dependencies do not support pip's --hash option.\n"
+                        "Please use an https URL instead, for example:\n"
+                        "  dockerfile-parse @ https://github.com/.../2.0.0.tar.gz \\\n"
+                        "      --hash=sha256:..."
+                    ),
+                )
             raise MissingChecksum(
                 None,
                 solution=(
-                    f"Hash is required, dependency does not specify any: {req.download_line}"
+                    f"Hash is required, dependency does not specify any: {req.download_line}\n"
                     "Please specify the expected hashes for all dependencies"
                 ),
             )


### PR DESCRIPTION
Resolves #1427
While going through `requirements.py` to understand the pip module, I noticed that when a git dependency is used alongside hashed dependencies, hermeto raises a misleading error telling the user to add a `--hash` to a git dependency.
## Changes

1) Detect VCS requirements in `validate_requirements_hashes()` and raise a specific error explaining that git dependencies do not support pip's   `--hash` option, pointing to the https URL alternative
2)Fix two missing `\n` separators in  solution strings that caused sentences to concatenate without any separator
