### PR TITLE
fix(pip): use path.name instead of name in _sdist_preference

### DIFF
--- a/hermeto/core/package_managers/pip/package_distributions.py
+++ b/hermeto/core/package_managers/pip/package_distributions.py
@@ -105,7 +105,7 @@ def _sdist_preference(sdist_pkg: DistributionPackageInfo) -> tuple[int, int]:
     # Higher number = higher preference
     yanked_pref = 0 if sdist_pkg.is_yanked else 1
 
-    filename = sdist_pkg.name
+    filename = sdist_pkg.path.name
     if filename.endswith(".tar.gz"):
         filetype_pref = 2
     elif filename.endswith(".zip"):

--- a/tests/unit/package_managers/pip/test_package_distributions.py
+++ b/tests/unit/package_managers/pip/test_package_distributions.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-only
+from pathlib import Path
 from unittest import mock
 
 import pypi_simple
@@ -43,12 +44,24 @@ def mock_pypi_simple_distribution_package(
 
 def test_sdist_sorting() -> None:
     """Test that sdist preference key can be used for sorting in the expected order."""
-    unyanked_tar_gz = mock_distribution_package_info(name="unyanked.tar.gz", is_yanked=False)
-    unyanked_zip = mock_distribution_package_info(name="unyanked.zip", is_yanked=False)
-    unyanked_tar_bz2 = mock_distribution_package_info(name="unyanked.tar.bz2", is_yanked=False)
-    yanked_tar_gz = mock_distribution_package_info(name="yanked.tar.gz", is_yanked=True)
-    yanked_zip = mock_distribution_package_info(name="yanked.zip", is_yanked=True)
-    yanked_tar_bz2 = mock_distribution_package_info(name="yanked.tar.bz2", is_yanked=True)
+    unyanked_tar_gz = mock_distribution_package_info(
+        name="unyanked", path=Path("unyanked.tar.gz"), is_yanked=False
+    )
+    unyanked_zip = mock_distribution_package_info(
+        name="unyanked", path=Path("unyanked.zip"), is_yanked=False
+    )
+    unyanked_tar_bz2 = mock_distribution_package_info(
+        name="unyanked", path=Path("unyanked.tar.bz2"), is_yanked=False
+    )
+    yanked_tar_gz = mock_distribution_package_info(
+        name="yanked", path=Path("yanked.tar.gz"), is_yanked=True
+    )
+    yanked_zip = mock_distribution_package_info(
+        name="yanked", path=Path("yanked.zip"), is_yanked=True
+    )
+    yanked_tar_bz2 = mock_distribution_package_info(
+        name="yanked", path=Path("yanked.tar.bz2"), is_yanked=True
+    )
 
     # Original order is descending by preference
     sdists = [
@@ -79,24 +92,28 @@ class TestProcessPreferBinaryMode:
     def test_returns_wheels_plus_best_sdist(self) -> None:
         """Prefer-binary mode returns wheels and the best sdist together."""
         wheel1 = mock_distribution_package_info(
-            name="pkg-1.0.0-cp312-cp312-manylinux_x86_64.whl",
+            name="pkg",
             version="1.0.0",
             package_type="wheel",
+            path=Path("pkg-1.0.0-cp312-cp312-manylinux_x86_64.whl"),
         )
         wheel2 = mock_distribution_package_info(
-            name="pkg-1.0.0-py3-none-any.whl",
+            name="pkg",
             version="1.0.0",
             package_type="wheel",
+            path=Path("pkg-1.0.0-py3-none-any.whl"),
         )
         sdist_tar = mock_distribution_package_info(
-            name="pkg-1.0.0.tar.gz",
+            name="pkg",
             version="1.0.0",
             package_type="sdist",
+            path=Path("pkg-1.0.0.tar.gz"),
         )
         sdist_zip = mock_distribution_package_info(
-            name="pkg-1.0.0.zip",
+            name="pkg",
             version="1.0.0",
             package_type="sdist",
+            path=Path("pkg-1.0.0.zip"),
         )
 
         result = _process_prefer_binary_mode(


### PR DESCRIPTION
Resolves: #1442

## Description

In `_sdist_preference`, the archive format is determined using `sdist_pkg.name`, which holds the canonical package name (e.g. `requests`) — never a filename. This makes the `.tar.gz` and `.zip` branches unreachable dead code, causing every sdist to score `0` unconditionally regardless of format.

## Affected code
```python
filename = sdist_pkg.name        # "requests" — wrong field, never a filename
if filename.endswith(".tar.gz"): # unreachable
    return 2
elif filename.endswith(".zip"):  # unreachable
    return 1
return 0                         # always reached
```

The actual archive filename lives in `sdist_pkg.path.name`, which is distinct from `sdist_pkg.name` as confirmed by how `DistributionPackageInfo` is constructed in `process_package_distributions`:
```python
dpi = DistributionPackageInfo(
    name,                                               # requirement.package → "requests"
    version,
    ...,
    pip_deps_dir.join_within_root(package.filename).path,  # Path(".../requests-2.28.0.tar.gz")
)
```

## Impact

When a package index serves multiple sdist formats for the same version, all candidates score `(1, 0)`. `max()` resolves the tie by returning the last maximum it encounters — so the selected format depends on the index's listing order, not the intended `.tar.gz > .zip > other` preference.

Verified with `distribute==0.6.49`, the only known PyPI package that ships both `.tar.gz` and `.zip` sdists — both incorrectly scored `(1, 0)` before the fix:
### Before
```python
'distribute-0.6.49.tar.gz' -> score=(1, 0)
'distribute-0.6.49.zip'    -> score=(1, 0)
winner: nondeterministic (depends on index listing order)
```
### After
```python
'distribute-0.6.49.tar.gz' -> score=(1, 2)
'distribute-0.6.49.zip'    -> score=(1, 1)
winner: 'distribute-0.6.49.tar.gz' (always)
```
While this edge case is rare on public PyPI, custom indexes are not constrained by this and may serve both formats.

## Fix
```python
# Before
filename = sdist_pkg.name

# After
filename = sdist_pkg.path.name
```

## Tests

- Updated `test_sdist_sorting` to pass archive filenames via `path=` instead of `name=`
- Updated `TestProcessPreferBinaryMode` mocks to correctly separate canonical name from archive filename

## DEBUG

<img width="1834" height="111" alt="Screenshot From 2026-03-23 20-33-27" src="https://github.com/user-attachments/assets/295d78c6-378b-4c14-b7df-c5a0ea20de9a" />
