### PR TITLE
tests: integration: Update rpm data

### DIFF
--- a/tests/integration/test_data/rpm_e2e/bom.json
+++ b/tests/integration/test_data/rpm_e2e/bom.json
@@ -8,9 +8,9 @@
       },
       "subjects": [
         "pkg:rpm/centos/gpm-libs@1.20.7-29.el9?arch=x86_64&checksum=sha256:d669a8aaabc03d8a44330f0d8115f87fbedc9396b554c592d66a0bd718a8e4cd&repository_id=appstream",
-        "pkg:rpm/centos/vim-common@8.2.2637-22.el9?arch=x86_64&checksum=sha256:fe58dadda94c42e502c1064387102134464948d2e1cd4bb4f93731cfa91d2b8e&epoch=2&repository_id=appstream",
-        "pkg:rpm/centos/vim-enhanced@8.2.2637-22.el9?arch=x86_64&checksum=sha256:ada993fa54366659f4118677cdb76eb30093ac71d86fe94c56ef87305be9bddc&epoch=2&repository_id=appstream",
-        "pkg:rpm/centos/vim-filesystem@8.2.2637-22.el9?arch=noarch&checksum=sha256:b767597168aad6a36fe82578422eba27bfca5ffb01c501a9df9e532e68c853ff&epoch=2&repository_id=baseos",
+        "pkg:rpm/centos/vim-common@8.2.2637-28.el9?arch=x86_64&checksum=sha256:225b9336591f2adb2616ee87b3296dd7d3244a5d01d857219e474691e127825e&epoch=2&repository_id=appstream",
+        "pkg:rpm/centos/vim-enhanced@8.2.2637-28.el9?arch=x86_64&checksum=sha256:b843e15aeb437ab3a12c97d07f47490617220b0c2534cef76450e43aa2a5322a&epoch=2&repository_id=appstream",
+        "pkg:rpm/centos/vim-filesystem@8.2.2637-28.el9?arch=noarch&checksum=sha256:041476da470f7cf2abdefecb441573f6a71649b86f747c5e6a33a9b6810064a3&epoch=2&repository_id=baseos",
         "pkg:rpm/centos/which@2.21-30.el9?arch=x86_64&checksum=sha256:d602350243d5950c473624788e78e783461e5db242cc0a2d7a988e1b9a3e079b&repository_id=baseos"
       ],
       "text": "hermeto:backend:rpm",
