### PR TITLE
tests: integration: Update RPM test data

### DIFF
--- a/tests/integration/test_data/rpm_missing_checksum/bom.json
+++ b/tests/integration/test_data/rpm_missing_checksum/bom.json
@@ -7,7 +7,7 @@
         }
       },
       "subjects": [
-        "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&repository_id=baseos"
+        "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&repository_id=baseos"
       ],
       "text": "hermeto:backend:rpm",
       "timestamp": "2025-01-01T00:00:00Z"
@@ -16,7 +16,7 @@
   "bomFormat": "CycloneDX",
   "components": [
     {
-      "bom-ref": "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&repository_id=baseos",
+      "bom-ref": "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&repository_id=baseos",
       "name": "centos-stream-repos",
       "properties": [
         {
@@ -28,7 +28,7 @@
           "value": "rpms.lock.yaml"
         }
       ],
-      "purl": "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&repository_id=baseos",
+      "purl": "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&repository_id=baseos",
       "type": "library",
       "version": "9.0"
     }

--- a/tests/integration/test_data/rpm_multiple_packages/bom.json
+++ b/tests/integration/test_data/rpm_multiple_packages/bom.json
@@ -8,8 +8,8 @@
       },
       "subjects": [
         "pkg:rpm/centos/alternatives@1.24-2.el9?arch=x86_64&checksum=sha256:1e9effe6f59312207b55f87eaded01e8f238622ad14018ffd33ef49e9ce8d4c6&repository_id=baseos",
-        "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&checksum=sha256:36f90791ba4dc3b160ec9129dbc141b9705081b88aee20a1f1cb883e22d0a584&repository_id=baseos",
-        "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&repository_id=baseos",
+        "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&checksum=sha256:da62952810eacfb857532029a6cfe15049345be202346c3d64e2d067a2149bb8&repository_id=baseos",
+        "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&repository_id=baseos",
         "pkg:rpm/centos/libcom_err@1.46.5-4.el9?arch=x86_64&checksum=sha256:5f9f13137f356f0122caa962dcc0839948584b804f62282a28fcfb1c3d6af549&repository_id=baseos",
         "pkg:rpm/centos/libcom_err@1.46.5-8.el9?arch=x86_64&checksum=sha256:ef43794f39d49b69e12506722e432a497e7f96038e26cab2c34476aad4b3d413&repository_id=baseos"
       ],
@@ -33,7 +33,7 @@
       "version": "1.24"
     },
     {
-      "bom-ref": "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&checksum=sha256:36f90791ba4dc3b160ec9129dbc141b9705081b88aee20a1f1cb883e22d0a584&repository_id=baseos",
+      "bom-ref": "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&checksum=sha256:da62952810eacfb857532029a6cfe15049345be202346c3d64e2d067a2149bb8&repository_id=baseos",
       "name": "centos-stream-repos",
       "properties": [
         {
@@ -41,12 +41,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&checksum=sha256:36f90791ba4dc3b160ec9129dbc141b9705081b88aee20a1f1cb883e22d0a584&repository_id=baseos",
+      "purl": "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&checksum=sha256:da62952810eacfb857532029a6cfe15049345be202346c3d64e2d067a2149bb8&repository_id=baseos",
       "type": "library",
       "version": "9.0"
     },
     {
-      "bom-ref": "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&repository_id=baseos",
+      "bom-ref": "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&repository_id=baseos",
       "name": "centos-stream-repos",
       "properties": [
         {
@@ -58,7 +58,7 @@
           "value": "this-project/rpms.lock.yaml"
         }
       ],
-      "purl": "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&repository_id=baseos",
+      "purl": "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&repository_id=baseos",
       "type": "library",
       "version": "9.0"
     },

--- a/tests/integration/test_data/rpm_multiple_packages_summary/bom.json
+++ b/tests/integration/test_data/rpm_multiple_packages_summary/bom.json
@@ -8,8 +8,8 @@
       },
       "subjects": [
         "pkg:rpm/centos/alternatives@1.24-2.el9?arch=x86_64&checksum=sha256:1e9effe6f59312207b55f87eaded01e8f238622ad14018ffd33ef49e9ce8d4c6&repository_id=baseos",
-        "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&checksum=sha256:36f90791ba4dc3b160ec9129dbc141b9705081b88aee20a1f1cb883e22d0a584&repository_id=baseos",
-        "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&repository_id=baseos",
+        "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&checksum=sha256:da62952810eacfb857532029a6cfe15049345be202346c3d64e2d067a2149bb8&repository_id=baseos",
+        "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&repository_id=baseos",
         "pkg:rpm/centos/libcom_err@1.46.5-4.el9?arch=x86_64&checksum=sha256:5f9f13137f356f0122caa962dcc0839948584b804f62282a28fcfb1c3d6af549&repository_id=baseos",
         "pkg:rpm/centos/libcom_err@1.46.5-8.el9?arch=x86_64&checksum=sha256:ef43794f39d49b69e12506722e432a497e7f96038e26cab2c34476aad4b3d413&repository_id=baseos"
       ],
@@ -37,7 +37,7 @@
       "version": "1.24"
     },
     {
-      "bom-ref": "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&checksum=sha256:36f90791ba4dc3b160ec9129dbc141b9705081b88aee20a1f1cb883e22d0a584&repository_id=baseos",
+      "bom-ref": "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&checksum=sha256:da62952810eacfb857532029a6cfe15049345be202346c3d64e2d067a2149bb8&repository_id=baseos",
       "name": "centos-stream-repos",
       "properties": [
         {
@@ -45,12 +45,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&checksum=sha256:36f90791ba4dc3b160ec9129dbc141b9705081b88aee20a1f1cb883e22d0a584&repository_id=baseos",
+      "purl": "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&checksum=sha256:da62952810eacfb857532029a6cfe15049345be202346c3d64e2d067a2149bb8&repository_id=baseos",
       "type": "library",
       "version": "9.0"
     },
     {
-      "bom-ref": "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&repository_id=baseos",
+      "bom-ref": "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&repository_id=baseos",
       "name": "centos-stream-repos",
       "properties": [
         {
@@ -66,7 +66,7 @@
           "value": "CentOS Stream package repositories"
         }
       ],
-      "purl": "pkg:rpm/centos/centos-stream-repos@9.0-28.el9?arch=noarch&repository_id=baseos",
+      "purl": "pkg:rpm/centos/centos-stream-repos@9.0-36.el9?arch=noarch&repository_id=baseos",
       "type": "library",
       "version": "9.0"
     },


### PR DESCRIPTION
We have to bump the fetched package versions due to 404 errors.