### PR TITLE
Fix(cargo): fixed vcs metdata in sbom for workspace members

### DIFF
--- a/hack/mock-unittest-data/gomod.py
+++ b/hack/mock-unittest-data/gomod.py
@@ -11,7 +11,6 @@ from tempfile import TemporaryDirectory
 
 from yarn import print_banner
 
-
 PANDEMO_DIR = "gomod-pandemonium"
 
 
@@ -38,7 +37,7 @@ def write_to_file(where, what, mocked_data_dir, **subprocess_kwargs):
 
 def replace_paths_with_placeholder(pandemo_dir, gomodcache, mocked_data_dir):
     subdirs_of_interest = ("non-vendored", "vendored", "workspaces")
-    fs_objects_to_check = [(mocked_data_dir/x).glob("**/*") for x in subdirs_of_interest]
+    fs_objects_to_check = [(mocked_data_dir / x).glob("**/*") for x in subdirs_of_interest]
     files_to_update = [o for o in chain.from_iterable(fs_objects_to_check) if o.is_file()]
     for fpath in files_to_update:
         data = fpath.read_text()
@@ -49,24 +48,26 @@ def replace_paths_with_placeholder(pandemo_dir, gomodcache, mocked_data_dir):
 
 def update_workspaces(redirect_to_file, pandemo_dir, mocked_data_dir):
     with open(f"{mocked_data_dir}/workspaces/go_work.json") as f:
-        d_paths = [v['DiskPath'] for v in json.loads(f.read())['Use']]
-        paths = [Path(f"{pandemo_dir}")/p.removeprefix("./") for p in d_paths if p != '.']
+        d_paths = [v["DiskPath"] for v in json.loads(f.read())["Use"]]
+        paths = [Path(f"{pandemo_dir}") / p.removeprefix("./") for p in d_paths if p != "."]
 
     for p in paths:
         print(f"preparing per-workspace directory {p}")
         mkdir_with_parents(f"{mocked_data_dir}/workspaces/{p.name}")
-        if (gosum:=Path(p)/"go.sum").exists():
+        if (gosum := Path(p) / "go.sum").exists():
             print(f"generating {mocked_data_dir}/workspaces/{p.name}/go.sum")
             copyfile(gosum, Path(f"{mocked_data_dir}/workspaces/{p.name}/go.sum"))
         redirect_to_file(
             where=f"workspaces/{p.name}/go_list_deps_threedot.json",
             what="go list -deps -json=ImportPath,Module,Standard,Deps ./...",
-            cwd=p
+            cwd=p,
         )
 
 
 def warn_about_potential_manual_intervention(mocked_data_dir):
-    non_vendored_diff = run(f"git diff -- {mocked_data_dir}/non-vendored", capture_output=True).stdout
+    non_vendored_diff = run(
+        f"git diff -- {mocked_data_dir}/non-vendored", capture_output=True
+    ).stdout
     vendored_diff = run(f"git diff -- {mocked_data_dir}/vendored", capture_output=True).stdout
     if vendored_diff or non_vendored_diff:
         nonvendor = f"{mocked_data_dir}/expected-results/resolve_gomod.json"
@@ -88,15 +89,12 @@ def main() -> None:
         pandemo_dir = tmpdir / PANDEMO_DIR
         gomodcache = tmpdir / "hermeto-mock-gomodcache"
 
-        subprocess_kwargs = {
-            "env": environ | {"GOMODCACHE": str(gomodcache)},
-            "cwd": pandemo_dir
-        }
+        subprocess_kwargs = {"env": environ | {"GOMODCACHE": str(gomodcache)}, "cwd": pandemo_dir}
 
         run(f"git clone https://github.com/cachito-testing/gomod-pandemonium {pandemo_dir}")
         run("git switch go-1.22-workspaces", **subprocess_kwargs)
         print(f"generating {mocked_data_dir}/workspaces/go.sum")
-        copyfile(pandemo_dir/"go.sum", Path(f"{mocked_data_dir}/workspaces/go.sum"))
+        copyfile(pandemo_dir / "go.sum", Path(f"{mocked_data_dir}/workspaces/go.sum"))
         redirect_to_file = partial(
             write_to_file, mocked_data_dir=mocked_data_dir, **subprocess_kwargs
         )
