### PR TITLE
docs: use ENTRYPOINT instead of CMD in pip.md Dockerfile example

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -848,7 +848,7 @@ RUN source /tmp/hermeto.env \
     && python3 -m pip install --use-pep517 -r requirements.txt \
     && python3 -m pip install --use-pep517 .
 
-CMD ["python3", "-m", "simple_color_output"]
+ENTRYPOINT ["python3", "-m", "simple_color_output"]
 ```
 
 After mounting the required Hermeto data, we can then build the image!


### PR DESCRIPTION
The example Dockerfile in docs/pip.md uses CMD without ENTRYPOINT
for a container that has a single fixed purpose.

Best practice for single-purpose containers is to use ENTRYPOINT
in exec form so the application process runs as PID 1 and handles
OS signals (SIGTERM, SIGINT) correctly. Using CMD alone means the
default command can be silently overridden at runtime by anyone
passing an argument to docker run.

Changed CMD to ENTRYPOINT in the example Dockerfile.

Signed-off-by: Aryan Chalotra <aryanchalotra96@gmail.com>