### PR TITLE
test: unit: conftest: Strip GIT_* env vars from the test session

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-only
+import os
 import sys
 import tarfile
 from pathlib import Path
@@ -11,6 +12,13 @@ from hermeto.core.rooted_path import RootedPath
 from hermeto.core.type_aliases import StrPath
 
 FileContents = str
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _clean_git_env() -> None:
+    """Strip selected GIT_ env vars that leak from outer git operations."""
+    for var in ("GIT_DIR",):
+        os.environ.pop(var, None)
 
 
 def _create_git_repo(path: Path, files: dict[StrPath, FileContents] | None = None) -> git.Repo:


### PR DESCRIPTION
When tests run outside the main repo context, i.e. from a git worktree, more specifically - in an interactive rebase - git sets an environment variable GIT_DIR to point to the original repo since we don't have .git metadata in a worktree.

    $ git rebase main -i -x 'env | grep GIT_'
    Executing: env | grep GIT_
    GIT_DIR=<path>/hermeto.git/.git/worktrees/hermeto-test
    GIT_EXEC_PATH=/usr/libexec/git-core
    GIT_PREFIX=

This causes our _create_git_repo unit test helper to indirectly re-initialize the main git repo via Repo.init() due to `git init <path>` actually ignoring <path> and instead working with what `GIT_DIR` is pointing to, a snippet from `git-init` man page:

    If the GIT_DIR environment variable is set then it specifies a path
    to use instead of ./.git for the base of the repository.

Add a session-scoped autouse fixture that strips all GIT_* environment variables once at the start of the test session, because:
1. we are creating a temporary test git repo anyway
2. a clean git environment for such a test git repo is desirable anyway