### PR TITLE
gomod: add vcs_url PURL qualifier for local modules

### DIFF
--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -125,6 +125,8 @@ class Module(NamedTuple):
         had a checksum for this module but didn't
     proxy: the list of custom proxy URLs used to fetch this module, or None if the module was
         fetched directly from VCS or only via the canonical Go proxy (proxy.golang.org).
+    vcs_url: the VCS URL qualifier for modules sourced from the local git repository, or None
+        for modules fetched from a remote source.
     """
 
     name: str
@@ -134,15 +136,19 @@ class Module(NamedTuple):
     main: bool = False
     missing_hash_in_file: Path | None = None
     proxy: list[str] | None = None
+    vcs_url: str | None = None
 
     @property
     def purl(self) -> str:
         """Get the purl for this module."""
+        qualifiers: dict[str, str] = {"type": "module"}
+        if self.vcs_url:
+            qualifiers["vcs_url"] = self.vcs_url
         purl = PackageURL(
             type="golang",
             name=self.real_path,
             version=self.version,
-            qualifiers={"type": "module"},
+            qualifiers=qualifiers,
         )
         return purl.to_string()
 
@@ -198,11 +204,14 @@ class Package(NamedTuple):
     @property
     def purl(self) -> str:
         """Get the purl for this package."""
+        qualifiers: dict[str, str] = {"type": "package"}
+        if self.module.vcs_url:
+            qualifiers["vcs_url"] = self.module.vcs_url
         purl = PackageURL(
             type="golang",
             name=self.real_path,
             version=self.module.version,
-            qualifiers={"type": "package"},
+            qualifiers=qualifiers,
         )
         return purl.to_string()
 
@@ -321,6 +330,7 @@ def _create_modules_from_parsed_data(
             real_path=real_path,
             missing_hash_in_file=missing_hash_in_file,
             proxy=proxy,
+            vcs_url=main_module.vcs_url if version_or_path.startswith(".") else None,
         )
 
     def _resolve_path_for_local_replacement(module: ParsedModule) -> str:
@@ -552,11 +562,14 @@ def _create_main_module_from_parsed_data(
         # Should not happen, since the version is always resolved from the Git repo
         raise RuntimeError(f"Version was not identified for main module at {resolved_subpath}")
 
+    vcs_url = get_repo_id(main_module_dir).as_vcs_url_qualifier()
+
     return Module(
         name=parsed_main_module.path,
         original_name=parsed_main_module.path,
         version=parsed_main_module.version,
         real_path=resolved_path,
+        vcs_url=vcs_url,
     )
 
 

--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -127,6 +127,8 @@ class Module(NamedTuple):
         had a checksum for this module but didn't
     proxy: the list of custom proxy URLs used to fetch this module, or None if the module was
         fetched directly from VCS or only via the canonical Go proxy (proxy.golang.org).
+    vcs_url: the VCS URL qualifier for modules sourced from the local git repository, or None
+        for modules fetched from a remote source.
     """
 
     name: str
@@ -136,15 +138,19 @@ class Module(NamedTuple):
     main: bool = False
     missing_hash_in_file: Path | None = None
     proxy: list[str] | None = None
+    vcs_url: str | None = None
 
     @property
     def purl(self) -> str:
         """Get the purl for this module."""
+        qualifiers: dict[str, str] = {"type": "module"}
+        if self.vcs_url:
+            qualifiers["vcs_url"] = self.vcs_url
         purl = PackageURL(
             type="golang",
             name=self.real_path,
             version=self.version,
-            qualifiers={"type": "module"},
+            qualifiers=qualifiers,
         )
         return purl.to_string()
 
@@ -200,11 +206,14 @@ class Package(NamedTuple):
     @property
     def purl(self) -> str:
         """Get the purl for this package."""
+        qualifiers: dict[str, str] = {"type": "package"}
+        if self.module.vcs_url:
+            qualifiers["vcs_url"] = self.module.vcs_url
         purl = PackageURL(
             type="golang",
             name=self.real_path,
             version=self.module.version,
-            qualifiers={"type": "package"},
+            qualifiers=qualifiers,
         )
         return purl.to_string()
 
@@ -323,6 +332,7 @@ def _create_modules_from_parsed_data(
             real_path=real_path,
             missing_hash_in_file=missing_hash_in_file,
             proxy=proxy,
+            vcs_url=main_module.vcs_url if version_or_path.startswith(".") else None,
         )
 
     def _resolve_path_for_local_replacement(module: ParsedModule) -> str:
@@ -569,11 +579,17 @@ def _create_main_module_from_parsed_data(
         # Should not happen, since the version is always resolved from the Git repo
         raise RuntimeError(f"Version was not identified for main module at {resolved_subpath}")
 
+    if repo_name is not None:
+        vcs_url = get_repo_id(main_module_dir).as_vcs_url_qualifier()
+    else:
+        vcs_url = None
+
     return Module(
         name=parsed_main_module.path,
         original_name=parsed_main_module.path,
         version=parsed_main_module.version,
         real_path=resolved_path,
+        vcs_url=vcs_url,
     )
 
 

--- a/tests/integration/test_data/gomod_correct_vendor_in_submodule_passes_vendor_check/bom.json
+++ b/tests/integration/test_data/gomod_correct_vendor_in_submodule_passes_vendor_check/bom.json
@@ -11,8 +11,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests%400543a5034b687df174c6b12b7b6b9c04770a856f",
+        "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests%400543a5034b687df174c6b12b7b6b9c04770a856f",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -136,7 +136,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests%400543a5034b687df174c6b12b7b6b9c04770a856f",
       "name": "github.com/cachito-testing/gomod-vendor-check-pass",
       "properties": [
         {
@@ -144,12 +144,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests%400543a5034b687df174c6b12b7b6b9c04770a856f",
       "type": "library",
       "version": "v0.0.0-20250910180432-ddc935adef13"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests%400543a5034b687df174c6b12b7b6b9c04770a856f",
       "name": "github.com/cachito-testing/gomod-vendor-check-pass",
       "properties": [
         {
@@ -157,7 +157,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests%400543a5034b687df174c6b12b7b6b9c04770a856f",
       "type": "library",
       "version": "v0.0.0-20250910180432-ddc935adef13"
     },

--- a/tests/integration/test_data/gomod_correct_vendor_passes_vendor_check/bom.json
+++ b/tests/integration/test_data/gomod_correct_vendor_passes_vendor_check/bom.json
@@ -11,8 +11,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40acda5b87da2406406ad4ddb1b77c1129eb9a7faf",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40acda5b87da2406406ad4ddb1b77c1129eb9a7faf",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -136,7 +136,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40acda5b87da2406406ad4ddb1b77c1129eb9a7faf",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -144,12 +144,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40acda5b87da2406406ad4ddb1b77c1129eb9a7faf",
       "type": "library",
       "version": "v0.0.0-20260311161302-acda5b87da24"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40acda5b87da2406406ad4ddb1b77c1129eb9a7faf",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -157,7 +157,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40acda5b87da2406406ad4ddb1b77c1129eb9a7faf",
       "type": "library",
       "version": "v0.0.0-20260311161302-acda5b87da24"
     },

--- a/tests/integration/test_data/gomod_e2e_1.18/bom.json
+++ b/tests/integration/test_data/gomod_e2e_1.18/bom.json
@@ -94,10 +94,10 @@
         "pkg:golang/fmt?type=package",
         "pkg:golang/github.com/Masterminds/semver@v1.4.2?type=module",
         "pkg:golang/github.com/Masterminds/semver@v1.4.2?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20230109085255-c3496edd5d45?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20230109085255-c3496edd5d45?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
+        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
         "pkg:golang/github.com/kr/pretty@v0.1.0?type=module",
         "pkg:golang/github.com/op/go-logging@v0.0.0-20160315200505-970db520ece7?type=module",
         "pkg:golang/github.com/op/go-logging@v0.0.0-20160315200505-970db520ece7?type=package",
@@ -1287,7 +1287,7 @@
       "version": "v1.4.2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20230109085255-c3496edd5d45?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "name": "github.com/release-engineering/retrodep/v2/retrodep/glide",
       "properties": [
         {
@@ -1295,12 +1295,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20230109085255-c3496edd5d45?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "type": "library",
       "version": "v2.0.0-20230109085255-c3496edd5d45"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20230109085255-c3496edd5d45?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "name": "github.com/release-engineering/retrodep/v2/retrodep",
       "properties": [
         {
@@ -1308,12 +1308,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20230109085255-c3496edd5d45?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "type": "library",
       "version": "v2.0.0-20230109085255-c3496edd5d45"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "name": "github.com/release-engineering/retrodep/v2",
       "properties": [
         {
@@ -1321,12 +1321,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "type": "library",
       "version": "v2.0.0-20230109085255-c3496edd5d45"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "name": "github.com/release-engineering/retrodep/v2",
       "properties": [
         {
@@ -1334,7 +1334,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "type": "library",
       "version": "v2.0.0-20230109085255-c3496edd5d45"
     },

--- a/tests/integration/test_data/gomod_e2e_1.21/bom.json
+++ b/tests/integration/test_data/gomod_e2e_1.21/bom.json
@@ -94,10 +94,10 @@
         "pkg:golang/fmt?type=package",
         "pkg:golang/github.com/Masterminds/semver@v1.4.2?type=module",
         "pkg:golang/github.com/Masterminds/semver@v1.4.2?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20240308152237-d0c316edef82?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20240308152237-d0c316edef82?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
+        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
         "pkg:golang/github.com/kr/pretty@v0.1.0?type=module",
         "pkg:golang/github.com/op/go-logging@v0.0.0-20160315200505-970db520ece7?type=module",
         "pkg:golang/github.com/op/go-logging@v0.0.0-20160315200505-970db520ece7?type=package",
@@ -1287,7 +1287,7 @@
       "version": "v1.4.2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20240308152237-d0c316edef82?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "name": "github.com/release-engineering/retrodep/v2/retrodep/glide",
       "properties": [
         {
@@ -1295,12 +1295,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20240308152237-d0c316edef82?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "type": "library",
       "version": "v2.0.0-20240308152237-d0c316edef82"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20240308152237-d0c316edef82?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "name": "github.com/release-engineering/retrodep/v2/retrodep",
       "properties": [
         {
@@ -1308,12 +1308,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20240308152237-d0c316edef82?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "type": "library",
       "version": "v2.0.0-20240308152237-d0c316edef82"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "name": "github.com/release-engineering/retrodep/v2",
       "properties": [
         {
@@ -1321,12 +1321,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "type": "library",
       "version": "v2.0.0-20240308152237-d0c316edef82"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "name": "github.com/release-engineering/retrodep/v2",
       "properties": [
         {
@@ -1334,7 +1334,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "type": "library",
       "version": "v2.0.0-20240308152237-d0c316edef82"
     },

--- a/tests/integration/test_data/gomod_e2e_1.21_dirty/bom.json
+++ b/tests/integration/test_data/gomod_e2e_1.21_dirty/bom.json
@@ -12,8 +12,8 @@
         "pkg:golang/fmt?type=package",
         "pkg:golang/github.com/cachito-testing/cachi2-gomod/twentyone@v0.0.0?type=module",
         "pkg:golang/github.com/cachito-testing/cachi2-gomod/twentyone@v0.0.0?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403353e452672851079f1926b6b2d7372447104b31",
+        "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403353e452672851079f1926b6b2d7372447104b31",
         "pkg:golang/internal/abi?type=package",
         "pkg:golang/internal/asan?type=package",
         "pkg:golang/internal/bisect?type=package",
@@ -142,7 +142,7 @@
       "version": "v0.0.0"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403353e452672851079f1926b6b2d7372447104b31",
       "name": "github.com/cachito-testing/cachi2-gomod/twenty",
       "properties": [
         {
@@ -150,12 +150,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403353e452672851079f1926b6b2d7372447104b31",
       "type": "library",
       "version": "v0.0.0-20240321211820-3353e4526728"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403353e452672851079f1926b6b2d7372447104b31",
       "name": "github.com/cachito-testing/cachi2-gomod/twenty",
       "properties": [
         {
@@ -163,7 +163,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403353e452672851079f1926b6b2d7372447104b31",
       "type": "library",
       "version": "v0.0.0-20240321211820-3353e4526728"
     },

--- a/tests/integration/test_data/gomod_e2e_1.22_workspace_vendoring/bom.json
+++ b/tests/integration/test_data/gomod_e2e_1.22_workspace_vendoring/bom.json
@@ -94,13 +94,13 @@
         "pkg:golang/github.com/davecgh/go-spew@v1.1.1?type=module",
         "pkg:golang/github.com/golang-jwt/jwt@v3.2.2%2Bincompatible?type=module",
         "pkg:golang/github.com/golang-jwt/jwt@v3.2.2%2Bincompatible?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo/middleware@v4.0.0-20240626062917-5aabb6779a32?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo/middleware@v4.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
         "pkg:golang/github.com/labstack/gommon/bytes@v0.4.2?type=package",
         "pkg:golang/github.com/labstack/gommon/color@v0.4.2?type=package",
         "pkg:golang/github.com/labstack/gommon/log@v0.4.2?type=package",
@@ -1307,7 +1307,7 @@
       "version": "v3.2.2+incompatible"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo/middleware@v4.0.0-20240626062917-5aabb6779a32?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo/middleware@v4.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "github.com/labstack/echo/v4/middleware",
       "properties": [
         {
@@ -1315,12 +1315,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo/middleware@v4.0.0-20240626062917-5aabb6779a32?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo/middleware@v4.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v4.0.0-20240626062917-5aabb6779a32"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "github.com/labstack/echo/v4",
       "properties": [
         {
@@ -1328,12 +1328,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v4.0.0-20240626062917-5aabb6779a32"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "github.com/labstack/echo/v4",
       "properties": [
         {
@@ -1341,12 +1341,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v4.0.0-20240626062917-5aabb6779a32"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "example.com/hello",
       "properties": [
         {
@@ -1354,12 +1354,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v0.0.0-20240626062917-5aabb6779a32"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "example.com/hello",
       "properties": [
         {
@@ -1367,12 +1367,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v0.0.0-20240626062917-5aabb6779a32"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "example.com/hiii",
       "properties": [
         {
@@ -1380,12 +1380,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v0.0.0-20240626062917-5aabb6779a32"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "example.com/hiii",
       "properties": [
         {
@@ -1393,7 +1393,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v0.0.0-20240626062917-5aabb6779a32"
     },

--- a/tests/integration/test_data/gomod_e2e_multiple_modules/bom.json
+++ b/tests/integration/test_data/gomod_e2e_multiple_modules/bom.json
@@ -11,11 +11,11 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161342-30959439437a?type=module",
+        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
+        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
+        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
+        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -141,7 +141,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "name": "github.com/hermetoproject/integration-tests/eggs-module",
       "properties": [
         {
@@ -149,12 +149,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "type": "library",
       "version": "v0.0.0-20260311161342-30959439437a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "name": "github.com/hermetoproject/integration-tests/eggs-module",
       "properties": [
         {
@@ -162,12 +162,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "type": "library",
       "version": "v0.0.0-20260311161342-30959439437a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "name": "github.com/hermetoproject/integration-tests/spam-module",
       "properties": [
         {
@@ -175,12 +175,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "type": "library",
       "version": "v0.0.0-20260311161342-30959439437a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "name": "github.com/hermetoproject/integration-tests/spam-module",
       "properties": [
         {
@@ -188,12 +188,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "type": "library",
       "version": "v0.0.0-20260311161342-30959439437a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161342-30959439437a?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -201,7 +201,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161342-30959439437a?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "type": "library",
       "version": "v0.0.0-20260311161342-30959439437a"
     },

--- a/tests/integration/test_data/gomod_e2e_vendor_nonvendor_module_mix_ordering_1/bom.json
+++ b/tests/integration/test_data/gomod_e2e_vendor_nonvendor_module_mix_ordering_1/bom.json
@@ -51,11 +51,11 @@
         "pkg:golang/fmt?type=package",
         "pkg:golang/github.com/google/uuid@v1.6.0?type=module",
         "pkg:golang/github.com/google/uuid@v1.6.0?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module/utils@v0.0.0-20251031153824-281b55caebf2?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
+        "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
+        "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module/utils@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
+        "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
+        "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
         "pkg:golang/hash?type=package",
         "pkg:golang/internal/abi?type=package",
         "pkg:golang/internal/asan?type=package",
@@ -665,7 +665,7 @@
       "version": "v1.6.0"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "name": "github.com/hermetoproject/integration-tests/gomod-vendor-non-vendor-mix/non-vendored-module",
       "properties": [
         {
@@ -673,12 +673,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "type": "library",
       "version": "v0.0.0-20251031153824-281b55caebf2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "name": "github.com/hermetoproject/integration-tests/gomod-vendor-non-vendor-mix/non-vendored-module",
       "properties": [
         {
@@ -686,12 +686,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "type": "library",
       "version": "v0.0.0-20251031153824-281b55caebf2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module/utils@v0.0.0-20251031153824-281b55caebf2?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module/utils@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "name": "github.com/hermetoproject/integration-tests/gomod-vendor-non-vendor-mix/vendored-module/utils",
       "properties": [
         {
@@ -699,12 +699,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module/utils@v0.0.0-20251031153824-281b55caebf2?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module/utils@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "type": "library",
       "version": "v0.0.0-20251031153824-281b55caebf2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "name": "github.com/hermetoproject/integration-tests/gomod-vendor-non-vendor-mix/vendored-module",
       "properties": [
         {
@@ -712,12 +712,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "type": "library",
       "version": "v0.0.0-20251031153824-281b55caebf2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "name": "github.com/hermetoproject/integration-tests/gomod-vendor-non-vendor-mix/vendored-module",
       "properties": [
         {
@@ -725,7 +725,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "type": "library",
       "version": "v0.0.0-20251031153824-281b55caebf2"
     },

--- a/tests/integration/test_data/gomod_empty_vendor_passes_vendor_check_in_permissive_mode/bom.json
+++ b/tests/integration/test_data/gomod_empty_vendor_passes_vendor_check_in_permissive_mode/bom.json
@@ -11,8 +11,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -95,8 +95,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -220,7 +220,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -228,12 +228,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
       "type": "library",
       "version": "v0.0.0-20260311161306-60f1ba765d09"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -241,7 +241,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
       "type": "library",
       "version": "v0.0.0-20260311161306-60f1ba765d09"
     },

--- a/tests/integration/test_data/gomod_generate_imported/bom.json
+++ b/tests/integration/test_data/gomod_generate_imported/bom.json
@@ -14,10 +14,10 @@
         "pkg:golang/encoding?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
+        "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
         "pkg:golang/internal/abi?type=package",
         "pkg:golang/internal/asan?type=package",
         "pkg:golang/internal/bisect?type=package",
@@ -171,7 +171,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "name": "github.com/hermetoproject/integration-tests/foobar",
       "properties": [
         {
@@ -179,12 +179,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "type": "library",
       "version": "v0.0.0-20260415150945-27ab4eeb7cc6"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "name": "github.com/hermetoproject/integration-tests/internal/generate",
       "properties": [
         {
@@ -192,12 +192,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "type": "library",
       "version": "v0.0.0-20260415150945-27ab4eeb7cc6"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -205,12 +205,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "type": "library",
       "version": "v0.0.0-20260415150945-27ab4eeb7cc6"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -218,7 +218,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "type": "library",
       "version": "v0.0.0-20260415150945-27ab4eeb7cc6"
     },

--- a/tests/integration/test_data/gomod_generate_imported/bom.json
+++ b/tests/integration/test_data/gomod_generate_imported/bom.json
@@ -14,10 +14,10 @@
         "pkg:golang/encoding?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20211026214220-a5af4262860e?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20211026214220-a5af4262860e?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20211026214220-a5af4262860e?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20211026214220-a5af4262860e?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20211026214220-a5af4262860e?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a5af4262860e53a354936f69d453a853e4da2deb",
+        "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20211026214220-a5af4262860e?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a5af4262860e53a354936f69d453a853e4da2deb",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20211026214220-a5af4262860e?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a5af4262860e53a354936f69d453a853e4da2deb",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20211026214220-a5af4262860e?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a5af4262860e53a354936f69d453a853e4da2deb",
         "pkg:golang/internal/abi?type=package",
         "pkg:golang/internal/asan?type=package",
         "pkg:golang/internal/bisect?type=package",
@@ -171,7 +171,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20211026214220-a5af4262860e?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20211026214220-a5af4262860e?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a5af4262860e53a354936f69d453a853e4da2deb",
       "name": "github.com/cachito-testing/go-generate-imported/foobar",
       "properties": [
         {
@@ -179,12 +179,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20211026214220-a5af4262860e?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20211026214220-a5af4262860e?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a5af4262860e53a354936f69d453a853e4da2deb",
       "type": "library",
       "version": "v0.0.0-20211026214220-a5af4262860e"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20211026214220-a5af4262860e?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20211026214220-a5af4262860e?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a5af4262860e53a354936f69d453a853e4da2deb",
       "name": "github.com/cachito-testing/go-generate-imported/internal/generate",
       "properties": [
         {
@@ -192,12 +192,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20211026214220-a5af4262860e?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20211026214220-a5af4262860e?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a5af4262860e53a354936f69d453a853e4da2deb",
       "type": "library",
       "version": "v0.0.0-20211026214220-a5af4262860e"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20211026214220-a5af4262860e?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20211026214220-a5af4262860e?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a5af4262860e53a354936f69d453a853e4da2deb",
       "name": "github.com/cachito-testing/go-generate-imported",
       "properties": [
         {
@@ -205,12 +205,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20211026214220-a5af4262860e?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20211026214220-a5af4262860e?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a5af4262860e53a354936f69d453a853e4da2deb",
       "type": "library",
       "version": "v0.0.0-20211026214220-a5af4262860e"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20211026214220-a5af4262860e?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20211026214220-a5af4262860e?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a5af4262860e53a354936f69d453a853e4da2deb",
       "name": "github.com/cachito-testing/go-generate-imported",
       "properties": [
         {
@@ -218,7 +218,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20211026214220-a5af4262860e?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20211026214220-a5af4262860e?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a5af4262860e53a354936f69d453a853e4da2deb",
       "type": "library",
       "version": "v0.0.0-20211026214220-a5af4262860e"
     },

--- a/tests/integration/test_data/gomod_local_deps/bom.json
+++ b/tests/integration/test_data/gomod_local_deps/bom.json
@@ -10,11 +10,11 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20260415150948-a311d3903a7b?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
+        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
+        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
         "pkg:golang/internal/abi?type=package",
         "pkg:golang/internal/asan?type=package",
         "pkg:golang/internal/bisect?type=package",
@@ -117,7 +117,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20260415150948-a311d3903a7b?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "name": "github.com/hermetoproject/some-module/some-package",
       "properties": [
         {
@@ -125,12 +125,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20260415150948-a311d3903a7b?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "type": "library",
       "version": "v0.0.0-20260415150948-a311d3903a7b"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "name": "github.com/hermetoproject/some-module",
       "properties": [
         {
@@ -138,12 +138,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "type": "library",
       "version": "v0.0.0-20260415150948-a311d3903a7b"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "name": "github.com/hermetoproject/some-module",
       "properties": [
         {
@@ -151,12 +151,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "type": "library",
       "version": "v0.0.0-20260415150948-a311d3903a7b"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -164,12 +164,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "type": "library",
       "version": "v0.0.0-20260415150948-a311d3903a7b"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -177,7 +177,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "type": "library",
       "version": "v0.0.0-20260415150948-a311d3903a7b"
     },

--- a/tests/integration/test_data/gomod_local_deps/bom.json
+++ b/tests/integration/test_data/gomod_local_deps/bom.json
@@ -10,11 +10,11 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20210216123728-b2e465b91a6a?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20210216123728-b2e465b91a6a?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20210216123728-b2e465b91a6a?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210216123728-b2e465b91a6a?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210216123728-b2e465b91a6a?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20210216123728-b2e465b91a6a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
+        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20210216123728-b2e465b91a6a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
+        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20210216123728-b2e465b91a6a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210216123728-b2e465b91a6a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210216123728-b2e465b91a6a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
         "pkg:golang/internal/abi?type=package",
         "pkg:golang/internal/asan?type=package",
         "pkg:golang/internal/bisect?type=package",
@@ -117,7 +117,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20210216123728-b2e465b91a6a?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20210216123728-b2e465b91a6a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
       "name": "github.com/cachito-testing/some-module/some-package",
       "properties": [
         {
@@ -125,12 +125,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20210216123728-b2e465b91a6a?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20210216123728-b2e465b91a6a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
       "type": "library",
       "version": "v0.0.0-20210216123728-b2e465b91a6a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20210216123728-b2e465b91a6a?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20210216123728-b2e465b91a6a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
       "name": "github.com/cachito-testing/some-module",
       "properties": [
         {
@@ -138,12 +138,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20210216123728-b2e465b91a6a?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20210216123728-b2e465b91a6a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
       "type": "library",
       "version": "v0.0.0-20210216123728-b2e465b91a6a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20210216123728-b2e465b91a6a?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20210216123728-b2e465b91a6a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
       "name": "github.com/cachito-testing/some-module",
       "properties": [
         {
@@ -151,12 +151,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20210216123728-b2e465b91a6a?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20210216123728-b2e465b91a6a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
       "type": "library",
       "version": "v0.0.0-20210216123728-b2e465b91a6a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210216123728-b2e465b91a6a?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210216123728-b2e465b91a6a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
       "name": "github.com/cachito-testing/cachito-gomod-local-deps",
       "properties": [
         {
@@ -164,12 +164,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210216123728-b2e465b91a6a?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210216123728-b2e465b91a6a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
       "type": "library",
       "version": "v0.0.0-20210216123728-b2e465b91a6a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210216123728-b2e465b91a6a?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210216123728-b2e465b91a6a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
       "name": "github.com/cachito-testing/cachito-gomod-local-deps",
       "properties": [
         {
@@ -177,7 +177,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210216123728-b2e465b91a6a?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210216123728-b2e465b91a6a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b2e465b91a6a272540c77d4dde1e317773ed700b",
       "type": "library",
       "version": "v0.0.0-20210216123728-b2e465b91a6a"
     },

--- a/tests/integration/test_data/gomod_missing_checksums/bom.json
+++ b/tests/integration/test_data/gomod_missing_checksums/bom.json
@@ -9,11 +9,11 @@
       "subjects": [
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161108-98375b8401ea?type=module",
+        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
+        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
+        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
+        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
         "pkg:golang/internal/abi?type=package",
@@ -109,7 +109,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "name": "github.com/hermetoproject/integration-tests/eggs-module",
       "properties": [
         {
@@ -117,12 +117,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "type": "library",
       "version": "v0.0.0-20260311161108-98375b8401ea"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "name": "github.com/hermetoproject/integration-tests/eggs-module",
       "properties": [
         {
@@ -130,12 +130,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "type": "library",
       "version": "v0.0.0-20260311161108-98375b8401ea"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "name": "github.com/hermetoproject/integration-tests/spam-module",
       "properties": [
         {
@@ -143,12 +143,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "type": "library",
       "version": "v0.0.0-20260311161108-98375b8401ea"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "name": "github.com/hermetoproject/integration-tests/spam-module",
       "properties": [
         {
@@ -156,12 +156,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "type": "library",
       "version": "v0.0.0-20260311161108-98375b8401ea"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161108-98375b8401ea?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -169,7 +169,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161108-98375b8401ea?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "type": "library",
       "version": "v0.0.0-20260311161108-98375b8401ea"
     },

--- a/tests/integration/test_data/gomod_with_deps/bom.json
+++ b/tests/integration/test_data/gomod_with_deps/bom.json
@@ -11,8 +11,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c1f6ac11dc73b44ede3dcc05555a586969b43c50",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c1f6ac11dc73b44ede3dcc05555a586969b43c50",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -136,7 +136,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c1f6ac11dc73b44ede3dcc05555a586969b43c50",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -144,12 +144,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c1f6ac11dc73b44ede3dcc05555a586969b43c50",
       "type": "library",
       "version": "v0.0.0-20260306125704-c1f6ac11dc73"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c1f6ac11dc73b44ede3dcc05555a586969b43c50",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -157,7 +157,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c1f6ac11dc73b44ede3dcc05555a586969b43c50",
       "type": "library",
       "version": "v0.0.0-20260306125704-c1f6ac11dc73"
     },

--- a/tests/integration/test_data/gomod_without_deps/bom.json
+++ b/tests/integration/test_data/gomod_without_deps/bom.json
@@ -7,8 +7,8 @@
         }
       },
       "subjects": [
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20200925115855-a888f7261b9a?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20200925115855-a888f7261b9a?type=package"
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20200925115855-a888f7261b9a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a888f7261b9a9683972fbd77da2d12fe86faef5e",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20200925115855-a888f7261b9a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a888f7261b9a9683972fbd77da2d12fe86faef5e"
       ],
       "text": "hermeto:backend:gomod",
       "timestamp": "2025-01-01T00:00:00Z"
@@ -17,7 +17,7 @@
   "bomFormat": "CycloneDX",
   "components": [
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20200925115855-a888f7261b9a?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20200925115855-a888f7261b9a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a888f7261b9a9683972fbd77da2d12fe86faef5e",
       "name": "github.com/cachito-testing/cachito-gomod-without-deps",
       "properties": [
         {
@@ -25,12 +25,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20200925115855-a888f7261b9a?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20200925115855-a888f7261b9a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a888f7261b9a9683972fbd77da2d12fe86faef5e",
       "type": "library",
       "version": "v0.0.0-20200925115855-a888f7261b9a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20200925115855-a888f7261b9a?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20200925115855-a888f7261b9a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a888f7261b9a9683972fbd77da2d12fe86faef5e",
       "name": "github.com/cachito-testing/cachito-gomod-without-deps",
       "properties": [
         {
@@ -38,7 +38,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20200925115855-a888f7261b9a?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20200925115855-a888f7261b9a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a888f7261b9a9683972fbd77da2d12fe86faef5e",
       "type": "library",
       "version": "v0.0.0-20200925115855-a888f7261b9a"
     }

--- a/tests/integration/test_data/gomod_without_deps/bom.json
+++ b/tests/integration/test_data/gomod_without_deps/bom.json
@@ -7,8 +7,8 @@
         }
       },
       "subjects": [
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=package"
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408e5cec9c6ec56396a7443dc57e088d099c1b0113",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408e5cec9c6ec56396a7443dc57e088d099c1b0113"
       ],
       "text": "hermeto:backend:gomod",
       "timestamp": "2025-01-01T00:00:00Z"
@@ -17,7 +17,7 @@
   "bomFormat": "CycloneDX",
   "components": [
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408e5cec9c6ec56396a7443dc57e088d099c1b0113",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -25,12 +25,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408e5cec9c6ec56396a7443dc57e088d099c1b0113",
       "type": "library",
       "version": "v0.0.0-20260415150951-8e5cec9c6ec5"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408e5cec9c6ec56396a7443dc57e088d099c1b0113",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -38,7 +38,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408e5cec9c6ec56396a7443dc57e088d099c1b0113",
       "type": "library",
       "version": "v0.0.0-20260415150951-8e5cec9c6ec5"
     }

--- a/tests/integration/test_data/gomod_workspaces/bom.json
+++ b/tests/integration/test_data/gomod_workspaces/bom.json
@@ -94,13 +94,13 @@
         "pkg:golang/github.com/davecgh/go-spew@v1.1.1?type=module",
         "pkg:golang/github.com/golang-jwt/jwt@v3.2.2%2Bincompatible?type=module",
         "pkg:golang/github.com/golang-jwt/jwt@v3.2.2%2Bincompatible?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo/middleware@v4.0.0-20240626205759-b97aca303b29?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo/middleware@v4.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
         "pkg:golang/github.com/labstack/gommon/bytes@v0.4.2?type=package",
         "pkg:golang/github.com/labstack/gommon/color@v0.4.2?type=package",
         "pkg:golang/github.com/labstack/gommon/log@v0.4.2?type=package",
@@ -1311,7 +1311,7 @@
       "version": "v3.2.2+incompatible"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo/middleware@v4.0.0-20240626205759-b97aca303b29?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo/middleware@v4.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "github.com/labstack/echo/v4/middleware",
       "properties": [
         {
@@ -1319,12 +1319,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo/middleware@v4.0.0-20240626205759-b97aca303b29?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo/middleware@v4.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v4.0.0-20240626205759-b97aca303b29"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "github.com/labstack/echo/v4",
       "properties": [
         {
@@ -1332,12 +1332,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v4.0.0-20240626205759-b97aca303b29"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "github.com/labstack/echo/v4",
       "properties": [
         {
@@ -1345,12 +1345,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v4.0.0-20240626205759-b97aca303b29"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "example.com/hiii",
       "properties": [
         {
@@ -1358,12 +1358,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v0.0.0-20240626205759-b97aca303b29"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "example.com/hiii",
       "properties": [
         {
@@ -1371,12 +1371,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v0.0.0-20240626205759-b97aca303b29"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "example.com/hello",
       "properties": [
         {
@@ -1384,12 +1384,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v0.0.0-20240626205759-b97aca303b29"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "example.com/hello",
       "properties": [
         {
@@ -1397,7 +1397,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v0.0.0-20240626205759-b97aca303b29"
     },

--- a/tests/integration/test_data/gomod_wrong_vendor_passes_vendor_check_in_permissive_mode/bom.json
+++ b/tests/integration/test_data/gomod_wrong_vendor_passes_vendor_check_in_permissive_mode/bom.json
@@ -11,8 +11,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -95,8 +95,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -220,7 +220,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -228,12 +228,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
       "type": "library",
       "version": "v0.0.0-20260415150954-f802197aba69"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -241,7 +241,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
       "type": "library",
       "version": "v0.0.0-20260415150954-f802197aba69"
     },

--- a/tests/integration/test_data/gomod_wrong_vendor_passes_vendor_check_in_permissive_mode/bom.json
+++ b/tests/integration/test_data/gomod_wrong_vendor_passes_vendor_check_in_permissive_mode/bom.json
@@ -11,8 +11,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408553df6498705b2b36614320ca0c65bc24a1d9e6",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408553df6498705b2b36614320ca0c65bc24a1d9e6",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -95,8 +95,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408553df6498705b2b36614320ca0c65bc24a1d9e6",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408553df6498705b2b36614320ca0c65bc24a1d9e6",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -220,7 +220,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408553df6498705b2b36614320ca0c65bc24a1d9e6",
       "name": "github.com/cachito-testing/gomod-vendor-check-fail",
       "properties": [
         {
@@ -228,12 +228,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408553df6498705b2b36614320ca0c65bc24a1d9e6",
       "type": "library",
       "version": "v0.0.0-20210729213647-8553df649870"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408553df6498705b2b36614320ca0c65bc24a1d9e6",
       "name": "github.com/cachito-testing/gomod-vendor-check-fail",
       "properties": [
         {
@@ -241,7 +241,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20210729213647-8553df649870?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408553df6498705b2b36614320ca0c65bc24a1d9e6",
       "type": "library",
       "version": "v0.0.0-20210729213647-8553df649870"
     },

--- a/tests/integration/test_data/multiple_gomod_and_npm/bom.json
+++ b/tests/integration/test_data/multiple_gomod_and_npm/bom.json
@@ -17,8 +17,8 @@
         "pkg:golang/encoding?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408c76c8dc8c615c25cb48211d95b24d9d171291ff",
+        "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408c76c8dc8c615c25cb48211d95b24d9d171291ff",
         "pkg:golang/github.com/sirupsen/logrus@v1.9.3?type=module",
         "pkg:golang/github.com/sirupsen/logrus@v1.9.3?type=package",
         "pkg:golang/github.com/stretchr/testify@v1.10.0?type=module",
@@ -266,7 +266,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408c76c8dc8c615c25cb48211d95b24d9d171291ff",
       "name": "example.com/greetings",
       "properties": [
         {
@@ -274,12 +274,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408c76c8dc8c615c25cb48211d95b24d9d171291ff",
       "type": "library",
       "version": "v0.0.0-20250515150126-8c76c8dc8c61"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408c76c8dc8c615c25cb48211d95b24d9d171291ff",
       "name": "example.com/greetings",
       "properties": [
         {
@@ -287,7 +287,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408c76c8dc8c615c25cb48211d95b24d9d171291ff",
       "type": "library",
       "version": "v0.0.0-20250515150126-8c76c8dc8c61"
     },

--- a/tests/unit/package_managers/gomod/test_main.py
+++ b/tests/unit/package_managers/gomod/test_main.py
@@ -1577,7 +1577,7 @@ def test_missing_gomod_file(
             [
                 Component(
                     name="github.com/my-org/my-repo",
-                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=module",
+                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=module&vcs_url=git%2Bhttps://github.com/my-org/my-repo.git%40abc123",
                     version="v1.0.0",
                 ),
                 Component(
@@ -1595,7 +1595,7 @@ def test_missing_gomod_file(
                 ),
                 Component(
                     name="github.com/my-org/my-repo",
-                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=package",
+                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=package&vcs_url=git%2Bhttps://github.com/my-org/my-repo.git%40abc123",
                     version="v1.0.0",
                 ),
                 Component(
@@ -1639,12 +1639,12 @@ def test_missing_gomod_file(
             [
                 Component(
                     name="github.com/my-org/my-repo",
-                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=module",
+                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=module&vcs_url=git%2Bhttps://github.com/my-org/my-repo.git%40abc123",
                     version="v1.0.0",
                 ),
                 Component(
                     name="github.com/my-org/my-repo/path",
-                    purl="pkg:golang/github.com/my-org/my-repo/path@v1.0.0?type=module",
+                    purl="pkg:golang/github.com/my-org/my-repo/path@v1.0.0?type=module&vcs_url=git%2Bhttps://github.com/my-org/my-repo.git%40abc123",
                     version="v1.0.0",
                 ),
                 Component(
@@ -1674,7 +1674,9 @@ def test_missing_gomod_file(
 @mock.patch("hermeto.core.package_managers.gomod.main._get_go_work_path")
 @mock.patch("hermeto.core.package_managers.gomod.main._vendor_changed")
 @mock.patch("hermeto.core.package_managers.gomod.main.create_backend_annotation")
+@mock.patch("hermeto.core.package_managers.gomod.main.get_repo_id")
 def test_fetch_gomod_source(
+    mock_get_repo_id: mock.Mock,
     mock_create_annotation: mock.Mock,
     mock_vendor_changed: mock.Mock,
     mock_get_go_work_path: mock.Mock,
@@ -1715,6 +1717,12 @@ def test_fetch_gomod_source(
     mock_find_missing_gomod_files.return_value = []
     mock_get_repository_name.return_value = "github.com/my-org/my-repo"
     mock_vendor_changed.return_value = False
+
+    mock_repo_id = mock.Mock()
+    mock_repo_id.as_vcs_url_qualifier.return_value = (
+        "git+https://github.com/my-org/my-repo.git@abc123"
+    )
+    mock_get_repo_id.return_value = mock_repo_id
 
     mock_tmp_dir.name = "tmpdir"
     mock_tmp_dir.return_value.__enter__.return_value = mock_tmp_dir

--- a/tests/unit/package_managers/gomod/test_main.py
+++ b/tests/unit/package_managers/gomod/test_main.py
@@ -1580,7 +1580,7 @@ def test_missing_gomod_file(
             [
                 Component(
                     name="github.com/my-org/my-repo",
-                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=module",
+                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=module&vcs_url=git%2Bhttps://github.com/my-org/my-repo.git%40abc123",
                     version="v1.0.0",
                 ),
                 Component(
@@ -1598,7 +1598,7 @@ def test_missing_gomod_file(
                 ),
                 Component(
                     name="github.com/my-org/my-repo",
-                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=package",
+                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=package&vcs_url=git%2Bhttps://github.com/my-org/my-repo.git%40abc123",
                     version="v1.0.0",
                 ),
                 Component(
@@ -1642,12 +1642,12 @@ def test_missing_gomod_file(
             [
                 Component(
                     name="github.com/my-org/my-repo",
-                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=module",
+                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=module&vcs_url=git%2Bhttps://github.com/my-org/my-repo.git%40abc123",
                     version="v1.0.0",
                 ),
                 Component(
                     name="github.com/my-org/my-repo/path",
-                    purl="pkg:golang/github.com/my-org/my-repo/path@v1.0.0?type=module",
+                    purl="pkg:golang/github.com/my-org/my-repo/path@v1.0.0?type=module&vcs_url=git%2Bhttps://github.com/my-org/my-repo.git%40abc123",
                     version="v1.0.0",
                 ),
                 Component(
@@ -1677,7 +1677,9 @@ def test_missing_gomod_file(
 @mock.patch("hermeto.core.package_managers.gomod.main._get_go_work_path")
 @mock.patch("hermeto.core.package_managers.gomod.main._vendor_changed")
 @mock.patch("hermeto.core.package_managers.gomod.main.create_backend_annotation")
+@mock.patch("hermeto.core.package_managers.gomod.main.get_repo_id")
 def test_fetch_gomod_source(
+    mock_get_repo_id: mock.Mock,
     mock_create_annotation: mock.Mock,
     mock_vendor_changed: mock.Mock,
     mock_get_go_work_path: mock.Mock,
@@ -1718,6 +1720,12 @@ def test_fetch_gomod_source(
     mock_find_missing_gomod_files.return_value = []
     mock_get_repository_name.return_value = "github.com/my-org/my-repo"
     mock_vendor_changed.return_value = False
+
+    mock_repo_id = mock.Mock()
+    mock_repo_id.as_vcs_url_qualifier.return_value = (
+        "git+https://github.com/my-org/my-repo.git@abc123"
+    )
+    mock_get_repo_id.return_value = mock_repo_id
 
     mock_tmp_dir.name = "tmpdir"
     mock_tmp_dir.return_value.__enter__.return_value = mock_tmp_dir


### PR DESCRIPTION
The gomod backend was not including the `vcs_url` qualifier on PURLs for modules sourced from the local git repository (main module, workspace modules and local replacement modules). 
Other backends (cargo, bundler, pip, npm) already include `vcs_url` for locally-sourced components. 

This brings gomod in line with that behavior.




Resolves: #1434