### PR TITLE
fix(scm): strip credentials from username-only HTTPS remote URLs

### DIFF
--- a/hermeto/core/scm.py
+++ b/hermeto/core/scm.py
@@ -267,11 +267,22 @@ def get_repo_for_path(repo_root: Path, target_path: Path) -> tuple[GitRepo, Path
 def _canonicalize_origin_url(url: str) -> str:
     if "://" in url:
         parsed: ParseResult = urlparse(url)
-        cleaned_netloc = parsed.netloc.replace(
-            f"{parsed.username}:{parsed.password}@",
-            "",
-        )
-        return parsed._replace(netloc=cleaned_netloc).geturl()
+        if parsed.scheme == "ssh":
+            return url
+
+        if parsed.scheme in ("https", "http"):
+            if parsed.username or parsed.password:
+                log.warning(
+                    "Credentials detected in git remote origin URL for host '%s'. "
+                    "They will be stripped before the URL is written to the SBOM. "
+                    "Consider removing credentials from your remote URL.",
+                    parsed.hostname,
+                )
+            host = parsed.hostname or ""
+            port = f":{parsed.port}" if parsed.port else ""
+            cleaned_netloc = f"{host}{port}"
+            return parsed._replace(netloc=cleaned_netloc).geturl()
+        return url
     # scp-style is "only recognized if there are no slashes before the first colon"
     elif re.match("^[^/]*:", url):
         parts = url.split("@", 1)

--- a/tests/unit/test_scm.py
+++ b/tests/unit/test_scm.py
@@ -30,6 +30,14 @@ class TestRepoID:
                 "https://student:password@github.com/student/repo.git",
                 "https://github.com/student/repo.git",
             ),
+            (
+                "https://my-token@github.com/org/repo.git",
+                "https://github.com/org/repo.git",
+            ),
+            (
+                "https://my-token@github.enterprise.corp:8443/org/repo.git",
+                "https://github.enterprise.corp:8443/org/repo.git",
+            ),
             # unsupported
             (
                 "./foo:bar",


### PR DESCRIPTION
_canonicalize_origin_url strips credentials from git remote URLs before writing them to the SBOM. It does this by building a search string as "username:password@" and calling .replace() on the netloc. When a token is used as the username with no password (e.g. https://TOKEN@github.com/org/repo.git), urlparse returns password=None. Python's f-string converts None to the literal text "None", producing the search string "TOKEN:None@" which does not exist in the URL. .replace() returns the original string unchanged with no error and the credential leaks into the SBOM output.

Fix by rebuilding netloc from parsed.hostname and parsed.port only, scoped to http/https schemes. Credentials are excluded by construction rather than by pattern matching, handling all credential formats correctly regardless of whether username, password, or both are present.

SSH URLs are explicitly excluded — the username in ssh://user@host is a system user (e.g. "git"), not a credential, and must be preserved.

A warning is logged when credentials are detected, using only the hostname in the message to avoid the warning itself leaking the token.

Add two parametrize cases to TestRepoID.test_get_repo_id that fail before this fix and pass after.

Closes #1394


Assisted-by: Claude