### PR TITLE
pip: fix missing separators in error messages

### DIFF
--- a/hermeto/core/package_managers/pip/requirements.py
+++ b/hermeto/core/package_managers/pip/requirements.py
@@ -635,7 +635,7 @@ def validate_requirements(requirements: list[PipRequirement]) -> None:
                 raise InvalidChecksum(
                     checksum=req.hashes,
                     solution=(
-                        f"URL requirement must specify exactly one hash, but specifies {n_hashes}"
+                        f"URL requirement must specify exactly one hash, but specifies {n_hashes}.\n"
                         "Please specify the expected hashes for all plain URLs using "
                         "--hash options (one --hash for each)"
                     ),
@@ -670,7 +670,7 @@ def validate_requirements_hashes(requirements: list[PipRequirement], require_has
             raise MissingChecksum(
                 None,
                 solution=(
-                    f"Hash is required, dependency does not specify any: {req.download_line}"
+                    f"Hash is required, dependency does not specify any: {req.download_line}.\n"
                     "Please specify the expected hashes for all dependencies"
                 ),
             )


### PR DESCRIPTION
Two `solution` strings in `validate_requirements` and `validate_requirements_hashes` were missing a `.\n` separator between sentences. 
Python implicit string concatenation joined them without any separator, producing output like:
`...specifies 0Please specify...`

Added `.\n` to match the existing pattern used in the same file (line 607).

Fixes #1467 