@@ -33,7 +33,7 @@
       "version": "1.20.7"
     },
     {
-      "bom-ref": "pkg:rpm/centos/vim-common@8.2.2637-22.el9?arch=x86_64&checksum=sha256:fe58dadda94c42e502c1064387102134464948d2e1cd4bb4f93731cfa91d2b8e&epoch=2&repository_id=appstream",
+      "bom-ref": "pkg:rpm/centos/vim-common@8.2.2637-28.el9?arch=x86_64&checksum=sha256:225b9336591f2adb2616ee87b3296dd7d3244a5d01d857219e474691e127825e&epoch=2&repository_id=appstream",
       "name": "vim-common",
       "properties": [
         {
@@ -41,12 +41,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:rpm/centos/vim-common@8.2.2637-22.el9?arch=x86_64&checksum=sha256:fe58dadda94c42e502c1064387102134464948d2e1cd4bb4f93731cfa91d2b8e&epoch=2&repository_id=appstream",
+      "purl": "pkg:rpm/centos/vim-common@8.2.2637-28.el9?arch=x86_64&checksum=sha256:225b9336591f2adb2616ee87b3296dd7d3244a5d01d857219e474691e127825e&epoch=2&repository_id=appstream",
       "type": "library",
       "version": "8.2.2637"
     },
     {
-      "bom-ref": "pkg:rpm/centos/vim-enhanced@8.2.2637-22.el9?arch=x86_64&checksum=sha256:ada993fa54366659f4118677cdb76eb30093ac71d86fe94c56ef87305be9bddc&epoch=2&repository_id=appstream",
+      "bom-ref": "pkg:rpm/centos/vim-enhanced@8.2.2637-28.el9?arch=x86_64&checksum=sha256:b843e15aeb437ab3a12c97d07f47490617220b0c2534cef76450e43aa2a5322a&epoch=2&repository_id=appstream",
       "name": "vim-enhanced",
       "properties": [
         {
@@ -54,12 +54,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:rpm/centos/vim-enhanced@8.2.2637-22.el9?arch=x86_64&checksum=sha256:ada993fa54366659f4118677cdb76eb30093ac71d86fe94c56ef87305be9bddc&epoch=2&repository_id=appstream",
+      "purl": "pkg:rpm/centos/vim-enhanced@8.2.2637-28.el9?arch=x86_64&checksum=sha256:b843e15aeb437ab3a12c97d07f47490617220b0c2534cef76450e43aa2a5322a&epoch=2&repository_id=appstream",
       "type": "library",
       "version": "8.2.2637"
     },
     {
-      "bom-ref": "pkg:rpm/centos/vim-filesystem@8.2.2637-22.el9?arch=noarch&checksum=sha256:b767597168aad6a36fe82578422eba27bfca5ffb01c501a9df9e532e68c853ff&epoch=2&repository_id=baseos",
+      "bom-ref": "pkg:rpm/centos/vim-filesystem@8.2.2637-28.el9?arch=noarch&checksum=sha256:041476da470f7cf2abdefecb441573f6a71649b86f747c5e6a33a9b6810064a3&epoch=2&repository_id=baseos",
       "name": "vim-filesystem",
       "properties": [
         {
@@ -67,7 +67,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:rpm/centos/vim-filesystem@8.2.2637-22.el9?arch=noarch&checksum=sha256:b767597168aad6a36fe82578422eba27bfca5ffb01c501a9df9e532e68c853ff&epoch=2&repository_id=baseos",
+      "purl": "pkg:rpm/centos/vim-filesystem@8.2.2637-28.el9?arch=noarch&checksum=sha256:041476da470f7cf2abdefecb441573f6a71649b86f747c5e6a33a9b6810064a3&epoch=2&repository_id=baseos",
       "type": "library",
       "version": "8.2.2637"
     },

--- a/tests/integration/test_data/rpm_e2e/fetch_deps_sha256sums.json
+++ b/tests/integration/test_data/rpm_e2e/fetch_deps_sha256sums.json
@@ -1,7 +1,7 @@
 {
   "rpm/x86_64/appstream/gpm-libs-1.20.7-29.el9.x86_64.rpm": "sha256:d669a8aaabc03d8a44330f0d8115f87fbedc9396b554c592d66a0bd718a8e4cd",
-  "rpm/x86_64/appstream/vim-common-8.2.2637-22.el9.x86_64.rpm": "sha256:fe58dadda94c42e502c1064387102134464948d2e1cd4bb4f93731cfa91d2b8e",
-  "rpm/x86_64/appstream/vim-enhanced-8.2.2637-22.el9.x86_64.rpm": "sha256:ada993fa54366659f4118677cdb76eb30093ac71d86fe94c56ef87305be9bddc",
-  "rpm/x86_64/baseos/vim-filesystem-8.2.2637-22.el9.noarch.rpm": "sha256:b767597168aad6a36fe82578422eba27bfca5ffb01c501a9df9e532e68c853ff",
+  "rpm/x86_64/appstream/vim-common-8.2.2637-28.el9.x86_64.rpm": "sha256:225b9336591f2adb2616ee87b3296dd7d3244a5d01d857219e474691e127825e",
+  "rpm/x86_64/appstream/vim-enhanced-8.2.2637-28.el9.x86_64.rpm": "sha256:b843e15aeb437ab3a12c97d07f47490617220b0c2534cef76450e43aa2a5322a",
+  "rpm/x86_64/baseos/vim-filesystem-8.2.2637-28.el9.noarch.rpm": "sha256:041476da470f7cf2abdefecb441573f6a71649b86f747c5e6a33a9b6810064a3",
   "rpm/x86_64/baseos/which-2.21-30.el9.x86_64.rpm": "sha256:d602350243d5950c473624788e78e783461e5db242cc0a2d7a988e1b9a3e079b"
 }


### PR DESCRIPTION
CentOS evicted more package versions from the repo index, we need updating.

**Depends on:** https://github.com/hermetoproject/integration-tests/pull/83