@@ -104,18 +102,18 @@ def main() -> None:
         redirect_to_file(where="workspaces/go_mod_download.json", what="go mod download -json")
         redirect_to_file(
             where="workspaces/go_list_deps_all.json",
-            what="go list -deps -json=ImportPath,Module,Standard,Deps all"
+            what="go list -deps -json=ImportPath,Module,Standard,Deps all",
         )
         redirect_to_file(
             where="workspaces/go_list_deps_threedot.json",
-            what="go list -deps -json=ImportPath,Module,Standard,Deps ./..."
+            what="go list -deps -json=ImportPath,Module,Standard,Deps ./...",
         )
         redirect_to_file(where="workspaces/go_work.json", what="go work edit -json")
 
         update_workspaces(
             redirect_to_file=redirect_to_file,
             pandemo_dir=pandemo_dir,
-            mocked_data_dir=mocked_data_dir
+            mocked_data_dir=mocked_data_dir,
         )
         run("git restore .", **subprocess_kwargs)
         run("git switch main", **subprocess_kwargs)
@@ -123,31 +121,30 @@ def main() -> None:
         redirect_to_file(where="non-vendored/go_mod_download.json", what="go mod download -json")
         redirect_to_file(
             where="non-vendored/go_list_deps_all.json",
-            what="go list -deps -json=ImportPath,Module,Standard,Deps all"
+            what="go list -deps -json=ImportPath,Module,Standard,Deps all",
         )
         redirect_to_file(
             where="non-vendored/go_list_deps_threedot.json",
-            what="go list -deps -json=ImportPath,Module,Standard,Deps ./..."
+            what="go list -deps -json=ImportPath,Module,Standard,Deps ./...",
         )
         print(f"generating {mocked_data_dir}/non-vendored/go.sum")
-        copyfile(pandemo_dir/"go.sum", Path(f"{mocked_data_dir}/non-vendored/go.sum"))
+        copyfile(pandemo_dir / "go.sum", Path(f"{mocked_data_dir}/non-vendored/go.sum"))
         print(f"generating {mocked_data_dir}/vendored/modules.txt")
         run("go mod vendor", **subprocess_kwargs)
         run("go mod tidy", **subprocess_kwargs)
         copyfile(
-            pandemo_dir/"vendor/modules.txt",
-            Path(f"{mocked_data_dir}/vendored/modules.txt")
+            pandemo_dir / "vendor/modules.txt", Path(f"{mocked_data_dir}/vendored/modules.txt")
         )
         redirect_to_file(
             where="vendored/go_list_deps_all.json",
-            what="go list -deps -json=ImportPath,Module,Standard,Deps all"
+            what="go list -deps -json=ImportPath,Module,Standard,Deps all",
         )
         redirect_to_file(
             where="vendored/go_list_deps_threedot.json",
-            what="go list -deps -json=ImportPath,Module,Standard,Deps ./..."
+            what="go list -deps -json=ImportPath,Module,Standard,Deps ./...",
         )
         print(f"generating {mocked_data_dir}/vendored/go.sum")
-        copyfile(pandemo_dir/"go.sum", Path(f"{mocked_data_dir}/vendored/go.sum"))
+        copyfile(pandemo_dir / "go.sum", Path(f"{mocked_data_dir}/vendored/go.sum"))
         replace_paths_with_placeholder(pandemo_dir, gomodcache, mocked_data_dir)
         warn_about_potential_manual_intervention(mocked_data_dir)
 

--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -451,6 +451,17 @@ def _generate_sbom_components(package_dir: RootedPath) -> list[Component]:
                     subpath=local_packages.get(pkg_name),
                 ).to_component()
             )
