### PR TITLE
refactor: Use a single PackageJson class

### DIFF
--- a/hermeto/core/package_managers/common.py
+++ b/hermeto/core/package_managers/common.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: GPL-3.0-only
+import json
+from collections import UserDict
+from pathlib import Path
+from typing import Any
+
+from hermeto.core.errors import InvalidLockfileFormat, LockfileNotFound
+
+
+class PackageJson(UserDict):
+    """Class representing package.json files."""
+
+    def __init__(self, path: Path, data: dict[str, Any]) -> None:
+        """Initialize a PackageJson object."""
+        self.path = path
+        super().__init__(data)
+
+    @classmethod
+    def from_file(cls, path: Path) -> "PackageJson":
+        """Create a PackageJson object from a package.json file."""
+        if not path.exists():
+            raise LockfileNotFound(
+                path,
+                solution="Make sure the package.json file exists in the specified directory.",
+            )
+
+        try:
+            with path.open("r") as f:
+                data = json.load(f)
+        except json.decoder.JSONDecodeError as e:
+            raise InvalidLockfileFormat(
+                lockfile_path=path,
+                err_details=str(e),
+                solution="The package.json file must contain valid JSON.",
+            )
+
+        return cls(path, data)
+
+    @classmethod
+    def from_dir(cls, path: Path) -> "PackageJson":
+        """Create a PackageJson object from a package.json file."""
+        return cls.from_file(path.joinpath("package.json"))
+
+    def write(self) -> None:
+        """Write the data to the package.json file."""
+        with self.path.open("w") as f:
+            json.dump(self.data, f, indent=2)
+            f.write("\n")

--- a/hermeto/core/package_managers/yarn/project.py
+++ b/hermeto/core/package_managers/yarn/project.py
@@ -6,7 +6,6 @@ It also provides basic utility functions. The main logic to resolve and prefetch
 should be implemented in other modules.
 """
 
-import json
 import logging
 import re
 from collections import UserDict
@@ -16,12 +15,8 @@ from typing import Any, Literal, NamedTuple, TypedDict
 import semver
 import yaml
 
-from hermeto.core.errors import (
-    InvalidLockfileFormat,
-    LockfileNotFound,
-    PackageRejected,
-    UnexpectedFormat,
-)
+from hermeto.core.errors import PackageRejected, UnexpectedFormat
+from hermeto.core.package_managers.common import PackageJson
 from hermeto.core.rooted_path import RootedPath
 
 log = logging.getLogger(__name__)
@@ -81,54 +76,6 @@ class YarnRc(UserDict):
         return cls(file_path, yarnrc_data)
 
 
-class PackageJson(UserDict):
-    """A package.json file.
-
-    This class maps the contents of a package.json file to a specialized dictionary.
-    """
-
-    def __init__(self, path: RootedPath, data: dict[str, Any]) -> None:
-        """Initialize a PackageJson object.
-
-        :param path: the path to the package.json file, relative to the request source dir.
-        :param data: the raw data for the package.json file.
-        """
-        self._path = path
-        super().__init__(data)
-
-    @classmethod
-    def from_file(cls, file_path: RootedPath) -> "PackageJson":
-        """Parse the content of a package.json file."""
-        try:
-            with file_path.path.open("r") as f:
-                package_json_data = json.load(f)
-        except FileNotFoundError:
-            raise LockfileNotFound(
-                files=file_path.path,
-                solution=(
-                    "Please double-check that you have specified the correct path "
-                    "to the package directory containing this file"
-                ),
-            )
-        except json.decoder.JSONDecodeError as e:
-            raise InvalidLockfileFormat(
-                lockfile_path=file_path.path,
-                err_details=str(e),
-                solution=(
-                    "The package.json file must contain valid JSON. "
-                    "Refer to the parser error and fix the contents of the file."
-                ),
-            )
-
-        return cls(file_path, package_json_data)
-
-    def write(self) -> None:
-        """Write the data to the package.json file."""
-        with self._path.path.open("w") as f:
-            json.dump(self.data, f, indent=2)
-            f.write("\n")
-
-
 class Project(NamedTuple):
     """A directory containing yarn sources."""
 
@@ -177,7 +124,7 @@ class Project(NamedTuple):
         else:
             yarn_rc = YarnRc(yarn_rc_path, {})
 
-        package_json = PackageJson.from_file(source_dir.join_within_root("package.json"))
+        package_json = PackageJson.from_dir(source_dir.path)
         return cls(source_dir, yarn_rc, package_json)
 
 

--- a/hermeto/core/package_managers/yarn_classic/project.py
+++ b/hermeto/core/package_managers/yarn_classic/project.py
@@ -6,7 +6,6 @@ It also provides basic utility functions. The main logic to resolve and prefetch
 the dependencies should be implemented in other modules.
 """
 
