### PR TITLE
fix(generate-env): dependent variables get stale values because mappings are built before path resolution

### DIFF
--- a/hermeto/core/extras/envfile.py
+++ b/hermeto/core/extras/envfile.py
@@ -1,12 +1,130 @@
 # SPDX-License-Identifier: GPL-3.0-only
 import json
+import re
 import shlex
+from collections import deque
 from enum import Enum
 from pathlib import Path
+from typing import Optional
 
 from hermeto import APP_NAME
 from hermeto.core.errors import UnsupportedFeature
-from hermeto.core.models.output import BuildConfig
+from hermeto.core.models.output import BuildConfig, EnvironmentVariable
+
+# Pattern that matches ${VAR_NAME} placeholders (brace-delimited only, never bare).
+_REF_PATTERN = re.compile(r"\$\{(\w+)\}")
+
+
+def _extract_refs(value: str) -> list[str]:
+    """Return all variable names referenced as ${NAME} in *value*."""
+    return _REF_PATTERN.findall(value)
+
+
+def _substitute(value: str, mappings: dict[str, str]) -> str:
+    """Replace every ${NAME} in *value* using *mappings* (brace-delimited only).
+
+    Unknown placeholders are left untouched so callers can detect them later.
+    Output_dir is treated as a regular mapping entry; pass it in *mappings* if needed.
+    """
+
+    def _replace(m: re.Match) -> str:  # type: ignore[type-arg]
+        name = m.group(1)
+        return mappings.get(name, m.group(0))
+
+    return _REF_PATTERN.sub(_replace, value)
+
+
+def _detect_cycles(
+    all_vars: list[EnvironmentVariable],
+    name_to_var: dict[str, EnvironmentVariable],
+) -> None:
+    """Raise ValueError if a cycle exists in the ${VAR} reference graph.
+
+    Uses iterative DFS; detected cycles are reported as a readable chain:
+      "Circular variable reference detected: A → B → A"
+    """
+    # Build adjacency list restricted to variables we know about.
+    adj: dict[str, list[str]] = {
+        v.name: [r for r in _extract_refs(v.value) if r in name_to_var] for v in all_vars
+    }
+
+    visited: set[str] = set()
+    rec_stack: set[str] = set()
+
+    def dfs(node: str, path: list[str]) -> Optional[list[str]]:
+        """Return the cycle path if found, else None."""
+        visited.add(node)
+        rec_stack.add(node)
+        path.append(node)
+        for neighbour in adj.get(node, []):
+            if neighbour not in visited:
+                result = dfs(neighbour, path)
+                if result is not None:
+                    return result
+            elif neighbour in rec_stack:
+                # Found cycle: slice from where the cycle starts to its end.
+                cycle_start = path.index(neighbour)
+                return path[cycle_start:] + [neighbour]
+        path.pop()
+        rec_stack.discard(node)
+        return None
+
+    for var in all_vars:
+        if var.name not in visited:
+            cycle = dfs(var.name, [])
+            if cycle is not None:
+                chain = " → ".join(cycle)
+                raise ValueError(f"Circular variable reference detected: {chain}")
+
+
+def _topological_sort(
+    names: list[str],
+    adj: dict[str, list[str]],
+) -> list[str]:
+    """Return *names* in topological order given the dependency adjacency list *adj*.
+
+    *adj[n]* lists the nodes that *n* depends on (i.e., must come **before** *n*).
+    The returned order has every dependency before the node that needs it.
+
+    Kahn's algorithm — assumes no cycles (caller checked already).
+    Only edges between nodes present in *names* are considered.
+    """
+    name_set = set(names)
+    # Restrict deps to within the name_set.
+    deps_of: dict[str, list[str]] = {
+        n: [d for d in adj.get(n, []) if d in name_set] for n in names
+    }
+
+    # Build reverse edges: dependency → list of nodes that need it.
+    # In Kahn's, in-degree of N = number of its unprocessed dependencies.
+    in_degree: dict[str, int] = {n: len(deps_of[n]) for n in names}
+    # reverse_adj[d] = list of nodes that depend on d
+    reverse_adj: dict[str, list[str]] = {n: [] for n in names}
+    for n, deps in deps_of.items():
+        for d in deps:
+            reverse_adj[d].append(n)
+
+    # Start with nodes whose dependencies are all satisfied (in_degree == 0).
+    queue: deque[str] = deque(n for n in names if in_degree[n] == 0)
+    order: list[str] = []
+
+    while queue:
+        node = queue.popleft()
+        order.append(node)
+        # Mark `node` as resolved; reduce in-degree of every node that needs it.
+        for dependent in reverse_adj[node]:
+            in_degree[dependent] -= 1
+            if in_degree[dependent] == 0:
+                queue.append(dependent)
+
+    # Any remaining nodes with in_degree > 0 indicate a cycle that slipped
+    # through (shouldn't happen if _detect_cycles ran first).
+    if len(order) != len(names):
+        remaining = [n for n in names if n not in set(order)]
+        raise ValueError(
+            f"Unexpected cycle among path variables: {', '.join(remaining)}"
+        )
+    return order
 
 
 class EnvFormat(str, Enum):
