### PR TITLE
refactor: implement batching of downloads for PyPI requirements

### DIFF
--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -5,7 +5,7 @@ import tarfile
 import zipfile
 from collections.abc import Iterable, Iterator
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 from urllib import parse as urlparse
 
 import pypi_simple
@@ -52,6 +52,11 @@ log = logging.getLogger(__name__)
 
 DEFAULT_BUILD_REQUIREMENTS_FILE = "requirements-build.txt"
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
+
+
+class _PyPIArtifact(NamedTuple):
+    requirement: PipRequirement
+    dpi: DistributionPackageInfo
 
 
 def fetch_pip_source(request: Request) -> RequestOutput:
@@ -321,34 +326,20 @@ def _process_req(
     return download_info
 
 
-def _process_pypi_req(
-    req: PipRequirement,
+def _process_pypi_reqs(
     requirements_file: PipRequirementsFile,
-    index_url: str,
     pip_deps_dir: RootedPath,
-    binary_filters: PipBinaryFilters | None = None,
+    pypi_artifacts: list[_PyPIArtifact],
 ) -> list[dict[str, Any]]:
-    download_infos: list[dict[str, Any]] = []
+    files = {dpi.url: dpi.path for _, dpi in pypi_artifacts if not dpi.path.exists()}
+    if files:
+        log.info("Downloading %d PyPI artifacts", len(files))
+        asyncio.run(async_download_files(files, get_config().runtime.concurrency_limit))
 
-    artifacts: list[DistributionPackageInfo] = process_package_distributions(
-        req, pip_deps_dir, binary_filters, index_url
-    )
-
-    files = {dpi.url: dpi.path for dpi in artifacts if not dpi.path.exists()}
-    asyncio.run(async_download_files(files, get_config().runtime.concurrency_limit))
-
-    for artifact in artifacts:
-        download_infos.append(
-            _process_req(
-                req,
-                requirements_file,
-                pip_deps_dir,
-                artifact.download_info,
-                dpi=artifact,
-            )
-        )
-
-    return download_infos
+    return [
+        _process_req(req, requirements_file, pip_deps_dir, dpi.download_info, dpi=dpi)
+        for req, dpi in pypi_artifacts
+    ]
 
 
 def _process_vcs_req(
@@ -415,17 +406,18 @@ def _download_dependencies(
     pip_deps_dir: RootedPath = output_dir.join_within_root("deps", "pip")
     pip_deps_dir.path.mkdir(parents=True, exist_ok=True)
 
+    pypi_artifacts: list[_PyPIArtifact] = []
     for req in requirements_file.requirements:
         log.info("-- Processing requirement line '%s'", req.download_line)
         if req.kind == "pypi":
-            download_infos: list[dict[str, Any]] = _process_pypi_req(
+            dpis: list[DistributionPackageInfo] = process_package_distributions(
                 req,
-                requirements_file=requirements_file,
-                index_url=options["index_url"] or pypi_simple.PYPI_SIMPLE_ENDPOINT,
-                pip_deps_dir=pip_deps_dir,
-                binary_filters=binary_filters,
+                pip_deps_dir,
+                binary_filters,
+                options["index_url"] or pypi_simple.PYPI_SIMPLE_ENDPOINT,
             )
-            processed.extend(download_infos)
+            pypi_artifacts.extend(_PyPIArtifact(req, dpi) for dpi in dpis)
+            continue
         elif req.kind == "vcs":
             download_info = _process_vcs_req(
                 req,
@@ -445,7 +437,10 @@ def _download_dependencies(
             # Should not happen
             raise RuntimeError(f"Unexpected requirement kind: '{req.kind!r}'")
 
-        log.info("-- Finished processing requirement line '%s'\n", req.download_line)
+        log.info("-- Finished processing requirement line '%s'", req.download_line)
+
+    pypi_download_infos = _process_pypi_reqs(requirements_file, pip_deps_dir, pypi_artifacts)
+    processed.extend(pypi_download_infos)
 
     return processed
 

--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import asyncio
+import functools
 import logging
 import tarfile
 import zipfile
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from pathlib import Path
 from typing import Any, NamedTuple
 from urllib import parse as urlparse
@@ -369,6 +370,16 @@ def _process_url_req(
     return result
 
 
+async def _resolve_pypi_distributions(
+    reqs: list[PipRequirement],
+    resolve_callback: Callable[[PipRequirement], list[DistributionPackageInfo]],
+) -> list[list[DistributionPackageInfo]]:
+    """Resolve PyPI distributions for all requirements concurrently."""
+    loop = asyncio.get_running_loop()
+    tasks = [loop.run_in_executor(None, resolve_callback, req) for req in reqs]
+    return await asyncio.gather(*tasks)
+
+
 def _download_dependencies(
     output_dir: RootedPath,
     requirements_file: PipRequirementsFile,
@@ -406,17 +417,11 @@ def _download_dependencies(
     pip_deps_dir: RootedPath = output_dir.join_within_root("deps", "pip")
     pip_deps_dir.path.mkdir(parents=True, exist_ok=True)
 
-    pypi_artifacts: list[_PyPIArtifact] = []
+    pypi_reqs: list[PipRequirement] = []
     for req in requirements_file.requirements:
         log.info("-- Processing requirement line '%s'", req.download_line)
         if req.kind == "pypi":
-            dpis: list[DistributionPackageInfo] = process_package_distributions(
-                req,
-                pip_deps_dir,
-                binary_filters,
-                options["index_url"] or pypi_simple.PYPI_SIMPLE_ENDPOINT,
-            )
-            pypi_artifacts.extend(_PyPIArtifact(req, dpi) for dpi in dpis)
+            pypi_reqs.append(req)
             continue
         elif req.kind == "vcs":
             download_info = _process_vcs_req(
@@ -439,8 +444,18 @@ def _download_dependencies(
 
         log.info("-- Finished processing requirement line '%s'", req.download_line)
 
-    pypi_download_infos = _process_pypi_reqs(requirements_file, pip_deps_dir, pypi_artifacts)
-    processed.extend(pypi_download_infos)
+    pypi_artifacts: list[_PyPIArtifact] = []
+    if pypi_reqs:
+        resolve_callback = functools.partial(
+            process_package_distributions,
+            pip_deps_dir=pip_deps_dir,
+            binary_filters=binary_filters,
+            index_url=options["index_url"] or pypi_simple.PYPI_SIMPLE_ENDPOINT,
+        )
+        pypi_dpis = asyncio.run(_resolve_pypi_distributions(pypi_reqs, resolve_callback))
+        reqs_dpis_zipped = zip(pypi_reqs, pypi_dpis)
+        pypi_artifacts = [_PyPIArtifact(req, dpi) for req, dpis in reqs_dpis_zipped for dpi in dpis]
+        processed.extend(_process_pypi_reqs(requirements_file, pip_deps_dir, pypi_artifacts))
 
     return processed
 

--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -5,7 +5,7 @@ import tarfile
 import zipfile
 from collections.abc import Iterable, Iterator
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 from urllib import parse as urlparse
 
 import pypi_simple
@@ -52,6 +52,11 @@ log = logging.getLogger(__name__)
 
 DEFAULT_BUILD_REQUIREMENTS_FILE = "requirements-build.txt"
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
+
+
+class _PyPIArtifact(NamedTuple):
+    requirement: PipRequirement
+    dpi: DistributionPackageInfo
 
 
 def fetch_pip_source(request: Request) -> RequestOutput:
@@ -321,34 +326,19 @@ def _process_req(
     return download_info
 
 
-def _process_pypi_req(
-    req: PipRequirement,
+def _process_pypi_reqs(
     requirements_file: PipRequirementsFile,
-    index_url: str,
     pip_deps_dir: RootedPath,
-    binary_filters: PipBinaryFilters | None = None,
+    pypi_artifacts: list[_PyPIArtifact],
 ) -> list[dict[str, Any]]:
-    download_infos: list[dict[str, Any]] = []
+    files = {dpi.url: dpi.path for _, dpi in pypi_artifacts if not dpi.path.exists()}
+    if files:
+        asyncio.run(async_download_files(files, get_config().runtime.concurrency_limit))
 
-    artifacts: list[DistributionPackageInfo] = process_package_distributions(
-        req, pip_deps_dir, binary_filters, index_url
-    )
-
-    files = {dpi.url: dpi.path for dpi in artifacts if not dpi.path.exists()}
-    asyncio.run(async_download_files(files, get_config().runtime.concurrency_limit))
-
-    for artifact in artifacts:
-        download_infos.append(
-            _process_req(
-                req,
-                requirements_file,
-                pip_deps_dir,
-                artifact.download_info,
-                dpi=artifact,
-            )
-        )
-
-    return download_infos
+    return [
+        _process_req(req, requirements_file, pip_deps_dir, dpi.download_info, dpi=dpi)
+        for req, dpi in pypi_artifacts
+    ]
 
 
 def _process_vcs_req(
@@ -415,17 +405,18 @@ def _download_dependencies(
     pip_deps_dir: RootedPath = output_dir.join_within_root("deps", "pip")
     pip_deps_dir.path.mkdir(parents=True, exist_ok=True)
 
+    pypi_artifacts: list[_PyPIArtifact] = []
     for req in requirements_file.requirements:
         log.info("-- Processing requirement line '%s'", req.download_line)
         if req.kind == "pypi":
-            download_infos: list[dict[str, Any]] = _process_pypi_req(
+            dpis: list[DistributionPackageInfo] = process_package_distributions(
                 req,
-                requirements_file=requirements_file,
-                index_url=options["index_url"] or pypi_simple.PYPI_SIMPLE_ENDPOINT,
-                pip_deps_dir=pip_deps_dir,
-                binary_filters=binary_filters,
+                pip_deps_dir,
+                binary_filters,
+                options["index_url"] or pypi_simple.PYPI_SIMPLE_ENDPOINT,
             )
-            processed.extend(download_infos)
+            pypi_artifacts.extend(_PyPIArtifact(req, dpi) for dpi in dpis)
+            continue
         elif req.kind == "vcs":
             download_info = _process_vcs_req(
                 req,
@@ -445,7 +436,14 @@ def _download_dependencies(
             # Should not happen
             raise RuntimeError(f"Unexpected requirement kind: '{req.kind!r}'")
 
-        log.info("-- Finished processing requirement line '%s'\n", req.download_line)
+        log.info("-- Finished processing requirement line '%s'", req.download_line)
+
+    pypi_download_infos = _process_pypi_reqs(requirements_file, pip_deps_dir, pypi_artifacts)
+    processed.extend(pypi_download_infos)
+
+    for req in requirements_file.requirements:
+        if req.kind == "pypi":
+            log.info("-- Finished processing requirement line '%s'", req.download_line)
 
     return processed
 

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -517,7 +517,6 @@ class TestDownload:
         index_url: str | None,
         binary_filters: PipBinaryFilters | None,
         rooted_tmp_path: RootedPath,
-        caplog: pytest.LogCaptureFixture,
     ) -> None:
         """
         Test dependency downloading.
@@ -525,12 +524,17 @@ class TestDownload:
         Mock the helper functions used for downloading here, test them properly elsewhere.
         """
         # <setup>
-        req = mock_requirement(
+        foo_req = mock_requirement(
             "foo", "pypi", download_line="foo==1.0", version_specs=[("==", "1.0")]
         )
         # match sdist hash, match wheel0 hash, mismatch wheel1 hash, no hash
         # for wheel2
-        req.hashes = ["sha256:abcdef", "sha256:defabc", "sha256:feebaa"]
+        foo_req.hashes = ["sha256:abcdef", "sha256:defabc", "sha256:feebaa"]
+
+        bar_req = mock_requirement(
+            "bar", "pypi", download_line="bar==2.0", version_specs=[("==", "2.0")]
+        )
+        bar_req.hashes = ["sha256:bbbbbb"]
 
         pypi_checksum_sdist = ChecksumInfo("sha256", "abcdef")
         pypi_checksum_wheels = [
@@ -552,7 +556,7 @@ class TestDownload:
             options.append(index_url)
 
         req_file = mock_requirements_file(
-            requirements=[req],
+            requirements=[foo_req, bar_req],
             options=options,
         )
 
@@ -560,26 +564,26 @@ class TestDownload:
 
         pip_deps = rooted_tmp_path.join_within_root("deps", "pip")
 
-        sdist_download = pip_deps.join_within_root("foo-1.0.tar.gz").path
+        foo_sdist_download = pip_deps.join_within_root("foo-1.0.tar.gz").path
 
-        sdist_DPI = mock_distribution_package_info(
+        foo_sdist_DPI = mock_distribution_package_info(
             "foo",
-            path=sdist_download,
+            path=foo_sdist_download,
             index_url=expect_index_url,
             pypi_checksum={pypi_checksum_sdist},
             req_file_checksums=set() if missing_req_file_checksum else {req_file_checksum_sdist},
         )
-        sdist_d_i = sdist_DPI.download_info | {
+        foo_sdist_d_i = foo_sdist_DPI.download_info | {
             "kind": "pypi",
             "requirement_file": str(req_file.file_path.subpath_from_root),
             "missing_req_file_checksum": missing_req_file_checksum,
             "package_type": "sdist",
             "index_url": expect_index_url,
         }
-        verify_sdist_checksum_call = mock.call(sdist_download, {pypi_checksum_sdist})
-        expected_downloads = [sdist_d_i]
+        verify_foo_sdist_checksum_call = mock.call(foo_sdist_download, {pypi_checksum_sdist})
+        expected_downloads = [foo_sdist_d_i]
 
-        wheels_DPI: list[pip.DistributionPackageInfo] = []
+        foo_wheels_DPI: list[pip.DistributionPackageInfo] = []
         if binary_filters is not None:
             wheel_0_download = pip_deps.join_within_root("foo-1.0-cp35-many-linux.whl").path
             wheel_1_download = pip_deps.join_within_root("foo-1.0-cp25-win32.whl").path
@@ -600,7 +604,7 @@ class TestDownload:
                         set() if missing_req_file_checksum else req_file_checksums_wheels
                     ),
                 )
-                wheels_DPI.append(dpi)
+                foo_wheels_DPI.append(dpi)
                 wheel_downloads.append(
                     dpi.download_info
                     | {
@@ -623,19 +627,47 @@ class TestDownload:
             )
             expected_downloads.extend(wheel_downloads)
 
-        mock_process_package_distributions.return_value = [sdist_DPI] + wheels_DPI
+        bar_pypi_checksum = ChecksumInfo("sha256", "bbbbbb")
+        bar_sdist_download = pip_deps.join_within_root("bar-2.0.tar.gz").path
+        bar_sdist_DPI = mock_distribution_package_info(
+            "bar",
+            version="2.0",
+            path=bar_sdist_download,
+            url="https://pypi.org/bar-2.0.tar.gz",
+            index_url=expect_index_url,
+            pypi_checksum={bar_pypi_checksum},
+            req_file_checksums=set() if missing_req_file_checksum else {bar_pypi_checksum},
+        )
+        expected_downloads.append(
+            bar_sdist_DPI.download_info
+            | {
+                "kind": "pypi",
+                "requirement_file": str(req_file.file_path.subpath_from_root),
+                "missing_req_file_checksum": missing_req_file_checksum,
+                "package_type": "sdist",
+                "index_url": expect_index_url,
+            }
+        )
 
+        mock_process_package_distributions.side_effect = [
+            [foo_sdist_DPI] + foo_wheels_DPI,
+            [bar_sdist_DPI],
+        ]
+
+        checksum_side_effects: list[PackageRejected | None] = []
         if binary_filters is not None:
-            mock_must_match_any_checksum.side_effect = [
-                None,  # sdist_download
+            checksum_side_effects = [
+                None,  # foo_sdist_download
                 None,  # wheel_0_download - checksums OK
                 PackageRejected("", solution=None),  # wheel_1_download - checksums NOK
                 PackageRejected("", solution=None),  # wheel_2_download - no checksums to verify
             ]
         else:
-            mock_must_match_any_checksum.side_effect = [
-                None,  # sdist_download
+            checksum_side_effects = [
+                None,  # foo_sdist_download
             ]
+        checksum_side_effects.append(None)  # bar_sdist_download
+        mock_must_match_any_checksum.side_effect = checksum_side_effects
         # </setup>
 
         # <call>
@@ -645,14 +677,28 @@ class TestDownload:
         # </call>
 
         # <check calls that must always be made>
-        mock_check_metadata_in_sdist.assert_called_once_with(sdist_DPI.path)
-        mock_process_package_distributions.assert_called_once_with(
-            req, pip_deps, binary_filters, expect_index_url
-        )
+        assert mock_check_metadata_in_sdist.call_count == 2
+        mock_check_metadata_in_sdist.assert_any_call(foo_sdist_DPI.path)
+        mock_check_metadata_in_sdist.assert_any_call(bar_sdist_DPI.path)
+
+        assert mock_process_package_distributions.call_count == 2
         # </check calls that must always be made>
 
+        # <check batch download>
+        mock_async_download_files.assert_called_once()
+        batched_files = mock_async_download_files.call_args[0][0]
+        expected_batch: dict[str, Path] = {
+            foo_sdist_DPI.url: foo_sdist_download,
+            bar_sdist_DPI.url: bar_sdist_download,
+        }
+        if binary_filters is not None:
+            for dpi in foo_wheels_DPI:
+                expected_batch[dpi.url] = dpi.path
+        assert batched_files == expected_batch
+        # </check batch download>
+
         verify_checksums_calls = [
-            verify_sdist_checksum_call,
+            verify_foo_sdist_checksum_call,
         ]
 
         if binary_filters is not None:
@@ -672,6 +718,8 @@ class TestDownload:
                         verify_wheel1_checksum_call,
                     ]
                 )
+
+        verify_checksums_calls.append(mock.call(bar_sdist_download, {bar_pypi_checksum}))
 
         mock_must_match_any_checksum.assert_has_calls(verify_checksums_calls)
         assert mock_must_match_any_checksum.call_count == len(verify_checksums_calls)

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -678,21 +678,6 @@ class TestDownload:
 
         # </check calls to checksum verification method>
 
-        # <check basic logging output>
-        assert f"-- Processing requirement line '{req.download_line}'" in caplog.text
-        assert (
-            f"Successfully processed '{req.download_line}' in path 'deps/pip/foo-1.0.tar.gz'"
-        ) in caplog.text
-        # </check basic logging output>
-
-        # <check downloaded wheels>
-        if binary_filters is not None:
-            # wheel 1 does not match any checksums
-            assert (
-                f"Download '{wheel_1_download.name}' was removed from the output directory"
-            ) in caplog.text
-        # </check downloaded wheels>
-
     @pytest.mark.parametrize("checksum_match", [True, False])
     @pytest.mark.parametrize("trusted_hosts", [[], ["example.org"]])
     @mock.patch("hermeto.core.package_managers.pip.main._download_url_package")


### PR DESCRIPTION
## Summary
- Implement batching of downloads for PyPI requirements
- Add unit test coverage for the batching behavior

## Context
Based on the work in #1478 by @victor-adebowale-momodu.

Closes: https://github.com/hermetoproject/hermeto/issues/1456
Closes #1478 