-import json
 import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
@@ -15,6 +14,7 @@ from typing import Any
 from pyarn import lockfile  # type: ignore
 
 from hermeto.core.errors import InvalidLockfileFormat, LockfileNotFound, PackageRejected
+from hermeto.core.package_managers.common import PackageJson
 from hermeto.core.rooted_path import RootedPath
 
 log = logging.getLogger(name=__name__)
@@ -43,44 +43,6 @@ class _CommonConfigFile(ABC):
     @abstractmethod
     def from_file(cls, path: RootedPath) -> "_CommonConfigFile":
         """Construct a ConfigFile instance."""
-
-
-class PackageJson(_CommonConfigFile):
-    """A package.json file.
-
-    This class abstracts the underlying attributes and only exposes what
-    is relevant for the request processing.
-    """
-
-    @property
-    def install_config(self) -> dict[str, Any]:
-        """Get the installConfig dict."""
-        return self.data.get("installConfig", {})
-
-    @classmethod
-    def from_file(cls, path: RootedPath) -> "PackageJson":
-        """Construct a PackageJson instance."""
-        try:
-            package_json_data = json.loads(path.path.read_text())
-        except FileNotFoundError:
-            raise LockfileNotFound(
-                files=path.path,
-                solution=(
-                    "Please double-check that you have specified the correct path "
-                    "to the package directory containing this file"
-                ),
-            )
-        except json.decoder.JSONDecodeError as e:
-            raise InvalidLockfileFormat(
-                lockfile_path=path.path,
-                err_details=str(e),
-                solution=(
-                    "The package.json file must contain valid JSON. "
-                    "Refer to the parser error and fix the contents of the file."
-                ),
-            )
-
-        return cls(path, package_json_data)
 
 
 @dataclass
