### PR TITLE
ci(docs): add dev version of docs built from main branch

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -10,6 +10,7 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -57,7 +58,7 @@ jobs:
           mike set-default --push latest
 
   deploy-dev:
-    if: github.event_name == 'push'
+    if: github.event_name != 'release'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,18 +1,29 @@
 # https://squidfunk.github.io/mkdocs-material/publishing-your-site/#with-github-actions
+# https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/
 
 name: Publish documentation
 on:
   release:
     types: [released]
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+
 permissions:
   contents: write
+
 jobs:
-  deploy:
+  deploy-release:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
         with:
           ref: refs/tags/${{ github.event.release.tag_name }}
+          # mike needs the full git history to manage versioned deployments
+          fetch-depth: 0
       - name: Configure Git Credentials
         run: |
           git config user.name github-actions[bot]
@@ -26,7 +37,7 @@ jobs:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache
           restore-keys: mkdocs-material-
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mike
       - name: Check if this is the latest release
         id: latest
         env:
@@ -38,5 +49,34 @@ jobs:
           else
             echo "is_latest=false" >> "$GITHUB_OUTPUT"
           fi
-      - run: mkdocs gh-deploy --force --strict
+      - name: Deploy release docs
         if: steps.latest.outputs.is_latest == 'true'
+        run: |
+          mike deploy --push --update-aliases \
+            ${{ github.event.release.tag_name }} latest
+          mike set-default --push latest
+
+  deploy-dev:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # mike needs the full git history to manage versioned deployments
+          fetch-depth: 0
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - run: echo "cache_id=$(date --utc '+%V')" >> "$GITHUB_ENV"
+      - uses: actions/cache@v5
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache
+          restore-keys: mkdocs-material-
+      - run: pip install mkdocs-material mike
+      - name: Deploy dev docs
+        run: mike deploy --push dev

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,3 +68,11 @@ exclude_docs: |
   dependency_confusion.md
   adr/
   design/
+
+# Versioning with mike
+extra:
+  version:
+    provider: mike
+    default:
+      - latest
+    alias: true


### PR DESCRIPTION
Currently, documentation is only deployed from released versions. However when docs changes are merged to main between releases, there is no way to preview them until the next release.

This PR adds a `'dev'` version of the docs built from the main branch using [mike](https://github.com/jimporter/mike). The version selector in the header allows users to switch between `'latest'` (released) and `'dev'` (main branch) docs.

### Changes:

- Migrate from `mkdocs gh-deploy` to `mike deploy` for versioned doc deployments.
- Add `deploy-dev` job triggered on push to main (`docs/**` and `mkdocs.yml` changes only).
- Add version provider config to `mkdocs.yml`.
- Set `'latest'` as default version so root URL redirects correctly.

### Testing (on fork):
**Deployed docs:**
- Dev: https://priyanshu-u07.github.io/hermeto/dev/
- Latest: https://priyanshu-u07.github.io/hermeto/latest/
- Root URL redirects to latest: https://priyanshu-u07.github.io/hermeto/

**CI runs:**
- Dev deployment (push to main): https://github.com/Priyanshu-u07/hermeto/actions/runs/23804270268
- Release deployment (v0.0.1-test): https://github.com/Priyanshu-u07/hermeto/actions/runs/23809809848


<img width="1871" height="870" alt="hermeto1" src="https://github.com/user-attachments/assets/2021741c-942b-490f-bdab-10d308e02f2f" />

### References:
- https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/
- https://github.com/jimporter/mike

### Note:
AI tools were used for researching mike documentation.

Closes: hermetoproject#1474