### PR TITLE
fix(pip): support multi-version python wheel tags

### DIFF
--- a/hermeto/core/package_managers/pip/package_distributions.py
+++ b/hermeto/core/package_managers/pip/package_distributions.py
@@ -368,26 +368,27 @@ class WheelsFilter(BinaryPackageFilter):
             or any(impl in interpreter for impl in self.py_impl)
         )
 
-        wheel_py_version = _parse_py_version(interpreter)
-        compatible_py_version = (
+        wheel_py_versions = _parse_py_version(interpreter)
+        compatible_py_version = any(
             self.py_version is None
-            or wheel_py_version == self.py_version
-            or (wheel_py_version < self.py_version and abi in ("abi3", "none"))
+            or v == self.py_version
+            or (v < self.py_version and abi in ("abi3", "none"))
+            for v in wheel_py_versions
         )
 
         return compatible_py_impl and compatible_py_version
 
 
-def _parse_py_version(interpreter: str) -> int:
+def _parse_py_version(interpreter: str) -> list[int]:
     """
     >>> _parse_py_version("cp312")
-    312
+    [312]
     >>> _parse_py_version("pp312")
-    312
+    [312]
     >>> _parse_py_version("py3")
-    3
+    [3]
     >>> _parse_py_version("py2.py3")
-    3
+    [2, 3]
     """
     parts = interpreter.split(".")
     versions = []
@@ -400,4 +401,4 @@ def _parse_py_version(interpreter: str) -> int:
     if not versions:
         raise RuntimeError(f"Invalid wheel interpreter: {interpreter}")
 
-    return max(versions)
+    return versions

--- a/tests/unit/package_managers/pip/test_package_distributions.py
+++ b/tests/unit/package_managers/pip/test_package_distributions.py
@@ -468,10 +468,11 @@ class TestWheelsFilter:
             PipBinaryFilters(**filter_kwargs)
 
     def test_parse_py_version_from_interpreter(self) -> None:
-        assert _parse_py_version("cp312") == 312
-        assert _parse_py_version("pp312") == 312
-        assert _parse_py_version("py3") == 3
-        assert _parse_py_version("py2.py3") == 3
+        assert _parse_py_version("cp312") == [312]
+        assert _parse_py_version("pp312") == [312]
+        assert _parse_py_version("py3") == [3]
+        assert _parse_py_version("py2.py3") == [2, 3]
+        assert _parse_py_version("py38.py39.py310") == [38, 39, 310]
 
     def test_filter_with_invalid_wheel_filename_is_skipped(self) -> None:
         filters = PipBinaryFilters()
@@ -535,6 +536,12 @@ class TestWheelsFilter:
             ),
             pytest.param(
                 "package-1.0.0-cp313-cp313-linux_x86_64.whl", False, id="higher_py_version"
+            ),
+            pytest.param(
+                "package-1.0.0-py38.py39.py310.py312-none-any.whl", True, id="multiple_py_versions_matches"
+            ),
+            pytest.param(
+                "package-1.0.0-py38.py39.py310-none-any.whl", False, id="multiple_py_versions_no_match"
             ),
         ],
     )


### PR DESCRIPTION
This PR addresses issue #1494.
Previously, _parse_py_version was extracting all valid versions from a multi-version Python wheel tag (like py38.py39.py310) but then forcefully reducing them down to just the max(versions). This caused Hermeto to incorrectly evaluate compatibility against a single version, accidentally rejecting perfectly valid, PEP-425-compliant wheels if the environment was set to one of the "lower" versions in the tag list.

**What I changed:**

- Refactored _parse_py_version in package_distributions.py to return the full list[int] of parsed versions.
-Updated _compatible_tag_interpreter to use any() so it evaluates compatibility across all the returned Python versions correctly.
-Added comprehensive unit tests in test_package_distributions.py to assert that multiple tags are correctly parsed as lists, and that parametric filtering logic properly accepts matching multi-version wheel tags.