### PR TITLE
docs: extend Yarn v4 design doc with workspace focus

### DIFF
--- a/docs/adr/0002-yarn-v4.md
+++ b/docs/adr/0002-yarn-v4.md
@@ -237,11 +237,22 @@ hardened:<br>
 
 </details>
 
+### Workspace focus
+
+[yarn workspaces focus](https://yarnpkg.com/cli/workspaces/focus) installs only the dependencies for specified workspaces and their transitive workspace dependencies. To produce accurate output, Hermeto queries each specified workspace individually using Yarn's workspace-scoped `info` command, which reports only the transitive dependencies of that workspace.
+
+`yarn workspaces focus` does not support `--mode skip-build` ([yarnpkg/berry#3524](https://github.com/yarnpkg/berry/issues/3524)), and `enableScripts: false` [does not apply to workspace scripts](https://github.com/yarnpkg/berry/pull/4781). To prevent workspace lifecycle scripts from executing, Hermeto strips the `scripts` field from workspace `package.json` files before running the command.
+
+> [!NOTE]
+> This feature is available in Yarn v3 via the `@yarnpkg/plugin-workspace-tools` plugin, but only Yarn v4 (where the plugin is built-in) is supported at this time.
+
 ## Decision
 
 The changes needed to support Yarn v4 boil down to raising the maximum supported version, adding a few integration tests to cover v4 scenarios and updating the documentation. The Corepack shim is compatible with v4, so the project will still be processed with the exact Yarn version that is defined in its configuration files.
 
 Enabling the newly introduced hardened mode during the prefetch might prove useful to further increase the security of the process, but is by no means necessary to introduce basic support for v4. The impact on the prefetching speed is something that needs to be investigated in depth before we decide to enable it, but the decision can be deferred to a later moment.
+
+Workspace focus is exposed as an optional `workspaces` field in the package input. When omitted, existing behavior is unchanged. An empty list is rejected as invalid input, and the field requires Yarn v4 or later.
 
 ## Consequences
 


### PR DESCRIPTION
Extend the Yarn v4 design document with workspace focus support: workspace-scoped dependency resolution, lifecycle script stripping, input validation, and version constraints.