### PR TITLE
bug(cargo): Handle missing [source] section in cargo vendor config for workspace-only projects

### DIFF
--- a/hermeto/core/package_managers/cargo/main.py
+++ b/hermeto/core/package_managers/cargo/main.py
@@ -141,10 +141,11 @@ def fetch_cargo_source(request: Request) -> RequestOutput:
         vendor_result = _fetch_dependencies(package_dir, request)
         # cargo allows to specify configuration per-package
         # https://doc.rust-lang.org/cargo/reference/config.html#hierarchical-structure
-        config_template = _swap_sources_directory_for_subsitution_slot(
-            vendor_result.config_template
-        )
-        project_files.append(_use_vendored_sources(package_dir, config_template))
+        if vendor_result.config_template:
+            config_template = _swap_sources_directory_for_subsitution_slot(
+                vendor_result.config_template
+            )
+            project_files.append(_use_vendored_sources(package_dir, config_template))
         package_components = _generate_sbom_components(package_dir)
 
         if vendor_result.lockfile_was_generated:


### PR DESCRIPTION
## Description

`_swap_sources_directory_for_subsitution_slot` unconditionally accessed `toml_template["source"]`, assuming `cargo vendor` always produces a `[source]` section in its config output. For projects with only workspace members and no registry dependencies, `cargo vendor` produces no `[source]` section, causing a `KeyError` crash.

## Affected code

```python
def _swap_sources_directory_for_subsitution_slot(template: str) -> dict:
    toml_template = tomlkit.parse(template).value
    # crashes when no registry deps — no [source] section produced by cargo vendor
    toml_template["source"]["vendored-sources"]["directory"] = "${output_dir}/deps/cargo"
    return toml_template
```

## Fix

```python
# Before — unconditional access
toml_template["source"]["vendored-sources"]["directory"] = "${output_dir}/deps/cargo"

# After — guard against missing [source] section
if "source" in toml_template:
    toml_template["source"]["vendored-sources"]["directory"] = "${output_dir}/deps/cargo"
```