@@ -138,7 +100,9 @@ class Project:
         - the presence of an expanded node_modules directory
         For more details on PnP, see: https://classic.yarnpkg.com/en/docs/pnp
         """
-        install_config_pnp_enabled = self.package_json.install_config.get("pnp", False)
+        install_config = self.package_json.data.get("installConfig", {})
+        install_config_pnp_enabled = install_config.get("pnp", False)
+
         pnp_cjs_exists = any(self.source_dir.path.glob("*.pnp.cjs"))
         node_modules_exists = self.source_dir.join_within_root("node_modules").path.exists()
         return install_config_pnp_enabled or pnp_cjs_exists or node_modules_exists
@@ -146,5 +110,5 @@ class Project:
     @classmethod
     def from_source_dir(cls, source_dir: RootedPath) -> "Project":
         """Create a Project from a sources directory path."""
-        package_json = PackageJson.from_file(source_dir.join_within_root("package.json"))
+        package_json = PackageJson.from_dir(source_dir.path)
         return cls(source_dir, package_json)

--- a/hermeto/core/package_managers/yarn_classic/project.py
+++ b/hermeto/core/package_managers/yarn_classic/project.py
@@ -121,9 +121,6 @@ class YarnLock(_CommonConfigFile):
         return cls(path, yarn_lockfile.data, yarn_lockfile)
 
 
-ConfigFile = PackageJson | YarnLock
-
-
 @dataclass(frozen=True)
 class Project:
     """Minimally, a directory containing yarn sources and parsed package.json."""

--- a/hermeto/core/package_managers/yarn_classic/resolver.py
+++ b/hermeto/core/package_managers/yarn_classic/resolver.py
@@ -15,8 +15,9 @@ from pyarn.lockfile import Package as PYarnPackage
 from hermeto import APP_NAME
 from hermeto.core.checksum import ChecksumInfo
 from hermeto.core.errors import PackageRejected, UnexpectedFormat
+from hermeto.core.package_managers.common import PackageJson
 from hermeto.core.package_managers.npm import NPM_REGISTRY_CNAMES
-from hermeto.core.package_managers.yarn_classic.project import PackageJson, Project, YarnLock
+from hermeto.core.package_managers.yarn_classic.project import Project, YarnLock
 from hermeto.core.package_managers.yarn_classic.utils import (
     find_runtime_deps,
     get_git_tarball_mirror_name,
@@ -337,9 +338,9 @@ def _get_packages_from_lockfile(
 
 def _get_main_package(source_dir: RootedPath, package_json: PackageJson) -> WorkspacePackage:
     """Return a WorkspacePackage for the main package in package.json."""
-    if "name" not in package_json._data:
+    if "name" not in package_json.data:
         raise PackageRejected(
-            f"The package.json file located at {package_json.path.path} is missing the name field",
+            f"The package.json file located at {package_json.path} is missing the name field",
             solution="Ensure the package.json file has a valid name.",
         )
     return WorkspacePackage(
@@ -401,7 +402,7 @@ def _read_name_from_tarball(tarball_path: RootedPath) -> str:
 
 def _read_name_from_package_json(path: RootedPath) -> str:
     """Read the package name from a package.json file."""
-    package_json = PackageJson.from_file(path)
+    package_json = PackageJson.from_file(path.path)
 
     if (name := package_json.data.get("name")) is None:
         raise ValueError(f"No 'name' field found in package.json in {path}")

--- a/hermeto/core/package_managers/yarn_classic/utils.py
+++ b/hermeto/core/package_managers/yarn_classic/utils.py
@@ -7,7 +7,8 @@ from urllib.parse import urlparse
 
 from pyarn.lockfile import Package as PYarnPackage
 
-from hermeto.core.package_managers.yarn_classic.project import PackageJson, YarnLock
+from hermeto.core.package_managers.common import PackageJson
+from hermeto.core.package_managers.yarn_classic.project import YarnLock
 from hermeto.core.package_managers.yarn_classic.workspaces import Workspace
 
 

--- a/hermeto/core/package_managers/yarn_classic/workspaces.py
+++ b/hermeto/core/package_managers/yarn_classic/workspaces.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import pydantic
 
-from hermeto.core.package_managers.yarn_classic.project import PackageJson
+from hermeto.core.package_managers.common import PackageJson
 from hermeto.core.rooted_path import RootedPath
 
 log = logging.getLogger(__name__)
@@ -21,6 +21,8 @@ class Workspace(pydantic.BaseModel):
         path: Path to workspace directory.
         package_json: Content of package.json file.
     """
+
+    model_config = pydantic.ConfigDict(arbitrary_types_allowed=True)
 
     path: Path
     package_json: PackageJson
@@ -76,7 +78,7 @@ def _extract_workspaces_globs(package: dict[str, Any]) -> list[str]:
 
 def extract_workspace_metadata(package_path: RootedPath) -> list[Workspace]:
     """Extract workspace metadata from a package."""
-    package_json = PackageJson.from_file(package_path.join_within_root("package.json"))
+    package_json = PackageJson.from_dir(package_path.path)
     workspaces_globs = _extract_workspaces_globs(package_json.data)
     workspaces_paths = _get_workspace_paths(workspaces_globs, package_path)
     ensure_no_path_leads_out(workspaces_paths, package_path)
@@ -100,7 +102,7 @@ def extract_workspace_metadata(package_path: RootedPath) -> list[Workspace]:
         parsed_workspaces.append(
             Workspace(
                 path=wp,
-                package_json=PackageJson.from_file(package_json_path),
+                package_json=PackageJson.from_file(package_json_path.path),
             )
         )
 

--- a/tests/unit/package_managers/yarn/test_project.py
+++ b/tests/unit/package_managers/yarn/test_project.py
@@ -12,8 +12,8 @@ from hermeto.core.errors import (
     PackageRejected,
     UnexpectedFormat,
 )
