### PR TITLE
feat(yarn-classic): implement permissive mode for missing lockfiles 

### DIFF
--- a/hermeto/core/package_managers/yarn_classic/main.py
+++ b/hermeto/core/package_managers/yarn_classic/main.py
@@ -7,10 +7,10 @@ from typing import Any
 
 from hermeto import APP_NAME
 from hermeto.core.errors import LockfileNotFound, PackageManagerError, PackageRejected
-from hermeto.core.models.input import Request
-from hermeto.core.models.output import Component, EnvironmentVariable, RequestOutput
+from hermeto.core.models.input import Mode, Request
+from hermeto.core.models.output import Annotation, Component, EnvironmentVariable, RequestOutput
 from hermeto.core.models.property_semantics import PropertySet
-from hermeto.core.models.sbom import create_backend_annotation
+from hermeto.core.models.sbom import create_backend_annotation, spdx_now
 from hermeto.core.package_managers.yarn.utils import (
     VersionsRange,
     extract_yarn_version_from_env,
@@ -50,6 +50,7 @@ class NotV1Lockfile(PackageRejected):
 def fetch_yarn_source(request: Request) -> RequestOutput:
     """Process all the yarn source directories in a request."""
     components: list[Component] = []
+    annotations: list[Annotation] = []
 
     def _ensure_mirror_dir_exists(output_dir: RootedPath) -> None:
         output_dir.join_within_root(MIRROR_DIR).path.mkdir(parents=True, exist_ok=True)
@@ -58,11 +59,15 @@ def fetch_yarn_source(request: Request) -> RequestOutput:
         package_path = request.source_dir.join_within_root(package.path)
         project = Project.from_source_dir(package_path)
 
-        _verify_repository(project)
+        lockfile_generated = _verify_repository(project, request.mode)
         _ensure_mirror_dir_exists(request.output_dir)
-        components.extend(_resolve_yarn_project(project, request.output_dir))
+        package_components = _resolve_yarn_project(project, request.output_dir, lockfile_generated)
 
-    annotations = []
+        if lockfile_generated:
+            _update_permissive_mode_annotation(annotations, package_components)
+
+        components.extend(package_components)
+
     if backend_annotation := create_backend_annotation(components, "yarn-classic"):
         annotations.append(backend_annotation)
     return RequestOutput.from_obj_list(
@@ -73,12 +78,36 @@ def fetch_yarn_source(request: Request) -> RequestOutput:
     )
 
 
-def _resolve_yarn_project(project: Project, output_dir: RootedPath) -> list[Component]:
+def _update_permissive_mode_annotation(
+    annotations: list[Annotation],
+    components: list[Component],
+) -> None:
+    """Update permissive mode SBOM annotation with subjects from the provided components."""
+    text = f"{APP_NAME}:permissive-mode:yarn-classic:generated-lockfile"
+    subjects = set(c.bom_ref for c in components)
+    for annotation in annotations:
+        if annotation.text == text:
+            annotation.subjects.update(subjects)
+            return
+
+    annotations.append(
+        Annotation(
+            subjects=subjects,
+            annotator={"organization": {"name": "red hat"}},
+            timestamp=spdx_now(),
+            text=text,
+        )
+    )
+
+
+def _resolve_yarn_project(
+    project: Project, output_dir: RootedPath, lockfile_generated: bool = False
+) -> list[Component]:
     """Process a request for a single yarn source directory."""
     log.info(f"Fetching the yarn dependencies at the subpath {project.source_dir}")
 
     _verify_corepack_yarn_version(project.source_dir, _get_prefetch_environment_variables())
-    _fetch_dependencies(project.source_dir, output_dir)
+    _fetch_dependencies(project.source_dir, output_dir, lockfile_generated)
     packages = resolve_packages(project, output_dir.join_within_root(MIRROR_DIR))
     _verify_no_offline_mirror_collisions(packages)
 
@@ -135,7 +164,9 @@ def _run_yarn_install(
     run_yarn_cmd(cmd, source_dir, env)
 
 
-def _fetch_dependencies(source_dir: RootedPath, output_dir: RootedPath) -> None:
+def _fetch_dependencies(
+    source_dir: RootedPath, output_dir: RootedPath, lockfile_generated: bool = False
+) -> None:
     """Fetch dependencies for the project.
 
     Install the project dependencies via a two-step process to overcome concurrency
@@ -147,7 +178,7 @@ def _fetch_dependencies(source_dir: RootedPath, output_dir: RootedPath) -> None:
     """
     # Populate the local cache with the project dependencies
     env = _get_prefetch_environment_variables()
-    _run_yarn_install(source_dir, env, frozen_lockfile=True)
+    _run_yarn_install(source_dir, env, frozen_lockfile=not lockfile_generated)
 
     # Populate the offline mirror from the local cache
     # Since the node_modules directory is already populated, we need to force a
@@ -211,18 +242,31 @@ def _reject_if_wrong_lockfile_version(project: Project) -> None:
         raise NotV1Lockfile(project.source_dir)
 
 
-def _reject_if_lockfile_is_missing(project: Project) -> None:
+def _verify_lockfile(project: Project, mode: Mode) -> bool:
     yarnlock_path = _get_path_to_yarn_lock(project)
+
     if not yarnlock_path.exists():
-        raise LockfileNotFound(
-            files=yarnlock_path,
-        )
+        if mode == Mode.PERMISSIVE:
+            log.warning(
+                f"yarn.lock is missing in {project.source_dir}. Continuing due to permissive mode."
+            )
 
+            return True  # no version-check
+        else:
+            raise LockfileNotFound(
+                files=yarnlock_path,
+                solution=f"yarn.lock not found in {project.source_dir}, run `yarn install` or use permissive mode",
+            )
 
-def _verify_repository(project: Project) -> None:
-    _reject_if_lockfile_is_missing(project)
+    # Check lockfile version
     _reject_if_wrong_lockfile_version(project)
+    return False
+
+
+def _verify_repository(project: Project, mode: Mode) -> bool:
+    lockfile_generated = _verify_lockfile(project, mode)
     _reject_if_pnp_install(project)
+    return lockfile_generated
 
 
 def _verify_corepack_yarn_version(source_dir: RootedPath, env: dict[str, str]) -> None:

--- a/tests/unit/package_managers/yarn_classic/test_main.py
+++ b/tests/unit/package_managers/yarn_classic/test_main.py
@@ -126,6 +126,7 @@ def test_fetch_yarn_source(
         text="hermeto:backend:yarn-classic",
     )
     mock_create_annotation.return_value = mock_annotation
+    mock_verify_repository.return_value = False
 
     package_dirs = [
         input_request.source_dir.join_within_root(p.path) for p in input_request.packages
@@ -138,8 +139,10 @@ def test_fetch_yarn_source(
     output = fetch_yarn_source(input_request)
 
     mock_create_project.assert_has_calls([mock.call(path) for path in package_dirs])
-    mock_resolve_yarn.assert_has_calls([mock.call(p, input_request.output_dir) for p in projects])
-    mock_verify_repository.assert_has_calls([mock.call(p) for p in projects])
+    mock_resolve_yarn.assert_has_calls(
+        [mock.call(p, input_request.output_dir, False) for p in projects]
+    )
+    mock_verify_repository.assert_has_calls([mock.call(p, input_request.mode) for p in projects])
 
     expected_output = RequestOutput(
         annotations=[mock_annotation],
@@ -164,12 +167,12 @@ def test_resolve_yarn_project(
     project = _prepare_project(rooted_tmp_path, {})
     output_dir = rooted_tmp_path.join_within_root("output")
 
-    _resolve_yarn_project(project, output_dir)
+    _resolve_yarn_project(project, output_dir, False)
 
     mock_verify_yarn_version.assert_called_once_with(
         project.source_dir, mock_prefetch_env_vars.return_value
     )
-    mock_fetch_dependencies.assert_called_once_with(project.source_dir, output_dir)
+    mock_fetch_dependencies.assert_called_once_with(project.source_dir, output_dir, False)
     mock_resolve_packages.assert_called_once_with(project, output_dir.join_within_root(MIRROR_DIR))
 
 

--- a/tests/unit/package_managers/yarn_classic/test_project.py
+++ b/tests/unit/package_managers/yarn_classic/test_project.py
@@ -5,6 +5,7 @@ import pytest
 from pyarn import lockfile  # type: ignore
 
 from hermeto.core.errors import PackageRejected
+from hermeto.core.models.input import Mode
 from hermeto.core.package_managers.yarn_classic.main import _verify_repository
 from hermeto.core.package_managers.yarn_classic.project import (
     ConfigFile,
@@ -202,7 +203,7 @@ def test_pnp_installs_true(
 
     _setup_pnp_installs(rooted_tmp_path, pnp_kind)
     with pytest.raises(PackageRejected):
-        _verify_repository(project)
+        _verify_repository(project, Mode.STRICT)
 
 
 @pytest.mark.parametrize(
@@ -239,4 +240,4 @@ def test_pnp_installs_false(
 
     project = Project.from_source_dir(rooted_tmp_path)
 
-    _verify_repository(project)
+    _verify_repository(project, Mode.STRICT)


### PR DESCRIPTION
Based on #937 

---
### Description
This PR implements **Permissive Mode** support for Yarn v1 (`yarn_classic`) projects. Previously, a missing `yarn.lock` file resulted in a `LockfileNotFound` error. Under the new logic, when `--mode permissive` is toggled, Hermeto will warn the user and generate a lockfile to proceed with dependency resolution.

### Key Architectural Changes:
The changes are inspired from the current implementation of missing lockfile in cargo.
1.  Merged lockfile existence and version checks into a single `_verify_lockfile` function. 
2.  The verification result (`lockfile_generated: bool`) is explicitly passed through functions.
3.  Updated `_fetch_dependencies` to toggle the Yarn `--frozen-lockfile` flag. If a lockfile was missing and permissive mode is active.
4.  Integrated with `hermeto.core.models.sbom` to annotate the generated SBOM. Components resolved via a generated lockfile are now tagged with `hermeto:permissive-mode:yarn-classic:generated-lockfile`.
5. Updated unit test mock assertions to the updated function signatures. 

### Verification Results
* **Strict Mode:** Verified that Hermeto correctly raises `LockfileNotFound` when `yarn.lock` is missing.
* **Permissive Mode:** Verified that Hermeto logs a warning, resolves dependencies successfully and includes the correct subjects in the SBOM annotations.
*  All existing tests passed.