+        elif pkg.get("source") is None:
+            # Workspace members have no `source` field in Cargo.lock.
+            # Assumes all sourceless packages not already matched are workspace members.
+            components.append(
+                LocalCargoPackage(
+                    name=pkg_name,
+                    version=pkg_version,
+                    vcs_url=vcs_url,
+                    subpath=pkg_name,
+                ).to_component()
+            )
         else:
             components.append(
                 CargoPackage(

--- a/tests/unit/package_managers/cargo/test_main.py
+++ b/tests/unit/package_managers/cargo/test_main.py
@@ -1,22 +1,36 @@
 # SPDX-License-Identifier: GPL-3.0-only
 import textwrap
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 import tomlkit
+from packageurl import PackageURL
 
 from hermeto.core.errors import UnexpectedFormat
 from hermeto.core.package_managers.cargo.main import (
     CargoPackage,
+    _generate_sbom_components,
     _resolve_main_package,
     _sanitize_cargo_config,
     _use_vendored_sources,
 )
 from hermeto.core.rooted_path import RootedPath
+from hermeto.core.scm import RepoID
 
 
 def write_cargo_toml(rooted_path: RootedPath, content: str) -> None:
     (rooted_path.path / "Cargo.toml").write_text(content)
+
+
+def write_cargo_lock(rooted_path: RootedPath, packages: list[dict]) -> None:
+    lines = ["version = 4", ""]
+    for pkg in packages:
+        lines.append("[[package]]")
+        for key, value in pkg.items():
+            lines.append(f'{key} = "{value}"')
+        lines.append("")
+    (rooted_path.path / "Cargo.lock").write_text("\n".join(lines))
 
 
 def test_standard_package_with_name_and_version(rooted_tmp_path: RootedPath) -> None:
@@ -284,3 +298,88 @@ def test_use_vendored_sources(
 
     assert result_toml["source"]["crates-io"]["replace-with"] == "vendored-sources"
     assert result_toml["source"]["vendored-sources"]["directory"] == "${output_dir}/deps/cargo"
+
+
+MOCK_REPO_ID = RepoID("ssh://git@github.com/test/repo.git", "abc123")
+
+
+def test_workspace_members_get_local_package_treatment(
+    rooted_tmp_path: RootedPath,
+) -> None:
+    write_cargo_toml(
+        rooted_tmp_path,
+        """
+        [package]
+        name = "bug"
+        version = "0.1.0"
+        [workspace]
+        members = ["","a", "b"]
+    """,
+    )
+    write_cargo_lock(
+        rooted_tmp_path,
+        [
+            {"name": "a", "version": "0.0.0"},
+            {"name": "b", "version": "0.0.0"},
+            {"name": "bug", "version": "0.1.0"},
+            {
+                "name": "mock",
+                "version": "0.0.1",
+                "source": "registry+https://github.com/rust-lang/crates.io-index",
+                "checksum": "abc123",
+            },
+        ],
+    )
+
+    with patch(
+        "hermeto.core.package_managers.cargo.main.get_repo_id",
+        return_value=MOCK_REPO_ID,
+    ):
+        components = _generate_sbom_components(rooted_tmp_path)
+
+    by_name = {c.name: PackageURL.from_string(c.purl) for c in components}
+
+    assert "vcs_url" in by_name["a"].qualifiers
+    assert by_name["a"].subpath == "a"
+
+    assert "vcs_url" in by_name["b"].qualifiers
+    assert by_name["b"].subpath == "b"
+
+    # registry package must have no vcs_url and no subpath
+    assert "vcs_url" not in by_name["mock"].qualifiers
+    assert by_name["mock"].subpath is None
+
+
+def test_registry_packages_unaffected_by_workspace_fix(
+    rooted_tmp_path: RootedPath,
+) -> None:
+    write_cargo_toml(
+        rooted_tmp_path,
+        """
+        [package]
+        name = "bug"
+        version = "0.1.0"
+    """,
+    )
+    write_cargo_lock(
+        rooted_tmp_path,
+        [
+            {"name": "bug", "version": "0.1.0"},
+            {
+                "name": "mock",
+                "version": "0.0.1",
+                "source": "registry+https://github.com/rust-lang/crates.io-index",
+                "checksum": "abc123",
+            },
+        ],
+    )
+    with patch(
+        "hermeto.core.package_managers.cargo.main.get_repo_id",
+        return_value=MOCK_REPO_ID,
+    ):
+        components = _generate_sbom_components(rooted_tmp_path)
+
+    mock = next(c for c in components if c.name == "mock")
+    purl = PackageURL.from_string(mock.purl)
+    assert "vcs_url" not in purl.qualifiers
+    assert purl.subpath is None


### PR DESCRIPTION
Resolves: #1455
## Description
_generate_sbom_components only considered root package, explicit path dependencies, and registry packages when generating SBOM components. Workspace members not declared as path dependencies had no source field in Cargo.lock but were still emitted as external CargoPackage components without VCS metadata, resulting in incorrect SBOM provenance.
### Affected code
```python
# Workspace members fall through to else branch, losing VCS metadata
else:
    components.append(
        CargoPackage(
            name=pkg_name,
            version=pkg_version,
            source=pkg.get("source"),
            checksum=pkg.get("checksum"),
        ).to_component()
    )
```
## Fix
```python
# Before — workspace members misclassified as external
else:
    components.append(CargoPackage(...).to_component())

# After — sourceless packages treated as local workspace members
elif pkg.get("source") is None:
    components.append(
        LocalCargoPackage(name=pkg_name, version=pkg_version, vcs_url=vcs_url, subpath=pkg_name)
        .to_component()
    )
else:
    components.append(CargoPackage(...).to_component())
```

## Tests
Added two unit tests for the changed behaviour.

## Assumptions
- The workspace is defined at the root, with `Cargo.lock` also at the root (already assumed).
- Workspace member directory names match their package names (`subpath=pkg_name`). Members where
  the directory name differs from the package name will produce incorrect subpaths in the SBOM.
- All packages without a source field in Cargo.lock are local i.e. workspace or path deps. it might change in future lock versions.