### PR TITLE
fix(pip): support multi-version python wheel tags

### DIFF
--- a/hermeto/core/package_managers/pip/package_distributions.py
+++ b/hermeto/core/package_managers/pip/package_distributions.py
@@ -368,26 +368,32 @@ class WheelsFilter(BinaryPackageFilter):
             or any(impl in interpreter for impl in self.py_impl)
         )
 
-        wheel_py_version = _parse_py_version(interpreter)
-        compatible_py_version = (
-            self.py_version is None
-            or wheel_py_version == self.py_version
-            or (wheel_py_version < self.py_version and abi in ("abi3", "none"))
+        wheel_py_versions = _parse_py_versions(interpreter)
+        compatible_py_version = self.py_version is None or any(
+            v == self.py_version or (v < self.py_version and abi in ("abi3", "none"))
+            for v in wheel_py_versions
         )
 
         return compatible_py_impl and compatible_py_version
 
 
-def _parse_py_version(interpreter: str) -> int:
-    """
-    >>> _parse_py_version("cp312")
-    312
-    >>> _parse_py_version("pp312")
-    312
-    >>> _parse_py_version("py3")
-    3
-    >>> _parse_py_version("py2.py3")
-    3
+def _parse_py_versions(interpreter: str) -> list[int]:
+    """Parse all Python version numbers from a wheel interpreter tag.
+
+    Supports multi-version compressed tags per PEP 425 (e.g. py38.py39.py310).
+    Some real-world packages on PyPI use these compressed tags, for example
+    semgrep (https://pypi.org/simple/semgrep/).
+
+    >>> _parse_py_versions("cp312")
+    [312]
+    >>> _parse_py_versions("pp312")
+    [312]
+    >>> _parse_py_versions("py3")
+    [3]
+    >>> _parse_py_versions("py2.py3")
+    [2, 3]
+    >>> _parse_py_versions("py38.py39.py310")
+    [38, 39, 310]
     """
     parts = interpreter.split(".")
     versions = []
@@ -400,4 +406,4 @@ def _parse_py_version(interpreter: str) -> int:
     if not versions:
         raise RuntimeError(f"Invalid wheel interpreter: {interpreter}")
 
-    return max(versions)
+    return versions

--- a/tests/unit/package_managers/pip/test_package_distributions.py
+++ b/tests/unit/package_managers/pip/test_package_distributions.py
@@ -10,7 +10,6 @@ from hermeto.core.errors import FetchError, PackageRejected
 from hermeto.core.models.input import PipBinaryFilters
 from hermeto.core.package_managers.pip.package_distributions import (
     WheelsFilter,
-    _parse_py_version,
     _process_prefer_binary_mode,
     _sdist_preference,
     process_package_distributions,
@@ -484,12 +483,6 @@ class TestWheelsFilter:
         with pytest.raises(ValueError):
             PipBinaryFilters(**filter_kwargs)
 
-    def test_parse_py_version_from_interpreter(self) -> None:
-        assert _parse_py_version("cp312") == 312
-        assert _parse_py_version("pp312") == 312
-        assert _parse_py_version("py3") == 3
-        assert _parse_py_version("py2.py3") == 3
-
     def test_filter_with_invalid_wheel_filename_is_skipped(self) -> None:
         filters = PipBinaryFilters()
         wheels_filter = WheelsFilter(filters)
@@ -552,6 +545,9 @@ class TestWheelsFilter:
             ),
             pytest.param(
                 "package-1.0.0-cp313-cp313-linux_x86_64.whl", False, id="higher_py_version"
+            ),
+            pytest.param(
+                "package-1.0.0-py38.py39.py310-none-any.whl", True, id="multi_version_tag_matches"
             ),
         ],
     )


### PR DESCRIPTION
Fixes #1494

This PR updates the pip wheel filter logic to properly support multi-version compressed tags (e.g., `py38.py39.py310`), commonly used by active projects like `semgrep`.

**Changes made:**

-Refactored `_parse_py_version` to `_parse_py_versions` to return a list of all parsed versions instead of just the maximum version.
-Updated `_compatible_tag_interpreter` to evaluate compatibility using `any()` across the returned list.
-Fixed the logic flaw from my previous attempt by keeping the `self.py_version is None` check safely outside the iteration loop.
-Added a specific test case in `test_package_distributions.py` simulating the `semgrep` artifact to explicitly verify multi-version tag compatibility.

**Verification:**

-Verified locally that nox -s python-3.10 passes 100% of tests.
-Formatted and checked with ruff.

Thanks to @eskultety for the feedback on the previous attempt and for helping me get the logic and testing right this time around.