+from hermeto.core.package_managers.common import PackageJson
 from hermeto.core.package_managers.yarn.project import (
-    PackageJson,
     Project,
     YarnRc,
     get_semver_from_package_manager,
@@ -140,7 +140,7 @@ def _prepare_package_json_file(rooted_tmp_path: RootedPath, data: str) -> Packag
     with open(path, "w") as f:
         f.write(data)
 
-    return PackageJson.from_file(path)
+    return PackageJson.from_file(path.path)
 
 
 def test_parse_package_json(rooted_tmp_path: RootedPath) -> None:
@@ -186,7 +186,7 @@ def test_parse_project_folder(rooted_tmp_path: RootedPath) -> None:
 
     assert project.yarn_rc is not None
     assert project.yarn_rc._path == rooted_tmp_path.join_within_root(".yarnrc.yml")
-    assert project.package_json._path == rooted_tmp_path.join_within_root("package.json")
+    assert project.package_json.path == rooted_tmp_path.join_within_root("package.json").path
 
 
 def test_parse_project_folder_without_yarnrc(rooted_tmp_path: RootedPath) -> None:
@@ -198,7 +198,7 @@ def test_parse_project_folder_without_yarnrc(rooted_tmp_path: RootedPath) -> Non
 
     assert len(project.yarn_rc.data) == 0
     assert project.yarn_rc._path == rooted_tmp_path.join_within_root(".yarnrc.yml")
-    assert project.package_json._path == rooted_tmp_path.join_within_root("package.json")
+    assert project.package_json.path == rooted_tmp_path.join_within_root("package.json").path
 
 
 def test_parse_empty_folder(rooted_tmp_path: RootedPath) -> None:

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -308,7 +308,7 @@ def mock_project(project_dir: RootedPath) -> Project:
     return Project(
         project_dir,
         YarnRc(project_dir.join_within_root(".yarnrc.yml"), {}),
-        PackageJson(project_dir.join_within_root("package.json"), {}),
+        PackageJson(project_dir.join_within_root("package.json").path, {}),
     )
 
 

--- a/tests/unit/package_managers/yarn_classic/test_project.py
+++ b/tests/unit/package_managers/yarn_classic/test_project.py
@@ -7,7 +7,6 @@ from pyarn import lockfile  # type: ignore
 from hermeto.core.errors import PackageRejected
 from hermeto.core.package_managers.yarn_classic.main import _verify_repository
 from hermeto.core.package_managers.yarn_classic.project import (
-    ConfigFile,
     PackageJson,
     Project,
     YarnLock,
@@ -52,15 +51,10 @@ package-1
 """
 
 
-def _prepare_config_file(
-    rooted_tmp_path: RootedPath, config_file_class: ConfigFile, filename: str, content: str
-) -> ConfigFile:
+def _write_file(rooted_tmp_path: RootedPath, filename: str, content: str) -> RootedPath:
     path = rooted_tmp_path.join_within_root(filename)
-
-    with open(path, "w") as f:
-        f.write(content)
-
-    return config_file_class.from_file(path)
+    path.path.write_text(content)
+    return path
 
 
 def _setup_pnp_installs(rooted_tmp_path: RootedPath, pnp_kind: str) -> None:
@@ -70,133 +64,74 @@ def _setup_pnp_installs(rooted_tmp_path: RootedPath, pnp_kind: str) -> None:
         rooted_tmp_path.join_within_root("foo.pnp.cjs").path.touch()
 
 
-@pytest.mark.parametrize(
-    "config_file_class, config_file_name, config_file_content",
-    [
-        pytest.param(PackageJson, "package.json", VALID_PACKAGE_JSON_FILE, id="package_json"),
-        pytest.param(YarnLock, "yarn.lock", VALID_YARN_LOCK_FILE, id="yarnlock"),
-    ],
-)
-def test_config_file_attributes(
-    rooted_tmp_path: RootedPath,
-    config_file_class: ConfigFile,
-    config_file_name: str,
-    config_file_content: str,
-) -> None:
-    found_config = _prepare_config_file(
-        rooted_tmp_path,
-        config_file_class,
-        config_file_name,
-        config_file_content,
-    )
-    assert found_config.path.root == rooted_tmp_path.root
+def test_package_json_config_file_attributes(rooted_tmp_path: RootedPath) -> None:
+    path = _write_file(rooted_tmp_path, "package.json", VALID_PACKAGE_JSON_FILE)
+    package_json = PackageJson.from_file(path)
+    assert package_json.path.root == rooted_tmp_path.root
 
 
-@pytest.mark.parametrize(
-    "config_file_class, config_file_name, config_file_content, content_kind",
-    [
-        pytest.param(
-            PackageJson, "package.json", VALID_PACKAGE_JSON_FILE, "json", id="package_json"
-        ),
-        pytest.param(YarnLock, "yarn.lock", VALID_YARN_LOCK_FILE, "pyarn", id="yarnlock"),
-    ],
-)
-def test_find_and_open_config_file(
-    rooted_tmp_path: RootedPath,
-    config_file_class: ConfigFile,
-    config_file_name: str,
-    config_file_content: str,
-    content_kind: str,
-) -> None:
-    found_config = _prepare_config_file(
-        rooted_tmp_path,
-        config_file_class,
-        config_file_name,
-        config_file_content,
-    )
-
-    if content_kind == "json":
-        assert found_config.data == json.loads(config_file_content)
-    elif content_kind == "pyarn":
-        assert found_config.data == lockfile.Lockfile.from_str(config_file_content).data
+def test_yarnlock_config_file_attributes(rooted_tmp_path: RootedPath) -> None:
+    path = _write_file(rooted_tmp_path, "yarn.lock", VALID_YARN_LOCK_FILE)
+    yarn_lock = YarnLock.from_file(path)
+    assert yarn_lock.path.root == rooted_tmp_path.root
 
 
-@pytest.mark.parametrize(
-    "config_file_class, config_file_name, config_file_content",
-    [
-        pytest.param(
-            PackageJson,
-            "package.json",
-            INVALID_JSON_FILE,
-            id="invalid_package_json",
-        ),
-        pytest.param(YarnLock, "yarn.lock", EMPTY_YARN_LOCK_FILE, id="empty_yarnlock"),
-        pytest.param(YarnLock, "yarn.lock", INVALID_YARN_LOCK_FILE, id="invalid_yarnlock"),
-    ],
-)
-def test_from_file_bad(
-    rooted_tmp_path: RootedPath,
-    config_file_class: ConfigFile,
-    config_file_name: str,
-    config_file_content: str,
-) -> None:
+def test_package_json_find_and_open_config_file(rooted_tmp_path: RootedPath) -> None:
+    path = _write_file(rooted_tmp_path, "package.json", VALID_PACKAGE_JSON_FILE)
+    package_json = PackageJson.from_file(path)
+    assert package_json.data == json.loads(VALID_PACKAGE_JSON_FILE)
+
+
+def test_yarnlock_find_and_open_config_file(rooted_tmp_path: RootedPath) -> None:
+    path = _write_file(rooted_tmp_path, "yarn.lock", VALID_YARN_LOCK_FILE)
+    yarn_lock = YarnLock.from_file(path)
+    assert yarn_lock.data == lockfile.Lockfile.from_str(VALID_YARN_LOCK_FILE).data
+
+
+def test_package_json_from_file_bad(rooted_tmp_path: RootedPath) -> None:
+    path = _write_file(rooted_tmp_path, "package.json", INVALID_JSON_FILE)
     with pytest.raises(PackageRejected):
-        _prepare_config_file(
-            rooted_tmp_path,
-            config_file_class,
-            config_file_name,
-            config_file_content,
-        )
+        PackageJson.from_file(path)
 
 
-@pytest.mark.parametrize(
-    "config_file_class, config_file_name",
-    [
-        pytest.param(
-            PackageJson,
-            "package.json",
-            id="missing_package_json",
-        ),
-        pytest.param(YarnLock, "yarn.lock", id="missing_yarnlock"),
-    ],
-)
-def test_from_file_missing(
-    rooted_tmp_path: RootedPath,
-    config_file_class: ConfigFile,
-    config_file_name: str,
-) -> None:
+def test_yarnlock_from_file_empty(rooted_tmp_path: RootedPath) -> None:
+    path = _write_file(rooted_tmp_path, "yarn.lock", EMPTY_YARN_LOCK_FILE)
     with pytest.raises(PackageRejected):
-        path = rooted_tmp_path.join_within_root(config_file_name)
-        config_file_class.from_file(path)
+        YarnLock.from_file(path)
+
+
+def test_yarnlock_from_file_invalid(rooted_tmp_path: RootedPath) -> None:
+    path = _write_file(rooted_tmp_path, "yarn.lock", INVALID_YARN_LOCK_FILE)
+    with pytest.raises(PackageRejected):
+        YarnLock.from_file(path)
+
+
+def test_package_json_from_file_missing(rooted_tmp_path: RootedPath) -> None:
+    with pytest.raises(PackageRejected):
+        path = rooted_tmp_path.join_within_root("package.json")
+        PackageJson.from_file(path)
+
+
+def test_yarnlock_from_file_missing(rooted_tmp_path: RootedPath) -> None:
+    with pytest.raises(PackageRejected):
+        path = rooted_tmp_path.join_within_root("yarn.lock")
+        YarnLock.from_file(path)
 
 
 @pytest.mark.parametrize(
-    "config_file_class, config_file_name, config_file_content, pnp_kind",
+    "content, pnp_kind",
     [
-        pytest.param(
-            PackageJson,
-            "package.json",
-            PNP_PACKAGE_JSON_FILE,
-            "install_config",
-            id="installConfig",
-        ),
-        pytest.param(PackageJson, "package.json", VALID_PACKAGE_JSON_FILE, "node", id="node"),
-        pytest.param(PackageJson, "package.json", VALID_PACKAGE_JSON_FILE, "pnp_cjs", id="pnp_cjs"),
+        pytest.param(PNP_PACKAGE_JSON_FILE, "install_config", id="installConfig"),
+        pytest.param(VALID_PACKAGE_JSON_FILE, "node", id="node"),
+        pytest.param(VALID_PACKAGE_JSON_FILE, "pnp_cjs", id="pnp_cjs"),
     ],
 )
 def test_pnp_installs_true(
     rooted_tmp_path: RootedPath,
-    config_file_class: ConfigFile,
-    config_file_name: str,
-    config_file_content: str,
+    content: str,
     pnp_kind: str,
 ) -> None:
-    _prepare_config_file(
-        rooted_tmp_path,
-        config_file_class,
-        config_file_name,
-        config_file_content,
-    )
+    _write_file(rooted_tmp_path, "package.json", content)
 
     project = Project.from_source_dir(rooted_tmp_path)
 
@@ -205,37 +140,9 @@ def test_pnp_installs_true(
         _verify_repository(project)
 
 
-@pytest.mark.parametrize(
-    "config_file_class, config_file_name, config_file_content",
-    [
-        pytest.param(
-            PackageJson,
-            "package.json",
-            VALID_PACKAGE_JSON_FILE,
-        ),
-    ],
-)
-def test_pnp_installs_false(
-    rooted_tmp_path: RootedPath,
-    config_file_class: ConfigFile,
-    config_file_name: str,
-    config_file_content: str,
-) -> None:
-    _prepare_config_file(
-        rooted_tmp_path,
-        config_file_class,
-        config_file_name,
-        config_file_content,
-    )
-    # A yarn v1 project needs a valid yarn lock to be accepted.
-    _prepare_config_file(
-        rooted_tmp_path,
-        # Ignoring type checking because of
-        #   incompatible type "type[YarnLock]"; expected "Union[PackageJson, YarnLock]"
-        YarnLock,  # type: ignore
-        "yarn.lock",
-        VALID_YARN_LOCK_FILE,
-    )
+def test_pnp_installs_false(rooted_tmp_path: RootedPath) -> None:
+    _write_file(rooted_tmp_path, "package.json", VALID_PACKAGE_JSON_FILE)
+    _write_file(rooted_tmp_path, "yarn.lock", VALID_YARN_LOCK_FILE)
 
     project = Project.from_source_dir(rooted_tmp_path)
 

--- a/tests/unit/package_managers/yarn_classic/test_project.py
+++ b/tests/unit/package_managers/yarn_classic/test_project.py
@@ -5,12 +5,9 @@ import pytest
 from pyarn import lockfile  # type: ignore
 
 from hermeto.core.errors import PackageRejected
+from hermeto.core.package_managers.common import PackageJson
 from hermeto.core.package_managers.yarn_classic.main import _verify_repository
-from hermeto.core.package_managers.yarn_classic.project import (
-    PackageJson,
-    Project,
-    YarnLock,
-)
+from hermeto.core.package_managers.yarn_classic.project import Project, YarnLock
 from hermeto.core.rooted_path import RootedPath
 
 VALID_PACKAGE_JSON_FILE = """
@@ -66,8 +63,8 @@ def _setup_pnp_installs(rooted_tmp_path: RootedPath, pnp_kind: str) -> None:
 
 def test_package_json_config_file_attributes(rooted_tmp_path: RootedPath) -> None:
     path = _write_file(rooted_tmp_path, "package.json", VALID_PACKAGE_JSON_FILE)
-    package_json = PackageJson.from_file(path)
-    assert package_json.path.root == rooted_tmp_path.root
+    package_json = PackageJson.from_file(path.path)
+    assert package_json.path == rooted_tmp_path.path / "package.json"
 
 
 def test_yarnlock_config_file_attributes(rooted_tmp_path: RootedPath) -> None:
@@ -78,7 +75,7 @@ def test_yarnlock_config_file_attributes(rooted_tmp_path: RootedPath) -> None:
 
 def test_package_json_find_and_open_config_file(rooted_tmp_path: RootedPath) -> None:
     path = _write_file(rooted_tmp_path, "package.json", VALID_PACKAGE_JSON_FILE)
-    package_json = PackageJson.from_file(path)
+    package_json = PackageJson.from_file(path.path)
     assert package_json.data == json.loads(VALID_PACKAGE_JSON_FILE)
 
 
@@ -91,7 +88,7 @@ def test_yarnlock_find_and_open_config_file(rooted_tmp_path: RootedPath) -> None
 def test_package_json_from_file_bad(rooted_tmp_path: RootedPath) -> None:
     path = _write_file(rooted_tmp_path, "package.json", INVALID_JSON_FILE)
     with pytest.raises(PackageRejected):
-        PackageJson.from_file(path)
+        PackageJson.from_file(path.path)
 
 
 def test_yarnlock_from_file_empty(rooted_tmp_path: RootedPath) -> None:
@@ -109,7 +106,7 @@ def test_yarnlock_from_file_invalid(rooted_tmp_path: RootedPath) -> None:
 def test_package_json_from_file_missing(rooted_tmp_path: RootedPath) -> None:
     with pytest.raises(PackageRejected):
         path = rooted_tmp_path.join_within_root("package.json")
-        PackageJson.from_file(path)
+        PackageJson.from_file(path.path)
 
 
 def test_yarnlock_from_file_missing(rooted_tmp_path: RootedPath) -> None:

--- a/tests/unit/package_managers/yarn_classic/test_resolver.py
+++ b/tests/unit/package_managers/yarn_classic/test_resolver.py
@@ -12,8 +12,8 @@ from pyarn.lockfile import Package as PYarnPackage
 
 from hermeto.core.checksum import ChecksumInfo
 from hermeto.core.errors import PackageRejected, UnexpectedFormat
+from hermeto.core.package_managers.common import PackageJson
 from hermeto.core.package_managers.yarn_classic.main import MIRROR_DIR
-from hermeto.core.package_managers.yarn_classic.project import PackageJson
 from hermeto.core.package_managers.yarn_classic.resolver import (
     FilePackage,
     GitPackage,
@@ -319,8 +319,8 @@ def test_resolve_packages(
 
 def test_get_main_package(rooted_tmp_path: RootedPath) -> None:
     package_json = PackageJson(
-        _path=rooted_tmp_path.join_within_root("package.json"),
-        _data={"name": "foo", "version": "1.0.0"},
+        rooted_tmp_path.join_within_root("package.json").path,
+        {"name": "foo", "version": "1.0.0"},
     )
     expected_output = WorkspacePackage(
         name="foo",
@@ -334,12 +334,10 @@ def test_get_main_package(rooted_tmp_path: RootedPath) -> None:
 
 def test_get_main_package_no_name(rooted_tmp_path: RootedPath) -> None:
     package_json = PackageJson(
-        _path=rooted_tmp_path.join_within_root("package.json"),
-        _data={},
+        rooted_tmp_path.join_within_root("package.json").path,
+        {},
     )
-    error_msg = (
-        f"The package.json file located at {package_json._path.path} is missing the name field"
-    )
+    error_msg = f"The package.json file located at {package_json.path} is missing the name field"
 
     with pytest.raises(PackageRejected, match=error_msg):
         _get_main_package(rooted_tmp_path, package_json)
@@ -352,11 +350,8 @@ def test_get_workspace_packages(rooted_tmp_path: RootedPath) -> None:
     package_json_path = workspace_path.join_within_root("package.json")
     package_json_path.path.write_text('{"name": "foo", "version": "1.0.0"}')
 
-    package_json = PackageJson.from_file(package_json_path)
-    workspace = Workspace(
-        path=workspace_path.path,
-        package_json=package_json,
-    )
+    package_json = PackageJson.from_file(package_json_path.path)
+    workspace = Workspace(path=workspace_path.path, package_json=package_json)
 
     expected = [
         WorkspacePackage(

--- a/tests/unit/package_managers/yarn_classic/test_utils.py
+++ b/tests/unit/package_managers/yarn_classic/test_utils.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 from unittest import mock
 
-from hermeto.core.package_managers.yarn_classic.project import PackageJson
+from hermeto.core.package_managers.common import PackageJson
 from hermeto.core.package_managers.yarn_classic.utils import find_runtime_deps
 from hermeto.core.package_managers.yarn_classic.workspaces import Workspace
 from hermeto.core.rooted_path import RootedPath
@@ -32,7 +32,7 @@ def test_find_runtime_deps(
 ) -> None:
     package_json_path = rooted_tmp_path.join_within_root("package.json")
     package_json_path.path.write_text(PACKAGE_JSON)
-    package_json = PackageJson.from_file(package_json_path)
+    package_json = PackageJson.from_file(package_json_path.path)
 
     mock_yarn_lock_instance = mock_yarn_lock.return_value
     mock_yarn_lock_instance.data = {
@@ -104,7 +104,7 @@ def test_find_runtime_deps_with_workspace(
 ) -> None:
     package_json_path = rooted_tmp_path.join_within_root("package.json")
     package_json_path.path.write_text(MAIN_PACKAGE_JSON)
-    package_json = PackageJson.from_file(package_json_path)
+    package_json = PackageJson.from_file(package_json_path.path)
 
     workspace_dir = rooted_tmp_path.join_within_root("packages/workspace")
     workspace_dir.path.mkdir(parents=True)
@@ -114,7 +114,7 @@ def test_find_runtime_deps_with_workspace(
 
     w = Workspace(
         path=workspace_dir.path,
-        package_json=PackageJson.from_file(workspace_package_json),
+        package_json=PackageJson.from_file(workspace_package_json.path),
     )
 
     mock_yarn_lock_instance = mock_yarn_lock.return_value

--- a/tests/unit/package_managers/yarn_classic/test_workspaces.py
+++ b/tests/unit/package_managers/yarn_classic/test_workspaces.py
@@ -46,7 +46,7 @@ def test_workspaces_could_be_parsed(
     expected_result = [
         Workspace(
             path=workspace_path.path,
-            package_json=PackageJson.from_file(workspace_package_json_path),
+            package_json=PackageJson.from_file(workspace_package_json_path.path),
         ),
     ]
     result = extract_workspace_metadata(rooted_tmp_path)


### PR DESCRIPTION
Having multiple identical classes is just a bad practise. Another one would arrive during the implementation of the **pnpm** backend.