### PR TITLE
feat(yarn): add workspace focus support for Yarn v4

### DIFF
--- a/docs/yarn.md
+++ b/docs/yarn.md
@@ -7,6 +7,7 @@
   - [Dealing with Yarn Zero-Installs](#dealing-with-yarn-zero-installs)
   - [Dealing with plugins](#dealing-with-plugins)
 - [Specifying packages to process](#specifying-packages-to-process)
+  - [Workspace focus](#workspace-focus)
   - [Controlling Yarn's behavior](#controlling-yarns-behavior)
   - [Downloading dependencies](#downloading-dependencies)
   - [Known pitfalls](#known-pitfalls)
@@ -114,6 +115,43 @@ or more simply by just invoking `hermeto fetch-deps yarn`.
 
 For complete example of how to pre-fetch dependencies, see
 [Example: Pre-fetch dependencies](#pre-fetch-dependencies).
+
+### Workspace focus
+
+For monorepo projects using [Yarn workspaces][], you can instruct Hermeto to
+fetch only the dependencies needed for specific workspaces rather than the
+entire project. This is done by specifying the `workspaces` field in the JSON
+input:
+
+```js
+{
+  "type": "yarn",
+  "path": ".",
+  // Only fetch dependencies for the "my-app" workspace
+  "workspaces": ["my-app"]
+}
+```
+
+Hermeto will fetch only the dependencies needed for the specified workspaces
+and their transitive workspace dependencies. Note that `devDependencies` are
+also included and will appear in the SBOM.
+
+You can specify multiple workspace names:
+
+```shell
+hermeto fetch-deps \
+  --source ./my-monorepo \
+  --output ./hermeto-output \
+  '{"type": "yarn", "workspaces": ["app-frontend", "lib-shared"]}'
+```
+
+> **NOTE**
+>
+> This feature requires **Yarn v4**. The workspace names must match the `name`
+> field in each workspace's `package.json`.
+
+When `workspaces` is not specified, Hermeto fetches dependencies for all
+workspaces.
 
 ### Controlling Yarn's behavior
 
@@ -269,5 +307,6 @@ podman build . \
 [project]: https://github.com/hermetoproject/doc-examples/tree/yarn-basic
 [yarn install]: https://yarnpkg.com/getting-started/usage/#installing-all-the-dependencies
 [Yarn protocols]: https://yarnpkg.com/protocols
+[Yarn workspaces]: https://yarnpkg.com/features/workspaces
 [yarn]: https://yarnpkg.com
 [ZIP archives]: https://yarnpkg.com/features/pnp/#packages-are-stored-inside-zip-archives-how-can-i-access-their-files

--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -396,6 +396,14 @@ class YarnPackageInput(_PackageInputBase):
     """Accepted input for a yarn package."""
 
     type: Literal["yarn"]
+    workspaces: list[str] | None = None
+
+    @pydantic.field_validator("workspaces")
+    @classmethod
+    def _workspaces_not_empty(cls, workspaces: list[str] | None) -> list[str] | None:
+        if workspaces is not None and len(workspaces) == 0:
+            raise ValueError("'workspaces' must not be an empty list, omit the field instead")
+        return workspaces
 
 
 PackageInput = Annotated[

--- a/hermeto/core/package_managers/yarn/main.py
+++ b/hermeto/core/package_managers/yarn/main.py
@@ -9,14 +9,20 @@ from hermeto.core.errors import LockfileNotFound, PackageManagerError, PackageRe
 from hermeto.core.models.input import Request
 from hermeto.core.models.output import Component, EnvironmentVariable, RequestOutput
 from hermeto.core.models.sbom import create_backend_annotation
+from hermeto.core.package_managers.yarn.locators import WorkspaceLocator
 from hermeto.core.package_managers.yarn.project import (
+    PackageJson,
     Plugin,
     Project,
     YarnRc,
     get_semver_from_package_manager,
     get_semver_from_yarn_path,
 )
-from hermeto.core.package_managers.yarn.resolver import create_components, resolve_packages
+from hermeto.core.package_managers.yarn.resolver import (
+    Package,
+    create_components,
+    resolve_packages,
+)
 from hermeto.core.package_managers.yarn.utils import (
     VersionsRange,
     extract_yarn_version_from_env,
@@ -35,7 +41,7 @@ def fetch_yarn_source(request: Request) -> RequestOutput:
         path = request.source_dir.join_within_root(package.path)
         project = Project.from_source_dir(path)
 
-        components.extend(_resolve_yarn_project(project, request.output_dir))
+        components.extend(_resolve_yarn_project(project, request.output_dir, package.workspaces))
 
     annotations = []
     if backend_annotation := create_backend_annotation(components, "yarn"):
@@ -101,21 +107,38 @@ def _verify_repository(project: Project) -> None:
     _check_lockfile(project)
 
 
-def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Component]:
+def _resolve_yarn_project(
+    project: Project,
+    output_dir: RootedPath,
+    workspaces: list[str] | None = None,
+) -> list[Component]:
     """Process a request for a single yarn source directory.
 
     :param project: the directory to be processed.
     :param output_dir: the directory where the prefetched dependencies will be placed.
+    :param workspaces: optional list of workspace names to focus on (Yarn v4 only).
     :raises PackageManagerError: if fetching dependencies fails
     """
     log.info(f"Fetching the yarn dependencies at the subpath {project.source_dir}")
 
     version = _configure_yarn_version(project)
+
+    if workspaces and version < semver.Version.parse("4.0.0"):
+        raise PackageRejected(
+            f"Workspace focus requires Yarn v4 or later, but this project uses Yarn {version}",
+            solution="Either upgrade to Yarn v4 or remove the 'workspaces' field from the input.",
+        )
+
     _verify_repository(project)
 
     _set_yarnrc_configuration(project, output_dir, version)
-    packages = resolve_packages(project.source_dir)
-    _fetch_dependencies(project.source_dir)
+
+    packages = resolve_packages(project.source_dir, workspaces)
+
+    if workspaces:
+        _strip_workspace_scripts(project.source_dir, packages)
+
+    _fetch_dependencies(project.source_dir, workspaces)
 
     return create_components(packages, project, output_dir)
 
@@ -241,14 +264,44 @@ def _set_yarnrc_configuration(
     yarn_rc.write()
 
 
-def _fetch_dependencies(source_dir: RootedPath) -> None:
-    """Fetch dependencies using 'yarn install'.
+def _strip_workspace_scripts(source_dir: RootedPath, packages: list[Package]) -> None:
+    """Remove scripts from workspace package.json files.
+
+    yarn workspaces focus does not support --mode skip-build, and enableScripts: false
+    does not apply to workspace scripts (https://github.com/yarnpkg/berry/pull/4781).
+    Stripping the scripts field prevents lifecycle scripts from executing during focus.
+
+    :param source_dir: the project source directory.
+    :param packages: packages returned by ``resolve_packages``, used to find workspace paths.
+    """
+    for pkg in packages:
+        locator = pkg.parsed_locator
+        if not isinstance(locator, WorkspaceLocator):
+            continue
+        pkg_json_path = source_dir.join_within_root(locator.relpath, "package.json")
+        if not pkg_json_path.path.exists():
+            continue
+        pkg_json = PackageJson.from_file(pkg_json_path)
+        if "scripts" in pkg_json:
+            del pkg_json["scripts"]
+            pkg_json.write()
+
+
+def _fetch_dependencies(source_dir: RootedPath, workspaces: list[str] | None = None) -> None:
+    """Fetch dependencies using 'yarn install' or 'yarn workspaces focus'.
+
+    When workspaces are specified, only the dependencies of those workspaces (and their
+    transitive workspace dependencies) are installed via 'yarn workspaces focus'.
 
     :param source_dir: the directory in which the yarn command will be called.
-    :raises PackageManagerError: if the 'yarn install' command fails.
+    :param workspaces: optional list of workspace names to focus on (Yarn v4 only).
+    :raises PackageManagerError: if the yarn command fails.
     """
     try:
-        run_yarn_cmd(["install", "--mode", "skip-build"], source_dir)
+        if workspaces:
+            run_yarn_cmd(["workspaces", "focus", *workspaces], source_dir)
+        else:
+            run_yarn_cmd(["install", "--mode", "skip-build"], source_dir)
     except PackageManagerError as e:
         # TODO: this follows a precedent set in resolver. Either a more robust way for
         # dealing with this must be found or a comment provided that such methods do not exist.

--- a/hermeto/core/package_managers/yarn/resolver.py
+++ b/hermeto/core/package_managers/yarn/resolver.py
@@ -141,36 +141,25 @@ class _YarnInfoEntry(pydantic.BaseModel):
     children: _YarnInfoChildren
 
 
-def resolve_packages(source_dir: RootedPath) -> list[Package]:
+def resolve_packages(source_dir: RootedPath, workspaces: list[str] | None = None) -> list[Package]:
     """Fetch and parse package data from the 'yarn info' output.
+
+    When *workspaces* is provided, runs ``yarn workspace $name info`` for each
+    workspace and deduplicates the results. Otherwise, runs ``yarn info --all``
+    to report the full dependency graph.
 
     This function also performs validation to ensure that the current yarn project can be
     processed.
 
+    :param source_dir: the directory containing the yarn project.
+    :param workspaces: optional list of workspace names to scope the query to.
     :raises UnsupportedFeature: if an unsupported locator type is found in 'yarn info' output
     :raises PackageManagerError: if the 'yarn info' command fails.
     """
-    try:
-        # --all: report dependencies of all workspaces, not just the active workspace
-        # --recursive: report transitive dependencies, not just direct ones
-        # --cache: include info about the cache entry for each dependency
-        result = run_yarn_cmd(["info", "--all", "--recursive", "--cache", "--json"], source_dir)
-    except PackageManagerError as e:
-        if e.stderr and "isn't supported by any available resolver" in e.stderr:
-            raise UnsupportedFeature(
-                "Found an unsupported dependency, more details in the logs.",
-                solution=dedent(
-                    f"""
-                    Please note that {APP_NAME} disables all Yarn plugins, which might be needed for
-                    the correct processing of a dependency. This is done to avoid arbitrary code
-                    execution, which would affect the accuracy of the SBOM.
-                    """
-                ),
-            )
-        raise
-
-    # the result is not a valid json list, but a sequence of json objects separated by line breaks
-    packages = [Package.from_info_string(info) for info in result.splitlines()]
+    if workspaces:
+        packages = _resolve_workspace_packages(source_dir, workspaces)
+    else:
+        packages = _resolve_all_packages(source_dir)
 
     n_unsupported = 0
     for package in packages:
@@ -186,6 +175,54 @@ def resolve_packages(source_dir: RootedPath) -> list[Package]:
         )
 
     return packages
+
+
+def _get_packages_from_yarn_info(args: list[str], source_dir: RootedPath) -> list[Package]:
+    """Run a ``yarn info`` variant and return the parsed packages."""
+    try:
+        result = run_yarn_cmd(args, source_dir)
+    except PackageManagerError as e:
+        if e.stderr and "isn't supported by any available resolver" in e.stderr:
+            raise UnsupportedFeature(
+                "Found an unsupported dependency, more details in the logs.",
+                solution=dedent(
+                    f"""
+                    Please note that {APP_NAME} disables all Yarn plugins, which might be needed for
+                    the correct processing of a dependency. This is done to avoid arbitrary code
+                    execution, which would affect the accuracy of the SBOM.
+                    """
+                ),
+            )
+        raise
+
+    # the result is not a valid json list, but a sequence of json objects separated by line breaks
+    return [Package.from_info_string(info) for info in result.splitlines()]
+
+
+def _resolve_all_packages(source_dir: RootedPath) -> list[Package]:
+    # --all: report dependencies of all workspaces, not just the active workspace
+    # --recursive: report transitive dependencies, not just direct ones
+    # --cache: include info about the cache entry for each dependency
+    return _get_packages_from_yarn_info(
+        ["info", "--all", "--recursive", "--cache", "--json"], source_dir
+    )
+
+
+def _resolve_workspace_packages(source_dir: RootedPath, workspaces: list[str]) -> list[Package]:
+    seen: dict[str, Package] = {}
+
+    for ws_name in workspaces:
+        # Run info scoped to a single workspace (without --all), so yarn only reports
+        # the transitive dependencies of that workspace rather than the full project.
+        packages = _get_packages_from_yarn_info(
+            ["workspace", ws_name, "info", "--recursive", "--cache", "--json"], source_dir
+        )
+        # Deduplicate across workspaces: overlapping deps appear only once
+        for pkg in packages:
+            if pkg.raw_locator not in seen:
+                seen[pkg.raw_locator] = pkg
+
+    return list(seen.values())
 
 
 def create_components(

--- a/tests/integration/test_data/yarn_e2e_workspace_focus/.build-config.yaml
+++ b/tests/integration/test_data/yarn_e2e_workspace_focus/.build-config.yaml
@@ -1,0 +1,10 @@
+environment_variables:
+- name: YARN_ENABLE_GLOBAL_CACHE
+  value: 'false'
+- name: YARN_ENABLE_IMMUTABLE_CACHE
+  value: 'false'
+- name: YARN_ENABLE_MIRROR
+  value: 'true'
+- name: YARN_GLOBAL_FOLDER
+  value: ${output_dir}/deps/yarn
+project_files: []

--- a/tests/integration/test_data/yarn_e2e_workspace_focus/bom.json
+++ b/tests/integration/test_data/yarn_e2e_workspace_focus/bom.json
@@ -1,0 +1,126 @@
+{
+  "annotations": [
+    {
+      "annotator": {
+        "organization": {
+          "name": "red hat"
+        }
+      },
+      "subjects": [
+        "pkg:npm/app@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40fac7c04c75beb888983e6e669f381a75eb96b2ed#packages/app",
+        "pkg:npm/is-number@6.0.0",
+        "pkg:npm/is-number@7.0.0",
+        "pkg:npm/is-odd@3.0.1",
+        "pkg:npm/ms@2.1.3",
+        "pkg:npm/shared@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40fac7c04c75beb888983e6e669f381a75eb96b2ed#packages/shared",
+        "pkg:npm/tooling@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40fac7c04c75beb888983e6e669f381a75eb96b2ed#packages/tooling"
+      ],
+      "text": "hermeto:backend:yarn",
+      "timestamp": "2025-01-01T00:00:00Z"
+    }
+  ],
+  "bomFormat": "CycloneDX",
+  "components": [
+    {
+      "bom-ref": "pkg:npm/app@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40fac7c04c75beb888983e6e669f381a75eb96b2ed#packages/app",
+      "name": "app",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:npm/app@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40fac7c04c75beb888983e6e669f381a75eb96b2ed#packages/app",
+      "type": "library",
+      "version": "1.0.0"
+    },
+    {
+      "bom-ref": "pkg:npm/is-number@6.0.0",
+      "name": "is-number",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:npm/is-number@6.0.0",
+      "type": "library",
+      "version": "6.0.0"
+    },
+    {
+      "bom-ref": "pkg:npm/is-number@7.0.0",
+      "name": "is-number",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:npm/is-number@7.0.0",
+      "type": "library",
+      "version": "7.0.0"
+    },
+    {
+      "bom-ref": "pkg:npm/is-odd@3.0.1",
+      "name": "is-odd",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:npm/is-odd@3.0.1",
+      "type": "library",
+      "version": "3.0.1"
+    },
+    {
+      "bom-ref": "pkg:npm/ms@2.1.3",
+      "name": "ms",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:npm/ms@2.1.3",
+      "type": "library",
+      "version": "2.1.3"
+    },
+    {
+      "bom-ref": "pkg:npm/shared@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40fac7c04c75beb888983e6e669f381a75eb96b2ed#packages/shared",
+      "name": "shared",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:npm/shared@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40fac7c04c75beb888983e6e669f381a75eb96b2ed#packages/shared",
+      "type": "library",
+      "version": "1.0.0"
+    },
+    {
+      "bom-ref": "pkg:npm/tooling@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40fac7c04c75beb888983e6e669f381a75eb96b2ed#packages/tooling",
+      "name": "tooling",
+      "properties": [
+        {
+          "name": "hermeto:found_by",
+          "value": "hermeto"
+        }
+      ],
+      "purl": "pkg:npm/tooling@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40fac7c04c75beb888983e6e669f381a75eb96b2ed#packages/tooling",
+      "type": "library",
+      "version": "1.0.0"
+    }
+  ],
+  "metadata": {
+    "tools": [
+      {
+        "name": "hermeto",
+        "vendor": "red hat"
+      }
+    ]
+  },
+  "specVersion": "1.6",
+  "version": 1
+}

--- a/tests/integration/test_data/yarn_e2e_workspace_focus/container/Containerfile
+++ b/tests/integration/test_data/yarn_e2e_workspace_focus/container/Containerfile
@@ -1,0 +1,17 @@
+FROM mirror.gcr.io/node:24-alpine
+
+# Test disabled network access
+RUN if getent hosts www.google.com; then echo "Has network access!"; exit 1; fi
+
+WORKDIR /src
+
+# The test fixture has lifecycle scripts that exit 1 (to verify Hermeto
+# strips them during prefetch). Remove them here so the build can proceed.
+RUN find packages -name package.json -exec \
+    node -e "const f=process.argv[1]; const p=JSON.parse(require('fs').readFileSync(f)); delete p.scripts; require('fs').writeFileSync(f, JSON.stringify(p, null, 2)+'\n')" {} \;
+
+RUN . /tmp/hermeto.env && yarn workspaces focus app
+
+# During the build, the source code is only mounted, not copied
+RUN cp -r /src /app
+WORKDIR /app

--- a/tests/integration/test_data/yarn_e2e_workspace_focus/fetch_deps_sha256sums.json
+++ b/tests/integration/test_data/yarn_e2e_workspace_focus/fetch_deps_sha256sums.json
@@ -1,0 +1,6 @@
+{
+  "yarn/cache/is-number-npm-6.0.0-30881e83e6-10c0.zip": "sha256:112ad988b5d69432e40d88c2e56c89e464564333781c3dc6087c8d65bf0d9ca3",
+  "yarn/cache/is-number-npm-7.0.0-060086935c-10c0.zip": "sha256:faf5a4eb4d522e2a5f62a310639554537c4f9345ede8fbb252ecbc7160b6dd96",
+  "yarn/cache/is-odd-npm-3.0.1-93c3c3f41b-10c0.zip": "sha256:f5505e35a9a8e2e2096cb0f4e50f42f3c5c50ebba047874d5e558e149521494a",
+  "yarn/cache/ms-npm-2.1.3-81ff3cfac1-10c0.zip": "sha256:af8904623f7ebad7274bcacd8bde2bd7aca0a3b2a1daa5ca0a678798061995b2"
+}

--- a/tests/integration/test_yarn.py
+++ b/tests/integration/test_yarn.py
@@ -132,6 +132,15 @@ def test_yarn_packages(
             "Hello from first package!",
             id="yarn_e2e_multiple_packages",
         ),
+        pytest.param(
+            utils.TestParameters(
+                branch="yarn/v4-workspace-focus",
+                packages=({"path": ".", "type": "yarn", "workspaces": ["app"]},),
+            ),
+            ["node", "packages/app/index.js"],
+            "workspace focus works!",
+            id="yarn_e2e_workspace_focus",
+        ),
     ],
 )
 def test_e2e_yarn(

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -308,6 +308,11 @@ class TestPackageInput:
                 r"Extra inputs are not permitted",
                 id="pip_binary_unknown_field",
             ),
+            pytest.param(
+                {"type": "yarn", "workspaces": []},
+                r"'workspaces' must not be an empty list, omit the field instead",
+                id="yarn_empty_workspaces",
+            ),
         ],
     )
     def test_invalid_packages(self, input_data: dict[str, Any], expect_error: str) -> None:

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -23,12 +23,15 @@ from hermeto.core.package_managers.yarn.main import (
     _configure_yarn_version,
     _fetch_dependencies,
     _generate_environment_variables,
+    _resolve_yarn_project,
     _set_yarnrc_configuration,
+    _strip_workspace_scripts,
     _verify_corepack_yarn_version,
     _verify_yarnrc_paths,
     fetch_yarn_source,
 )
 from hermeto.core.package_managers.yarn.project import PackageJson, Plugin, YarnRc
+from hermeto.core.package_managers.yarn.resolver import Package
 from hermeto.core.package_managers.yarn.utils import VersionsRange
 from hermeto.core.rooted_path import RootedPath
 
@@ -481,8 +484,9 @@ def test_fetch_yarn_source(
         mock.call(
             project,
             input_request.output_dir,
+            package.workspaces,
         )
-        for project in mock_project
+        for project, package in zip(mock_project, input_request.yarn_packages)
     ]
     mock_resolve_yarn.assert_has_calls(calls)
 
@@ -492,3 +496,69 @@ def test_fetch_yarn_source(
         build_config=BuildConfig(environment_variables=yarn_env_variables),
     )
     assert output == expected_output
+
+
+@mock.patch("hermeto.core.package_managers.yarn.main.run_yarn_cmd")
+def test_fetch_dependencies_with_workspaces(
+    mock_yarn_cmd: mock.Mock, rooted_tmp_path: RootedPath
+) -> None:
+    _fetch_dependencies(rooted_tmp_path, workspaces=["app-a", "lib-shared"])
+
+    mock_yarn_cmd.assert_called_once_with(
+        ["workspaces", "focus", "app-a", "lib-shared"], rooted_tmp_path
+    )
+
+
+@mock.patch("hermeto.core.package_managers.yarn.main._configure_yarn_version")
+def test_workspace_focus_rejected_for_yarn_v3(
+    mock_configure_version: mock.Mock, rooted_tmp_path: RootedPath
+) -> None:
+    """Workspace focus is rejected when the project uses Yarn v3."""
+    mock_configure_version.return_value = semver.Version.parse("3.6.1")
+    project = mock.Mock(source_dir=rooted_tmp_path)
+
+    with pytest.raises(PackageRejected):
+        _resolve_yarn_project(project, rooted_tmp_path, workspaces=["app"])
+
+
+def test_strip_workspace_scripts(rooted_tmp_path: RootedPath) -> None:
+    """Scripts are removed only from workspace package.json files in the package list."""
+    import json
+
+    pkg_a_dir = rooted_tmp_path.join_within_root("packages", "app")
+    pkg_a_dir.path.mkdir(parents=True)
+    pkg_a_json = pkg_a_dir.join_within_root("package.json")
+    pkg_a_json.path.write_text(
+        json.dumps({"name": "app", "scripts": {"build": "tsc", "postinstall": "echo hi"}})
+    )
+
+    pkg_b_dir = rooted_tmp_path.join_within_root("packages", "unrelated")
+    pkg_b_dir.path.mkdir(parents=True)
+    pkg_b_json = pkg_b_dir.join_within_root("package.json")
+    pkg_b_json.path.write_text(
+        json.dumps({"name": "unrelated", "scripts": {"postinstall": "echo bad"}})
+    )
+
+    packages = [
+        Package(
+            raw_locator="app@workspace:packages/app",
+            version=None,
+            checksum=None,
+            cache_path=None,
+        ),
+        Package(
+            raw_locator="is-number@npm:7.0.0",
+            version="7.0.0",
+            checksum="abc",
+            cache_path="/cache/is-number.zip",
+        ),
+    ]
+
+    _strip_workspace_scripts(rooted_tmp_path, packages)
+
+    data_a = json.loads(pkg_a_json.path.read_text())
+    assert "scripts" not in data_a
+
+    # Workspace not in the package list is left untouched
+    data_b = json.loads(pkg_b_json.path.read_text())
+    assert data_b["scripts"] == {"postinstall": "echo bad"}

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -12,7 +12,12 @@ from semver import Version
 
 from hermeto import APP_NAME
 from hermeto.core.constants import Mode
-from hermeto.core.errors import NotAGitRepo, PackageRejected, UnsupportedFeature
+from hermeto.core.errors import (
+    NotAGitRepo,
+    PackageManagerError,
+    PackageRejected,
+    UnsupportedFeature,
+)
 from hermeto.core.models.sbom import Component, Patch, PatchDiff, Pedigree
 from hermeto.core.package_managers.yarn.locators import (
     Locator,
@@ -218,6 +223,20 @@ def test_resolve_packages(mock_run_yarn_cmd: mock.Mock, rooted_tmp_path: RootedP
 
     for package in packages:
         assert package.parsed_locator == parse_locator(package.raw_locator)
+
+
+@mock.patch("hermeto.core.package_managers.yarn.resolver.run_yarn_cmd")
+def test_resolve_packages_unsupported_resolver(
+    mock_run_yarn_cmd: mock.Mock, rooted_tmp_path: RootedPath
+) -> None:
+    """Unsupported resolver errors are raised as UnsupportedFeature for all packages."""
+    mock_run_yarn_cmd.side_effect = PackageManagerError(
+        "yarn info failed",
+        stderr="foo@exec:./gen.js: isn't supported by any available resolver",
+    )
+
+    with pytest.raises(UnsupportedFeature):
+        resolve_packages(rooted_tmp_path)
 
 
 @mock.patch("hermeto.core.package_managers.yarn.resolver.run_yarn_cmd")
@@ -1269,3 +1288,59 @@ def test_path_patch_raises_without_repo_in_permissive_mode(
 
     with pytest.raises(PackageRejected):
         _ComponentResolver({}, [patch_locator], mock_proj, rooted_tmp_path.re_root("output"))
+
+
+@mock.patch("hermeto.core.package_managers.yarn.resolver.run_yarn_cmd")
+def test_resolve_packages_deduplicates_workspaces(
+    mock_yarn_cmd: mock.Mock, rooted_tmp_path: RootedPath
+) -> None:
+    """Packages appearing in multiple workspace trees are deduplicated."""
+    shared_line = json.dumps(
+        {
+            "value": "shared@workspace:packages/shared",
+            "children": {
+                "Version": "1.0.0",
+                "Cache": {"Checksum": None, "Path": None},
+            },
+        }
+    )
+    app_only = json.dumps(
+        {
+            "value": "is-number@npm:7.0.0",
+            "children": {
+                "Version": "7.0.0",
+                "Cache": {"Checksum": "abc", "Path": "/cache/is-number.zip"},
+            },
+        }
+    )
+    lib_only = json.dumps(
+        {
+            "value": "left-pad@npm:1.3.0",
+            "children": {
+                "Version": "1.3.0",
+                "Cache": {"Checksum": "def", "Path": "/cache/left-pad.zip"},
+            },
+        }
+    )
+
+    mock_yarn_cmd.side_effect = [
+        f"{app_only}\n{shared_line}",
+        f"{lib_only}\n{shared_line}",
+    ]
+
+    result = resolve_packages(rooted_tmp_path, workspaces=["app", "lib"])
+
+    assert len(result) == 3
+    locators = [p.raw_locator for p in result]
+    assert locators == [
+        "is-number@npm:7.0.0",
+        "shared@workspace:packages/shared",
+        "left-pad@npm:1.3.0",
+    ]
+    assert mock_yarn_cmd.call_count == 2
+    mock_yarn_cmd.assert_any_call(
+        ["workspace", "app", "info", "--recursive", "--cache", "--json"], rooted_tmp_path
+    )
+    mock_yarn_cmd.assert_any_call(
+        ["workspace", "lib", "info", "--recursive", "--cache", "--json"], rooted_tmp_path
+    )


### PR DESCRIPTION
Allow users to specify workspaces in the package input so that only the dependencies for those workspaces are prefetched via [`yarn workspaces focus`](https://yarnpkg.com/cli/workspaces/focus). The output reflects only the packages actually installed for the focused workspaces, including their transitive workspace dependencies.

Each specified workspace is queried via `yarn workspace <name> info --recursive --cache --json`, and results are deduplicated across workspaces. When `workspaces` is omitted, existing behavior is unchanged.

Since `yarn workspaces focus` does not support `--mode skip-build`, and [`enableScripts: false` does not apply to workspace scripts](https://github.com/yarnpkg/berry/pull/4781), the `scripts` field is stripped from workspace `package.json` files before running the command to prevent lifecycle script execution.

### Usage

To focus on a single workspace, add the `workspaces` field to the package input:

```json
{"path": ".", "type": "yarn", "workspaces": ["my-app"]}
```

Multiple workspaces can be specified:

```json
{"path": ".", "type": "yarn", "workspaces": ["my-app", "my-lib"]}
```

### Input validation

- `workspaces: []` is rejected (omit the field instead to fetch all dependencies)
- `workspaces` requires Yarn v4 or later

### Before merging

This PR depends on [hermetoproject/integration-tests#69](https://github.com/hermetoproject/integration-tests/pull/69) which adds the integration test fixture.

Closes #1508