### PR TITLE
feat(generic): add bearer token auth for downloads

### DIFF
--- a/hermeto/core/package_managers/general.py
+++ b/hermeto/core/package_managers/general.py
@@ -71,9 +71,9 @@ async def _async_download_binary_file(
     session: aiohttp_retry.RetryClient,
     url: str,
     download_path: StrPath,
-    auth: aiohttp.BasicAuth | None = None,
     ssl_context: ssl.SSLContext | None = None,
     chunk_size: int = 8192,
+    headers: dict[str, str] | None = None,
 ) -> None:
     """
     Download a binary file (such as a TAR archive) from a URL using asyncio.
@@ -81,8 +81,8 @@ async def _async_download_binary_file(
     :param aiohttp_retry.RetryClient session: Aiohttp interface for making HTTP requests.
     :param str url: URL for file download
     :param str download_path: File path location
-    :param aiohttp.BasicAuth auth: Authentication for the URL
     :param int chunk_size: Chunk size param for Response.content.read()
+    :param dict[str, str] headers: Custom HTTP headers.
     :raise FetchError: If download failed
     """
     try:
@@ -94,9 +94,9 @@ async def _async_download_binary_file(
         async with session.get(
             url,
             timeout=timeout,
-            auth=auth,
             raise_for_status=True,
             ssl=ssl_context,
+            headers=headers,
         ) as resp:
             with open(download_path, "wb") as f:
                 while True:
@@ -115,18 +115,32 @@ async def _async_download_binary_file(
     log.debug(f"Download completed - {url}")
 
 
+def _merge_headers(
+    global_headers: dict[str, str] | None,
+    url_headers: dict[str, str] | None,
+) -> dict[str, str] | None:
+    """Merge global headers and url-specific headers."""
+    if not global_headers and not url_headers:
+        return None
+    merged = dict(global_headers or {})
+    merged.update(url_headers or {})
+    return merged
+
+
 async def async_download_files(
     files_to_download: Mapping[str, StrPath],
     concurrency_limit: int,
     ssl_context: ssl.SSLContext | None = None,
-    auth: aiohttp.BasicAuth | None = None,
+    headers: dict[str, str] | None = None,
+    headers_by_url: Mapping[str, dict[str, str]] | None = None,
 ) -> None:
     """Asynchronous function to download files.
 
     :param files_to_download: Mapping of URLs and file paths to download.
     :param concurrency_limit: Max number of concurrent tasks (downloads).
     :param ssl_context: Optional SSL context for the requests.
-    :param auth: Optional authorization data for proxies.
+    :param headers: Optional custom HTTP headers to apply to all requests.
+    :param headers_by_url: Optional mapping of URL to custom HTTP headers.
     """
     trace_config = aiohttp.TraceConfig()
     num_attempts: int = int(DEFAULT_RETRY_OPTIONS["total"])
@@ -163,6 +177,10 @@ async def async_download_files(
                         t.cancel()
                     raise
 
+            # Get the headers specifically for this URL and merge them with global headers
+            url_specific_headers = headers_by_url.get(url) if headers_by_url else None
+            merged_headers = _merge_headers(headers, url_specific_headers)
+
             tasks.add(
                 asyncio.create_task(
                     _async_download_binary_file(
@@ -170,7 +188,7 @@ async def async_download_files(
                         url,
                         download_path,
                         ssl_context=ssl_context,
-                        auth=auth,
+                        headers=merged_headers,
                     )
                 )
             )

--- a/hermeto/core/package_managers/generic/main.py
+++ b/hermeto/core/package_managers/generic/main.py
@@ -14,7 +14,7 @@ from hermeto.core.models.input import Request
 from hermeto.core.models.output import RequestOutput
 from hermeto.core.models.sbom import Component, create_backend_annotation
 from hermeto.core.package_managers.general import async_download_files
-from hermeto.core.package_managers.generic.models import GenericLockfileV1
+from hermeto.core.package_managers.generic.models import GenericLockfileV1, LockfileArtifactUrl
 from hermeto.core.rooted_path import RootedPath
 
 log = logging.getLogger(__name__)
@@ -83,13 +83,24 @@ def _resolve_generic_lockfile(lockfile_path: Path, output_dir: RootedPath) -> li
     log.info(f"Reading generic lockfile: {lockfile_path}")
     lockfile = _load_lockfile(lockfile_path, output_dir)
     to_download: dict[str, str | os.PathLike[str]] = {}
+    headers_by_url: dict[str, dict[str, str]] = {}
 
     for artifact in lockfile.artifacts:
         # create the parent directory for the artifact
         Path.mkdir(Path(artifact.filename).parent, parents=True, exist_ok=True)
-        to_download[str(artifact.download_url)] = artifact.filename
+        url = str(artifact.download_url)
+        to_download[url] = artifact.filename
 
-    asyncio.run(async_download_files(to_download, get_config().runtime.concurrency_limit))
+        if isinstance(artifact, LockfileArtifactUrl):
+            auth_header = artifact.resolve_auth_header()
+            if auth_header:
+                headers_by_url[url] = auth_header
+
+    asyncio.run(
+        async_download_files(
+            to_download, get_config().runtime.concurrency_limit, headers_by_url=headers_by_url
+        )
+    )
 
     # verify checksums
     for artifact in lockfile.artifacts:

--- a/hermeto/core/package_managers/generic/models.py
+++ b/hermeto/core/package_managers/generic/models.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-only
+import os
 import re
 from abc import ABC, abstractmethod
 from collections import Counter
@@ -24,12 +25,64 @@ from hermeto.core.models.sbom import Component, ExternalReference
 from hermeto.core.rooted_path import RootedPath
 
 CHECKSUM_FORMAT = re.compile(r"^[a-zA-Z0-9]+:[a-zA-Z0-9]+$")
+ENV_VAR_PATTERN = re.compile(r"\$(?:([A-Za-z_][A-Za-z0-9_]*)|(\{([A-Za-z_][A-Za-z0-9_]*)\}))")
+
+
+def resolve_env_vars(value: str) -> str:
+    """Resolve environment variable placeholders in a string.
+
+    Replaces shell-like ``$VAR`` and ``${VAR}`` references with the corresponding
+    environment variable values.
+
+    :param value: the string that may contain ``$VAR`` or ``${VAR}`` placeholders
+    :return: the string with all placeholders resolved
+    :raises PackageManagerError: if any referenced environment variable is not set
+    """
+    matches = list(ENV_VAR_PATTERN.finditer(value))
+    if not matches:
+        return value
+
+    var_names = [match.group(1) or match.group(3) for match in matches]
+    missing_vars = sorted({var for var in var_names if var not in os.environ})
+
+    if missing_vars:
+        raise PackageManagerError(
+            f"Required environment variable(s) not set: {', '.join(missing_vars)}"
+        )
+
+    def _replace(match: re.Match) -> str:
+        var_name = match.group(1) or match.group(3)
+        return os.environ[var_name]
+
+    return ENV_VAR_PATTERN.sub(_replace, value)
+
+
+class BearerAuth(BaseModel):
+    """Bearer token authentication configuration.
+
+    :param header: HTTP header name to use (defaults to ``Authorization``)
+    :param value: header value, may contain ``$ENV_VAR`` or ``${ENV_VAR}`` references
+    """
+
+    header: str = "Authorization"
+    value: str
+    model_config = ConfigDict(extra="forbid")
+
+
+class AuthConfig(BaseModel):
+    """Authentication configuration wrapper.
+
+    Currently supports only ``bearer``, but is extensible for future auth types.
+    """
+
+    bearer: BearerAuth
+    model_config = ConfigDict(extra="forbid")
 
 
 class LockfileMetadata(BaseModel):
     """Defines format of the metadata section in the lockfile."""
 
-    version: Literal["1.0"]
+    version: Literal["1.0", "2.0"]
     model_config = ConfigDict(extra="forbid")
 
 
@@ -94,9 +147,11 @@ class LockfileArtifactUrl(LockfileArtifactBase):
     Defines format of a single artifact in the lockfile.
 
     :param download_url: The URL to download the artifact from.
+    :param auth: Optional authentication configuration for this artifact.
     """
 
     download_url: Annotated[AnyUrl, PlainSerializer(str, return_type=str)]
+    auth: AuthConfig | None = None
 
     def resolve_filename(self) -> str:
         """Resolve the filename of the artifact."""
@@ -104,6 +159,24 @@ class LockfileArtifactUrl(LockfileArtifactBase):
             url_path = urlparse(str(self.download_url)).path
             return Path(url_path).name
         return self.filename
+
+    def resolve_auth_header(self) -> dict[str, str]:
+        """Resolve the authentication header for this artifact.
+
+        :return: a dict mapping header name to resolved value, or empty dict if no auth
+        :raises PackageManagerError: if a referenced env var is not set
+        """
+        if self.auth is None:
+            return {}
+        bearer = self.auth.bearer
+        try:
+            resolved_value = resolve_env_vars(bearer.value)
+        except PackageManagerError:
+            raise PackageManagerError(
+                f"Authentication failed for '{self.download_url}': "
+                f"could not resolve environment variable(s) in auth value '{bearer.value}'"
+            )
+        return {bearer.header: resolved_value}
 
     def get_sbom_component(self) -> Component:
         """Return an SBOM component representation of the artifact."""
@@ -218,7 +291,7 @@ class LockfileArtifactMaven(LockfileArtifactBase):
 
 
 class GenericLockfileV1(BaseModel):
-    """Defines format of our generic lockfile, version 1.0."""
+    """Defines format of our generic lockfile, versions 1.0 and 2.0."""
 
     metadata: LockfileMetadata
     artifacts: list[LockfileArtifactUrl | LockfileArtifactMaven]
@@ -237,4 +310,16 @@ class GenericLockfileV1(BaseModel):
                 + (f"Duplicate filenames: {duplicate_filenames}" if duplicate_filenames else "")
             )
 
+        return self
+
+    @model_validator(mode="after")
+    def no_auth_in_v1(self) -> "GenericLockfileV1":
+        """Validate that auth is not used in v1.0 lockfiles."""
+        if self.metadata.version == "1.0":
+            for artifact in self.artifacts:
+                if isinstance(artifact, LockfileArtifactUrl) and artifact.auth is not None:
+                    raise ValueError(
+                        "The 'auth' field is not supported in lockfile version 1.0. "
+                        "Please upgrade to version 2.0 to use authentication."
+                    )
         return self

--- a/hermeto/core/package_managers/npm.py
+++ b/hermeto/core/package_managers/npm.py
@@ -538,7 +538,7 @@ async def _async_download_tar(files_to_download_list: list[dict[str, dict[str, A
     ftd = lambda ftd: {it["fetch_url"]: it["download_path"] for it in ftd.values()}
     adf = partial(async_download_files, concurrency_limit=get_config().runtime.concurrency_limit)
 
-    await asyncio.gather(*[adf(files_to_download=ftd(f), auth=auth(f)) for f in ftdl])
+    await asyncio.gather(*[adf(files_to_download=ftd(f), headers=auth(f)) for f in ftdl])
 
 
 def _get_npm_dependencies(
@@ -577,10 +577,12 @@ def _get_npm_dependencies(
                 if config.npm.proxy_url is not None:
                     fetch_url = _patch_url_to_point_to_a_proxy(url, config.npm.proxy_url)
                     if config.npm.proxy_login and config.npm.proxy_password:
-                        proxy_auth = aiohttp.BasicAuth(
-                            config.npm.proxy_login,
-                            config.npm.proxy_password,
-                        )
+                        proxy_auth = {
+                            "Authorization": aiohttp.BasicAuth(
+                                config.npm.proxy_login,
+                                config.npm.proxy_password,
+                            ).encode()
+                        }
             else:  # dep_type == "https"
                 if info["integrity"]:
                     algorithm, digest = ChecksumInfo.from_sri(info["integrity"])

--- a/tests/unit/package_managers/test_general.py
+++ b/tests/unit/package_managers/test_general.py
@@ -180,9 +180,9 @@ async def test_async_download_binary_file(
     assert session.get.call_args == mock.call(
         url,
         timeout=aiohttp.ClientTimeout(total=None, connect=30, sock_read=300),
-        auth=None,
         raise_for_status=True,
         ssl=None,
+        headers=None,
     )
 
 

--- a/tests/unit/package_managers/test_generic.py
+++ b/tests/unit/package_managers/test_generic.py
@@ -4,12 +4,14 @@ from typing import Any
 from unittest import mock
 
 import pytest
+from pydantic import ValidationError
 
 from hermeto import APP_NAME
 from hermeto.core.errors import (
     ChecksumVerificationFailed,
     InvalidLockfileFormat,
     LockfileNotFound,
+    PackageManagerError,
     PackageRejected,
     PathOutsideRoot,
 )
@@ -22,6 +24,12 @@ from hermeto.core.package_managers.generic.main import (
     _resolve_generic_lockfile,
     _resolve_lockfile_path,
     fetch_generic_source,
+)
+from hermeto.core.package_managers.generic.models import (
+    AuthConfig,
+    BearerAuth,
+    LockfileArtifactUrl,
+    resolve_env_vars,
 )
 from hermeto.core.rooted_path import RootedPath
 
@@ -123,6 +131,48 @@ artifacts:
     - download_url: https://example.com/artifact
       filename: archive.zip
       checksum: md5:32112bed1914cfe3799600f962750b1d
+"""
+
+LOCKFILE_V2_WITH_AUTH = """
+metadata:
+    version: '2.0'
+artifacts:
+    - download_url: https://gitlab.example.com/api/v4/projects/123/repository/archive.tar.gz
+      filename: archive.tar.gz
+      checksum: sha256:abc123def456
+      auth:
+        bearer:
+          header: PRIVATE-TOKEN
+          value: "$GITLAB_TOKEN"
+    - download_url: https://api.github.com/repos/owner/repo/tarball/v1.0.0
+      filename: repo.tar.gz
+      checksum: sha256:def456abc789
+      auth:
+        bearer:
+          value: "Bearer $GITHUB_TOKEN"
+    - download_url: https://example.com/public-file.zip
+      checksum: sha256:aaa111bbb222
+"""
+
+LOCKFILE_V2_NO_AUTH = """
+metadata:
+    version: '2.0'
+artifacts:
+    - download_url: https://example.com/artifact
+      filename: archive.zip
+      checksum: md5:3a18656e1cea70504b905836dee14db0
+"""
+
+LOCKFILE_V1_WITH_AUTH = """
+metadata:
+    version: '1.0'
+artifacts:
+    - download_url: https://example.com/artifact
+      filename: archive.zip
+      checksum: md5:3a18656e1cea70504b905836dee14db0
+      auth:
+        bearer:
+          value: "$MY_TOKEN"
 """
 
 
@@ -251,6 +301,11 @@ def test_resolve_generic_no_lockfile(mock_load: mock.Mock, rooted_tmp_path: Root
             InvalidLockfileFormat,
             id="wrong_checksum_format",
         ),
+        pytest.param(
+            LOCKFILE_V1_WITH_AUTH,
+            InvalidLockfileFormat,
+            id="auth_in_v1_rejected",
+        ),
     ],
 )
 @mock.patch("hermeto.core.package_managers.generic.main.asyncio.run")
@@ -376,11 +431,13 @@ def test_load_generic_lockfile_valid(rooted_tmp_path: RootedPath) -> None:
                 "download_url": "https://example.com/artifact",
                 "filename": str(rooted_tmp_path.join_within_root("archive.zip")),
                 "checksum": "md5:3a18656e1cea70504b905836dee14db0",
+                "auth": None,
             },
             {
                 "checksum": "md5:32112bed1914cfe3799600f962750b1d",
                 "download_url": "https://example.com/more/complex/path/file.tar.gz?foo=bar#fragment",
                 "filename": str(rooted_tmp_path.join_within_root("file.tar.gz")),
+                "auth": None,
             },
         ],
     }
