### PR TITLE
fix: propagate exist_ok in write_file_tree

### DIFF
--- a/tests/common_utils/__init__.py
+++ b/tests/common_utils/__init__.py
@@ -32,4 +32,4 @@ def write_file_tree(tree_def: dict, rooted_at: StrPath, exist_ok: bool = False) 
             entry_path.write_text(value)
         else:
             entry_path.mkdir(exist_ok=exist_ok)
-            write_file_tree(value, entry_path)
+            write_file_tree(value, entry_path, exist_ok=exist_ok)


### PR DESCRIPTION
This is a follow-up to #1443
Propagate exist_ok parameter in recursive write_file_tree call
to prevent failure when directories already exist.

Signed-off-by: Aryan Chalotra <aryanchalotra96@gmail.com>