### PR TITLE
yarn: enforce safe defaults for state paths to prevent validation bypass

### DIFF
--- a/hermeto/core/package_managers/yarn/main.py
+++ b/hermeto/core/package_managers/yarn/main.py
@@ -48,33 +48,6 @@ def fetch_yarn_source(request: Request) -> RequestOutput:
     )
 
 
-def _verify_yarnrc_paths(project: Project) -> None:
-    paths_conf_opts = {
-        # pnpDataPath is only configurable in Yarn v3
-        project.yarn_rc.get("pnpDataPath"): "pnpDataPath",
-        project.yarn_rc.get("pnpUnpluggedFolder"): "pnpUnpluggedFolder",
-        project.yarn_rc.get("installStatePath"): "installStatePath",
-        project.yarn_rc.get("patchFolder"): "patchFolder",
-        project.yarn_rc.get("virtualFolder"): "virtualFolder",
-    }
-
-    for path in paths_conf_opts:
-        if path is not None:
-            try:
-                project.source_dir.join_within_root(path)
-            except Exception:
-                raise PackageRejected(
-                    (
-                        f"YarnRC '{paths_conf_opts[path]}={path}' property: path points "
-                        "outside of the source directory"
-                    ),
-                    solution=(
-                        "Make sure that all Yarn RC configuration options specifying a path "
-                        "point to a relative location inside the main repository"
-                    ),
-                )
-
-
 def _check_zero_installs(project: Project) -> None:
     if project.is_zero_installs:
         raise PackageRejected(
@@ -96,7 +69,6 @@ def _check_lockfile(project: Project) -> None:
 
 
 def _verify_repository(project: Project) -> None:
-    _verify_yarnrc_paths(project)
     _check_zero_installs(project)
     _check_lockfile(project)
 
@@ -223,6 +195,13 @@ def _set_yarnrc_configuration(
     yarn_rc["enableScripts"] = False
     yarn_rc["enableGlobalCache"] = True
     yarn_rc["globalFolder"] = str(output_dir.join_within_root("deps", "yarn"))
+    yarn_rc["installStatePath"] = "./.yarn/install-state.gz"
+    yarn_rc["pnpUnpluggedFolder"] = "./.yarn/unplugged"
+    yarn_rc["patchFolder"] = "./.yarn/patches"
+    yarn_rc["virtualFolder"] = "./.yarn/__virtual__"
+    # pnpDataPath is only configurable in Yarn v3
+    if version in VersionsRange("3.0.0", "4.0.0-rc1"):
+        yarn_rc["pnpDataPath"] = "./.pnp.data.json"
 
     config = get_config()
     if (proxy_url := config.yarn.proxy_url) is not None:

--- a/tests/unit/package_managers/yarn/test_main.py
+++ b/tests/unit/package_managers/yarn/test_main.py
@@ -2,7 +2,6 @@
 import re
 from enum import Enum
 from itertools import chain, zip_longest
-from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -25,7 +24,6 @@ from hermeto.core.package_managers.yarn.main import (
     _generate_environment_variables,
     _set_yarnrc_configuration,
     _verify_corepack_yarn_version,
-    _verify_yarnrc_paths,
     fetch_yarn_source,
 )
 from hermeto.core.package_managers.yarn.project import PackageJson, Plugin, YarnRc
@@ -335,28 +333,20 @@ def test_set_yarnrc_configuration(
         "unsafeHttpWhitelist": [],
         "pnpMode": "strict",
         "plugins": expected_plugins,
+        "installStatePath": "./.yarn/install-state.gz",
+        "pnpUnpluggedFolder": "./.yarn/unplugged",
+        "patchFolder": "./.yarn/patches",
+        "virtualFolder": "./.yarn/__virtual__",
     }
+
+    if yarn_version in VersionsRange("3.0.0", "4.0.0-rc1"):
+        expected_data["pnpDataPath"] = "./.pnp.data.json"
 
     if yarn_version in VersionsRange("4.0.0-rc1", "5.0.0"):
         expected_data["enableConstraintsChecks"] = False
 
     assert yarn_rc.data == expected_data
     mock_write.assert_called_once()
-
-
-@mock.patch("hermeto.core.package_managers.yarn.main.get_semver_from_package_manager")
-def test_verify_yarnrc_paths(
-    mock_get_semver: mock.Mock,
-    rooted_tmp_path: RootedPath,
-) -> None:
-    output_dir = rooted_tmp_path.join_within_root("output")
-    yarn_rc = YarnRc(rooted_tmp_path.join_within_root(".yarnrc.yml"), {})
-    project = mock.Mock()
-    project.yarn_rc = yarn_rc
-    project.package_json = mock.MagicMock()
-
-    _set_yarnrc_configuration(project, output_dir, semver.Version.parse("3.0.0"))
-    _verify_yarnrc_paths(project)
 
 
 def test_check_missing_lockfile(rooted_tmp_path: RootedPath) -> None:
@@ -366,29 +356,6 @@ def test_check_missing_lockfile(rooted_tmp_path: RootedPath) -> None:
 
     with pytest.raises(LockfileNotFound):
         _check_lockfile(project)
-
-
-@pytest.mark.parametrize(
-    "opt_path",
-    [
-        pytest.param("/custom/path", id="installStatePath"),
-        pytest.param("/custom/path", id="patchFolder"),
-        pytest.param("/custom/path", id="pnpDataPath"),
-        pytest.param("/custom/path", id="pnpUnpluggedFolder"),
-        pytest.param("/custom/path", id="virtualFolder"),
-    ],
-)
-def test_verify_yarnrc_paths_fail(
-    request: pytest.FixtureRequest, tmp_path: Path, opt_path: str
-) -> None:
-    project = mock.Mock()
-    project.source_dir = tmp_path
-    project.yarn_rc = YarnRc(
-        RootedPath(tmp_path / ".yarnrc.yml"), {request.node.callspec.id: opt_path}
-    )
-
-    with pytest.raises(PackageRejected):
-        _verify_yarnrc_paths(project)
 
 
 def test_generate_environment_variables(yarn_env_variables: list[EnvironmentVariable]) -> None:


### PR DESCRIPTION
# Description
While I was looking into how Hermeto handles Yarn dependencies, I noticed that the `_verify_yarnrc_paths` function uses `RootedPath` to block absolute paths (like `/tmp/something`). It works great for literal strings. However, it evaluates the raw string before Yarn actually runs.
If a user puts an environment variable into a path, like `${TMPDIR:-/tmp}/hermeto_state.gz`, the Python validator sees a string starting with `$`. It assumes this is just a weird relative folder name and lets it pass. But when the Yarn binary actually executes, it resolves that variable to the absolute path and writes the file to the host system.
 
## Impact Assessment
The practical impact of this bypass is significantly limited by several factors:
* In standard production deployments, Hermeto runs within a container. Any file written outside the workspace is still trapped within the container and wiped upon completion.
* Yarn writes these state files as binary GZIP data, so there's no risk of data exfiltration, no RCE, no privilege escalation, and the content isn't chosen by the attacker.
* It requires a clear, readable change to the `.yarnrc.yml` file, which is easily caught during standard PR code reviews or by any AI review bots.

## How to reproduce it locally
```bash
mkdir -p hermeto-yarn-repro && cd hermeto-yarn-repro
git init --bare /tmp/local-origin.git
echo '{"name": "sandbox-escape", "version": "1.0.0", "packageManager": "yarn@3.6.4"}' > package.json

# Enable corepack and generate a valid yarn.lock FIRST
corepack enable
yarn install

# Inject the malicious Yarn configuration with the environment variable payload
cat << 'EOF' > .yarnrc.yml
installStatePath: "${TMPDIR:-/tmp}/hermeto_state.gz"
EOF

git init
git config user.name "Hermeto Tester"
git config user.email "test@example.com"
git remote add origin file:///tmp/local-origin.git
git add .
git commit -m "chore: setup workspace with malicious yarnrc"
git push origin HEAD

# Ensure the host system's /tmp is clean of previous test files
rm -f /tmp/hermeto_state.gz

hermeto fetch-deps --source . --output ./repro_output yarn

# Verify the sandbox escape (File is written to /tmp)
ls -lh /tmp/hermeto_state.gz
```

## Expected behavior
Hermeto should either block the `${...}` syntax during validation, or explicitly override the path to yarn defaults so that `hermeto_state.gz` is written inside the sandbox only and is deleted upon pre-fetch completion.

## Actual behavior
The validator allows the path to pass, and the file is written outside the intended workspace directory within the container.

## Changes
* Overrode `installStatePath`, `pnpUnpluggedFolder`, and `pnpDataPath` to their official Yarn defaults based on yarn docs.
* Removed these from `_verify_yarnrc_paths` since they are now explicitly set by Hermeto.