@@ -391,3 +448,263 @@ def test_load_generic_lockfile_valid(rooted_tmp_path: RootedPath) -> None:
         f.write(LOCKFILE_VALID)
 
     assert _load_lockfile(lockfile_path.path, rooted_tmp_path).model_dump() == expected_lockfile
+
+
+# =============================================
+# Tests for bearer token authentication support
+# =============================================
+
+
+class TestResolveEnvVars:
+    """Tests for resolve_env_vars utility function."""
+
+    @pytest.mark.parametrize(
+        "env_vars, input_string, expected",
+        [
+            ({"MY_TOKEN": "secret123"}, "$MY_TOKEN", "secret123"),
+            ({"GITHUB_TOKEN": "ghp_xxx"}, "Bearer $GITHUB_TOKEN", "Bearer ghp_xxx"),
+            ({"GITEA_TOKEN": "tok_yyy"}, "token $GITEA_TOKEN", "token tok_yyy"),
+            ({"VAR1": "aaa", "VAR2": "bbb"}, "$VAR1:$VAR2", "aaa:bbb"),
+            ({}, "plain-value", "plain-value"),
+            ({}, "", ""),
+            ({"MY_TOKEN": "secret456"}, "${MY_TOKEN}", "secret456"),
+            ({"USER": "admin"}, "${USER}_token", "admin_token"),
+            ({"VAR1": "aaa", "VAR2": "bbb"}, "$VAR1:${VAR2}", "aaa:bbb"),
+        ],
+        ids=[
+            "single_var",
+            "var_with_prefix",
+            "var_with_nonstandard_prefix",
+            "multiple_vars",
+            "no_vars",
+            "empty_string",
+            "curly_brace_single_var",
+            "curly_brace_with_prefix",
+            "mixed_syntax",
+        ],
+    )
+    def test_success_cases(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        env_vars: dict[str, str],
+        input_string: str,
+        expected: str,
+    ) -> None:
+        for name, value in env_vars.items():
+            monkeypatch.setenv(name, value)
+        assert resolve_env_vars(input_string) == expected
+
+    @pytest.mark.parametrize(
+        "vars_to_del, input_string, match_re",
+        [
+            (["NONEXISTENT_VAR"], "$NONEXISTENT_VAR", "NONEXISTENT_VAR"),
+            (["MISSING1", "MISSING2"], "$MISSING1 $MISSING2", "MISSING1.*MISSING2"),
+            (["MISSING_VAR"], "${MISSING_VAR}", "MISSING_VAR"),
+        ],
+        ids=["single_missing", "multiple_missing", "curly_brace_missing"],
+    )
+    def test_missing_vars_raise(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        vars_to_del: list[str],
+        input_string: str,
+        match_re: str,
+    ) -> None:
+        for var in vars_to_del:
+            monkeypatch.delenv(var, raising=False)
+        with pytest.raises(PackageManagerError, match=match_re):
+            resolve_env_vars(input_string)
+
+
+class TestBearerAuthModel:
+    """Tests for BearerAuth Pydantic model."""
+
+    def test_defaults(self) -> None:
+        auth = BearerAuth(value="$TOKEN")
+        assert auth.header == "Authorization"
+        assert auth.value == "$TOKEN"
+
+    def test_custom_header(self) -> None:
+        auth = BearerAuth(header="PRIVATE-TOKEN", value="$GITLAB_TOKEN")
+        assert auth.header == "PRIVATE-TOKEN"
+
+    def test_extra_fields_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            BearerAuth(value="$TOKEN", unknown_field="bad")  # type: ignore[call-arg]
+
+
+class TestAuthConfig:
+    """Tests for AuthConfig Pydantic model."""
+
+    def test_valid(self) -> None:
+        config = AuthConfig(bearer=BearerAuth(value="$TOKEN"))
+        assert config.bearer.value == "$TOKEN"
+
+    def test_extra_fields_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            AuthConfig(
+                bearer=BearerAuth(value="$TOKEN"),
+                unknown="bad",  # type: ignore[call-arg]
+            )
+
+
+class TestResolveAuthHeader:
+    """Tests for LockfileArtifactUrl.resolve_auth_header method."""
+
+    def test_no_auth(self, rooted_tmp_path: RootedPath) -> None:
+        artifact = LockfileArtifactUrl.model_validate(
+            {
+                "download_url": "https://example.com/file.zip",
+                "checksum": "sha256:abc123",
+            },
+            context={"output_dir": rooted_tmp_path},
+        )
+        assert artifact.resolve_auth_header() == {}
+
+    def test_bearer_default_header(
+        self, rooted_tmp_path: RootedPath, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+        artifact = LockfileArtifactUrl.model_validate(
+            {
+                "download_url": "https://api.github.com/repos/owner/repo/tarball/v1.0",
+                "checksum": "sha256:abc123",
+                "auth": {"bearer": {"value": "Bearer $GITHUB_TOKEN"}},
+            },
+            context={"output_dir": rooted_tmp_path},
+        )
+        assert artifact.resolve_auth_header() == {"Authorization": "Bearer ghp_test123"}
+
+    def test_bearer_custom_header(
+        self, rooted_tmp_path: RootedPath, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat_xxx")
+        artifact = LockfileArtifactUrl.model_validate(
+            {
+                "download_url": "https://gitlab.example.com/api/v4/projects/123/archive.tar.gz",
+                "checksum": "sha256:abc123",
+                "auth": {"bearer": {"header": "PRIVATE-TOKEN", "value": "$GITLAB_TOKEN"}},
+            },
+            context={"output_dir": rooted_tmp_path},
+        )
+        assert artifact.resolve_auth_header() == {"PRIVATE-TOKEN": "glpat_xxx"}
+
+    def test_missing_env_var_raises(self, rooted_tmp_path: RootedPath) -> None:
+        artifact = LockfileArtifactUrl.model_validate(
+            {
+                "download_url": "https://example.com/file.zip",
+                "checksum": "sha256:abc123",
+                "auth": {"bearer": {"value": "$UNSET_TOKEN"}},
+            },
+            context={"output_dir": rooted_tmp_path},
+        )
+        with pytest.raises(PackageManagerError, match="Authentication failed for"):
+            artifact.resolve_auth_header()
+
+    def test_missing_env_var_includes_url(self, rooted_tmp_path: RootedPath) -> None:
+        artifact = LockfileArtifactUrl.model_validate(
+            {
+                "download_url": "https://private.example.com/secret.tar.gz",
+                "checksum": "sha256:abc123",
+                "auth": {"bearer": {"value": "$MISSING_SECRET"}},
+            },
+            context={"output_dir": rooted_tmp_path},
+        )
+        with pytest.raises(PackageManagerError, match="private.example.com/secret.tar.gz"):
+            artifact.resolve_auth_header()
+
+
+class TestAuthInLockfileV1Rejected:
+    """Test that auth is rejected in v1.0 lockfiles."""
+
+    def test_auth_in_v1_raises(self, rooted_tmp_path: RootedPath) -> None:
+        lockfile_path = rooted_tmp_path.join_within_root(DEFAULT_LOCKFILE_NAME)
+        with open(lockfile_path, "w") as f:
+            f.write(LOCKFILE_V1_WITH_AUTH)
+
+        with pytest.raises(InvalidLockfileFormat):
+            _load_lockfile(lockfile_path.path, rooted_tmp_path)
+
+
+class TestLockfileV2WithAuth:
+    """Tests for lockfile v2.0 with auth configuration."""
+
+    def test_load_v2_no_auth(self, rooted_tmp_path: RootedPath) -> None:
+        lockfile_path = rooted_tmp_path.join_within_root(DEFAULT_LOCKFILE_NAME)
+        with open(lockfile_path, "w") as f:
+            f.write(LOCKFILE_V2_NO_AUTH)
+
+        lockfile = _load_lockfile(lockfile_path.path, rooted_tmp_path)
+        assert lockfile.metadata.version == "2.0"
+        assert len(lockfile.artifacts) == 1
+        artifact = lockfile.artifacts[0]
+        assert isinstance(artifact, LockfileArtifactUrl)
+        assert artifact.auth is None
+
+    def test_load_v2_with_auth(self, rooted_tmp_path: RootedPath) -> None:
+        lockfile_path = rooted_tmp_path.join_within_root(DEFAULT_LOCKFILE_NAME)
+        with open(lockfile_path, "w") as f:
+            f.write(LOCKFILE_V2_WITH_AUTH)
+
+        lockfile = _load_lockfile(lockfile_path.path, rooted_tmp_path)
+        assert lockfile.metadata.version == "2.0"
+        assert len(lockfile.artifacts) == 3
+
+        # GitLab artifact with custom header
+        gitlab_artifact = lockfile.artifacts[0]
+        assert isinstance(gitlab_artifact, LockfileArtifactUrl)
+        assert gitlab_artifact.auth is not None
+        assert gitlab_artifact.auth.bearer.header == "PRIVATE-TOKEN"
+        assert gitlab_artifact.auth.bearer.value == "$GITLAB_TOKEN"
+
+        # GitHub artifact with default Authorization header
+        github_artifact = lockfile.artifacts[1]
+        assert isinstance(github_artifact, LockfileArtifactUrl)
+        assert github_artifact.auth is not None
+        assert github_artifact.auth.bearer.header == "Authorization"
+        assert github_artifact.auth.bearer.value == "Bearer $GITHUB_TOKEN"
+
+        # Public artifact without auth
+        public_artifact = lockfile.artifacts[2]
+        assert isinstance(public_artifact, LockfileArtifactUrl)
+        assert public_artifact.auth is None
+
+    @mock.patch("hermeto.core.package_managers.generic.main.asyncio.run")
+    @mock.patch("hermeto.core.package_managers.generic.main.async_download_files")
+    @mock.patch("hermeto.core.package_managers.generic.main.must_match_any_checksum")
+    def test_resolve_lockfile_passes_auth_headers(
+        self,
+        mock_checksums: mock.Mock,
+        mock_download: mock.Mock,
+        mock_asyncio_run: mock.Mock,
+        rooted_tmp_path: RootedPath,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("GITLAB_TOKEN", "glpat_test")
+        monkeypatch.setenv("GITHUB_TOKEN", "ghp_test")
+
+        lockfile_path = rooted_tmp_path.join_within_root(DEFAULT_LOCKFILE_NAME)
+        with open(lockfile_path, "w") as f:
+            f.write(LOCKFILE_V2_WITH_AUTH)
+
+        _resolve_generic_lockfile(lockfile_path.path, rooted_tmp_path)
+
+        # Verify async_download_files was called with correct headers_by_url
+        mock_asyncio_run.assert_called_once()
+        # The coroutine was created by async_download_files; verify the mock was called
+        mock_download.assert_called_once()
+        _, kwargs = mock_download.call_args
+        assert "headers_by_url" in kwargs
+        headers = kwargs["headers_by_url"]
+
+        # GitLab artifact should have PRIVATE-TOKEN header
+        gitlab_url = "https://gitlab.example.com/api/v4/projects/123/repository/archive.tar.gz"
+        assert headers[gitlab_url] == {"PRIVATE-TOKEN": "glpat_test"}
+
+        # GitHub artifact should have Authorization header
+        github_url = "https://api.github.com/repos/owner/repo/tarball/v1.0.0"
+        assert headers[github_url] == {"Authorization": "Bearer ghp_test"}
+
+        # Public artifact should NOT be in headers_by_url
+        public_url = "https://example.com/public-file.zip"
+        assert public_url not in headers

--- a/tests/unit/package_managers/test_npm.py
+++ b/tests/unit/package_managers/test_npm.py
@@ -1952,7 +1952,7 @@ def test_npm_proxy_credentials_do_not_propagate_to_nonregistry_hosts(
     _get_npm_dependencies(rooted_tmp_path, deps_to_download)
 
     for call in mock_async_download_files.mock_calls:
-        assert call.kwargs["auth"] is None, "Found credentials where they should not be!"
+        assert call.kwargs.get("headers") is None, "Found credentials where they should not be!"
 
 
 @pytest.mark.parametrize(
@@ -2011,7 +2011,7 @@ def test_npm_proxy_credentials_propagate_to_registry_hosts(
 
     msg = "Not found credentials where they should be!"
     for call in mock_async_download_files.mock_calls:
-        assert call.kwargs["auth"] is not None, msg
+        assert call.kwargs.get("headers") is not None, msg
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This implements bearer token authentication for the generic backend, allowing artifacts to be downloaded from private registries.

It introduces a new v2.0 lockfile schema with an 'auth' field and extends the download pipeline to inject per-URL authorization headers.

Closes #1224 
Assisted-by: Claude