### PR TITLE
fix(pip): handle None entries in AST list fields

### DIFF
--- a/hermeto/core/package_managers/pip/project_files.py
+++ b/hermeto/core/package_managers/pip/project_files.py
@@ -585,9 +585,12 @@ class SetupPY(SetupFile):
                 if setup_call is not None:
                     setup_path.append(ASTPathElement(root_node, name))
                     return setup_call, setup_path
-            # Value is a list of nodes (use any(), nodes will never be mixed with non-nodes)
+            # Value is a list that contains AST nodes. Some lists also contain None
+            # (e.g. Dict.keys uses None to represent ** unpacking).
             elif isinstance(value, list) and any(isinstance(x, ast.AST) for x in value):
                 for i, node in enumerate(value):
+                    if not isinstance(node, ast.AST):
+                        continue
                     setup_call, setup_path = self._find_setup_call(node)
                     if setup_call is not None:
                         setup_path.append(ASTPathElement(root_node, name, i))

--- a/tests/unit/package_managers/pip/test_project_files.py
+++ b/tests/unit/package_managers/pip/test_project_files.py
@@ -1013,6 +1013,21 @@ class TestSetupPY:
                 [],
                 id="none",
             ),
+            pytest.param(
+                dedent(
+                    """
+                    from setuptools import setup
+                    extra = {'bar': False}
+                    opts = {
+                        'foo': True,
+                        **extra,
+                    }
+                    setup(setup_requires=["maturin==0.14.0"], **opts)
+                    """
+                ),
+                ["maturin==0.14.0"],
+                id="dict-unpacking",
+            ),
         ],
     )
     def test_get_setup_requires(


### PR DESCRIPTION
Python's AST represents dict unpacking with None in Dict.keys. The existing code assumed that list fields only contain AST nodes and would therefore crash when encountering None.

Seen in the wild with lxml:
https://github.com/lxml/lxml/blob/283d02ec8966c0e99f4666dc7bdd936479e97246/setup.py#L98