@@ -53,14 +171,100 @@ def generate_envfile(build_config: BuildConfig, fmt: EnvFormat, relative_to_path
     - json: [{"name": "GOCACHE", "value": "/path/to/output-dir/deps/gomod"}, ...]
     - env: export GOCACHE=/path/to/output-dir/deps/gomod
            export ...
+
+    Resolution order (two-pass):
+    1. Detect cycles in the ${VAR} reference graph (raise ValueError if found).
+    2. Resolve kind="path" variables in topological order (dependencies first):
+       - Absolute values are kept unchanged.
+       - Empty values raise ValueError.
+       - Relative values are prepended with *relative_to_path*.
+       - Any ${VAR} references within path vars are substituted using already-
+         resolved path variables (allows chained path→path dependencies).
+    3. Build a full substitution mapping from all variables (using resolved
+       path values) plus ``output_dir`` for legacy template compatibility.
+    4. Resolve all remaining (non-path) variables via ${VAR} substitution.
+    5. Raise ValueError for any ${VAR} placeholders still present after
+       substitution (indicates a reference to an undefined variable).
+    6. Write variables to the env file in their original declaration order.
     """
-    # pass all variables as placeholder mappings to env var template value resolution
-    mappings = {var.name: var.value for var in build_config.environment_variables}
+    all_vars = build_config.environment_variables  # list in declaration order
+
+    # Build name→var lookup (declaration order preserved in all_vars).
+    name_to_var: dict[str, EnvironmentVariable] = {v.name: v for v in all_vars}
+
+    # ── Step 0: global cycle detection ────────────────────────────────────────
+    _detect_cycles(list(all_vars), name_to_var)
+
+    # ── Step 1: resolve kind="path" variables, in dependency order ────────────
+    path_vars = [v for v in all_vars if v.kind == "path"]
+    path_names = [v.name for v in path_vars]
+
+    # Adjacency: path var → path vars it depends on.
+    path_adj: dict[str, list[str]] = {
+        v.name: [r for r in _extract_refs(v.value) if r in set(path_names)] for v in path_vars
+    }
+    # Topological order: dependencies come FIRST so we can substitute as we go.
+    topo_order = _topological_sort(path_names, path_adj)
+
+    # Resolved values for path vars (populated incrementally).
+    resolved_path: dict[str, str] = {}
+
+    for name in topo_order:
+        var = name_to_var[name]
+        raw = var.value
+
+        if raw == "":
+            raise ValueError(
+                f"Path variable '{name}' has an empty value; "
+                "cannot prepend output directory to an empty path."
+            )
+
+        # First substitute any references to already-resolved path vars.
+        # This handles chained path→path dependencies, e.g.:
+        #   GOMODBASE (path) = ${GOMODCACHE}/cache
+        # After substitution, the value becomes an absolute path pulled from
+        # the already-resolved GOMODCACHE, so we must NOT prepend output_dir again.
+        substituted = _substitute(raw, resolved_path)
+
+        if Path(substituted).is_absolute():
+            # Value is already absolute (either originally or after substitution).
+            resolved = substituted
+        else:
+            # Still relative — prepend output_dir.
+            resolved = f"{relative_to_path.as_posix()}/{substituted}"
+
+        resolved_path[name] = resolved
+
+    # ── Step 2: build full mappings (resolved path values + non-path values) ──
+    mappings: dict[str, str] = {}
+    for var in all_vars:
+        if var.kind == "path":
+            mappings[var.name] = resolved_path[var.name]
+        else:
+            mappings[var.name] = var.value
+    # Legacy compatibility: callers expect ${output_dir} to work in values.
     mappings["output_dir"] = relative_to_path.as_posix()
-    env_vars = [
-        (env_var.name, env_var.resolve_value(mappings))
-        for env_var in build_config.environment_variables
-    ]
+
+    # ── Step 3: resolve non-path variables ────────────────────────────────────
+    resolved_all: dict[str, str] = dict(resolved_path)  # seed with path results
+    for var in all_vars:
+        if var.kind != "path":
+            resolved_all[var.name] = _substitute(var.value, mappings)
+
+    # ── Step 4: detect undefined references ───────────────────────────────────
+    for var in all_vars:
+        resolved_value = resolved_all[var.name]
+        leftover = _REF_PATTERN.findall(resolved_value)
+        # Filter out 'output_dir' — it is a synthetic key, not a user-defined var.
+        undefined = [ref for ref in leftover if ref != "output_dir" and ref not in name_to_var]
+        if undefined:
+            raise ValueError(
+                f"Variable '{undefined[0]}' referenced by '{var.name}' is not defined."
+            )
+
+    # ── Step 5: emit output in original declaration order ─────────────────────
+    env_vars = [(var.name, resolved_all[var.name]) for var in all_vars]
+
     if fmt == EnvFormat.json:
         content = json.dumps([{"name": name, "value": value} for name, value in env_vars])
     else:

--- a/tests/unit/extras/test_envfile.py
+++ b/tests/unit/extras/test_envfile.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-only
+import re
 from pathlib import Path
 from textwrap import dedent
 
@@ -78,3 +79,206 @@ def test_generate_env_as_env() -> None:
 
     content = generate_envfile(build_config, EnvFormat.env, relative_to_path=Path("/output/dir"))
     assert content == expect_content
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Regression tests for issue #1424 – stale path-variable resolution
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _make_config(env_vars: list[dict]) -> BuildConfig:  # type: ignore[type-arg]
+    """Convenience wrapper so tests stay short."""
+    return BuildConfig(environment_variables=env_vars, project_files=[])
+
+
+# 1 ── path var referenced by a plain var ─────────────────────────────────────
+def test_path_var_referenced_by_plain_var() -> None:
+    """GOMODCACHE (path) must be fully resolved before GOPROXY (plain) uses it."""
+    env_vars = [
+        {"name": "GOMODCACHE", "value": "deps/gomod/pkg/mod", "kind": "path"},
+        {"name": "GOPROXY", "value": "file://${GOMODCACHE}/cache/download", "kind": "literal"},
+    ]
+    build_config = _make_config(env_vars)
+    content = generate_envfile(build_config, EnvFormat.json, relative_to_path=Path("/tmp/output"))
+
+    import json
+
+    result = {item["name"]: item["value"] for item in json.loads(content)}
+    assert result["GOMODCACHE"] == "/tmp/output/deps/gomod/pkg/mod"
+    assert result["GOPROXY"] == "file:///tmp/output/deps/gomod/pkg/mod/cache/download"
+
+
+# 2 ── chained path vars (path → path dependency) ─────────────────────────────
+def test_chained_path_vars() -> None:
+    """GOMODBASE (path) references GOMODCACHE (path); both must get absolute paths."""
+    env_vars = [
+        {"name": "GOMODCACHE", "value": "deps/gomod/pkg/mod", "kind": "path"},
+        {"name": "GOMODBASE", "value": "${GOMODCACHE}/cache", "kind": "path"},
+        {"name": "GOPROXY", "value": "file://${GOMODBASE}/download", "kind": "literal"},
+    ]
+    build_config = _make_config(env_vars)
+    content = generate_envfile(build_config, EnvFormat.json, relative_to_path=Path("/out"))
+
+    import json
+
+    result = {item["name"]: item["value"] for item in json.loads(content)}
+    assert result["GOMODCACHE"] == "/out/deps/gomod/pkg/mod"
+    assert result["GOMODBASE"] == "/out/deps/gomod/pkg/mod/cache"
+    assert result["GOPROXY"] == "file:///out/deps/gomod/pkg/mod/cache/download"
+
+
+# 3 ── circular reference raises ValueError ────────────────────────────────────
+def test_circular_reference_raises() -> None:
+    """A self-referencing or mutually-cyclic variable must raise ValueError."""
+    env_vars = [
+        {"name": "MYVAR", "value": "${MYVAR}/suffix", "kind": "literal"},
+    ]
+    build_config = _make_config(env_vars)
+    with pytest.raises(ValueError, match="Circular variable reference detected"):
+        generate_envfile(build_config, EnvFormat.env, relative_to_path=Path("/out"))
+
+
+def test_mutual_circular_reference_raises() -> None:
+    """Two variables that reference each other must raise ValueError."""
+    env_vars = [
+        {"name": "AVAR", "value": "${BVAR}/x", "kind": "literal"},
+        {"name": "BVAR", "value": "${AVAR}/y", "kind": "literal"},
+    ]
+    build_config = _make_config(env_vars)
+    with pytest.raises(ValueError, match="Circular variable reference detected"):
+        generate_envfile(build_config, EnvFormat.env, relative_to_path=Path("/out"))
+
+
+# 4 ── undefined reference raises ValueError ───────────────────────────────────
+def test_undefined_reference_raises() -> None:
+    """A reference to a variable that does not exist must raise ValueError."""
+    env_vars = [
+        {"name": "GOPROXY", "value": "file://${NONEXISTENT}/cache/download", "kind": "literal"},
+    ]
+    build_config = _make_config(env_vars)
+    with pytest.raises(ValueError, match="NONEXISTENT"):
+        generate_envfile(build_config, EnvFormat.env, relative_to_path=Path("/out"))
+
+
+# 5 ── plain → plain substitution still works ─────────────────────────────────
+def test_plain_to_plain_substitution_unchanged() -> None:
+    """Non-path vars referencing other non-path vars must continue to resolve."""
+    env_vars = [
+        {"name": "BASE_URL", "value": "https://example.com", "kind": "literal"},
+        {"name": "FULL_URL", "value": "${BASE_URL}/api/v1", "kind": "literal"},
+    ]
+    build_config = _make_config(env_vars)
+    content = generate_envfile(build_config, EnvFormat.json, relative_to_path=Path("/out"))
+
+    import json
+
+    result = {item["name"]: item["value"] for item in json.loads(content)}
+    assert result["BASE_URL"] == "https://example.com"
+    assert result["FULL_URL"] == "https://example.com/api/v1"
+
+
+# 6 ── already-absolute path not double-prefixed ───────────────────────────────
+def test_already_absolute_path_not_double_prefixed() -> None:
+    """A kind='path' variable with an absolute value must not get output_dir prepended."""
+    env_vars = [
+        {"name": "SOME_PATH", "value": "/already/absolute/path", "kind": "path"},
+    ]
+    build_config = _make_config(env_vars)
+    content = generate_envfile(build_config, EnvFormat.json, relative_to_path=Path("/out"))
+
+    import json
+
+    result = {item["name"]: item["value"] for item in json.loads(content)}
+    assert result["SOME_PATH"] == "/already/absolute/path"
+
+
+# 7 ── empty path var raises ValueError ───────────────────────────────────────
+def test_empty_path_var_raises() -> None:
+    """A kind='path' variable with an empty value must raise ValueError."""
+    env_vars = [
+        {"name": "EMPTY_PATH", "value": "", "kind": "path"},
+    ]
+    build_config = _make_config(env_vars)
+    with pytest.raises(ValueError, match="EMPTY_PATH"):
+        generate_envfile(build_config, EnvFormat.env, relative_to_path=Path("/out"))
+
+
+# 8 ── multiple references in a single value ───────────────────────────────────
+def test_multiple_references_in_single_value() -> None:
+    """All ${VAR} occurrences within a single value must be resolved."""
+    env_vars = [
+        {"name": "GOMODCACHE", "value": "deps/gomod", "kind": "path"},
+        {"name": "GOPATH", "value": "deps/go", "kind": "path"},
+        # Two distinct refs + a repeated ref in one value:
+        {
+            "name": "COMBO",
+            "value": "${GOMODCACHE}/cache:${GOPATH}/pkg:${GOMODCACHE}/dl",
+            "kind": "literal",
+        },
+    ]
+    build_config = _make_config(env_vars)
+    content = generate_envfile(build_config, EnvFormat.json, relative_to_path=Path("/out"))
+
+    import json
+
+    result = {item["name"]: item["value"] for item in json.loads(content)}
+    assert result["COMBO"] == "/out/deps/gomod/cache:/out/deps/go/pkg:/out/deps/gomod/dl"
+
+
+# 9 ── substring variable names not corrupted ─────────────────────────────────
+def test_substring_variable_names_not_corrupted() -> None:
+    """Substituting ${PATH} must not corrupt ${GOPATH} (substring match guard)."""
+    env_vars = [
+        {"name": "GOPATH", "value": "/go", "kind": "literal"},
+        {"name": "PATH", "value": "/usr/bin", "kind": "literal"},
+        {"name": "RESULT", "value": "${PATH}:${GOPATH}/bin", "kind": "literal"},
+    ]
+    build_config = _make_config(env_vars)
+    content = generate_envfile(build_config, EnvFormat.json, relative_to_path=Path("/out"))
+
+    import json
+
+    result = {item["name"]: item["value"] for item in json.loads(content)}
+    assert result["GOPATH"] == "/go"
+    assert result["PATH"] == "/usr/bin"
+    assert result["RESULT"] == "/usr/bin:/go/bin"
+
+
+# 10 ── unused path var still resolved ────────────────────────────────────────
+def test_unused_path_var_resolved() -> None:
+    """A path var that no other variable references must still get an absolute path."""
+    env_vars = [
+        {"name": "STANDALONE_CACHE", "value": "deps/cache", "kind": "path"},
+    ]
+    build_config = _make_config(env_vars)
+    content = generate_envfile(build_config, EnvFormat.json, relative_to_path=Path("/base"))
+
+    import json
+
+    result = {item["name"]: item["value"] for item in json.loads(content)}
+    assert result["STANDALONE_CACHE"] == "/base/deps/cache"
+
+
+# 11 ── output order matches (alphabetically sorted) declaration order ─────────
+def test_output_declaration_order_preserved() -> None:
+    """Variables must be emitted in the same order they appear in build_config.
+
+    BuildConfig sorts vars alphabetically, so the output order should be
+    alphabetical — verifying that generate_envfile does not reorder them.
+    """
+    env_vars = [
+        {"name": "GOMODCACHE", "value": "deps/gomod/pkg/mod", "kind": "path"},
+        {"name": "GOPROXY", "value": "file://${GOMODCACHE}/cache", "kind": "literal"},
+        {"name": "GOSUMDB", "value": "sum.golang.org", "kind": "literal"},
+    ]
+    build_config = _make_config(env_vars)
+    content = generate_envfile(build_config, EnvFormat.json, relative_to_path=Path("/out"))
+
+    import json
+
+    items = json.loads(content)
+    names = [item["name"] for item in items]
+    # BuildConfig sorts alphabetically: GOMODCACHE < GOPROXY < GOSUMDB
+    assert names == sorted(names)
+    assert names == ["GOMODCACHE", "GOPROXY", "GOSUMDB"]
+


### PR DESCRIPTION
## Bug Fix: generate-env resolves dependent variables using stale pre-resolved values

### Context
In the hermeto codebase, the `generate_env.py` file contains a `generate_envfile` function
that has a variable resolution ordering bug.

### The Bug
The function builds a substitution `mappings` dict from raw variable values BEFORE resolving
`kind="path"` variables. This means when a variable like `GOPROXY` references `${GOMODCACHE}`,
it gets substituted with the raw unresolved value of `GOMODCACHE` (e.g. `deps/gomod/pkg/mod`)
instead of its fully resolved absolute path (e.g. `${output_dir}/deps/gomod/pkg/mod`).

**Current broken flow:**
1. Build `mappings = {var.name: var.value for var in build_config.environment_variables}`
   → At this point `GOMODCACHE = "deps/gomod/pkg/mod"` (relative, not yet path-resolved)
2. Resolve `kind="path"` variables → `GOMODCACHE` becomes `/tmp/output/deps/gomod/pkg/mod`
3. Resolve `GOPROXY` using stale mappings → `GOPROXY = "file://deps/gomod/pkg/mod/cache/download"` 

**Expected result:**
`GOPROXY = "file:///tmp/output/deps/gomod/pkg/mod/cache/download"` 

### Fix Required
In `hermeto/core/generate_env.py`, fix the `generate_envfile` function to build the
substitution `mappings` dict AFTER all `kind="path"` variables have been resolved,
not before. The correct order is:

1. First pass: resolve all `kind="path"` variables (prepend `output_dir`)
2. Then build `mappings` from the now-resolved values
3. Then resolve all remaining variable references using these correct mappings

### Implementation guidance
- Find where `mappings` is constructed (likely a dict comprehension over
  `build_config.environment_variables`)
- Find where `kind="path"` resolution happens (likely a call to `resolve_value` or
  similar that prepends `output_dir` to path-kind vars)
- Reorder so path resolution happens first, then mappings are built from the
  already-resolved values
- Ensure the fix handles the case where `kind="path"` variables reference OTHER
  `kind="path"` variables (topological ordering may be needed if such chains exist;
  if not, a single-pass reorder is sufficient)
- Add or update unit tests in the corresponding test file to cover:
  - A `kind="path"` variable (`GOMODCACHE`) with a relative value
  - A dependent variable (`GOPROXY`) that references the path variable via `${GOMODCACHE}`
  - Assert the dependent variable resolves to the absolute path, not the relative one

### Files to look at
- `hermeto/core/generate_env.py` — primary fix location
- `tests/unit/test_generate_env.py` (or similar) — add regression test
- `hermeto/package_managers/gomod.py` — for understanding how GOMODCACHE/GOPROXY
  env vars are declared (kind="path" vs plain), for test fixtures

### Acceptance criteria
- `GOPROXY` (and any variable referencing a `kind="path"` variable) resolves to an
  absolute path including the `output_dir` prefix
- No existing tests are broken
- New test explicitly covers the stale-mapping regression case

fixes #1424 