### PR TITLE
fix(pip): gracefully skip sdist artifacts on checksum mismatch

### DIFF
--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -281,7 +281,7 @@ def _process_req(
     pip_deps_dir: RootedPath,
     download_info: dict[str, Any],
     dpi: DistributionPackageInfo | None = None,
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     download_info["kind"] = req.kind
     download_info["requirement_file"] = str(requirements_file.file_path.subpath_from_root)
     download_info["missing_req_file_checksum"] = True
@@ -289,19 +289,22 @@ def _process_req(
 
     def _checksum_must_match_or_path_unlink(
         path: Path, checksum_info: Iterable[ChecksumInfo]
-    ) -> None:
+    ) -> bool:
         try:
             # returns None, raises PackageRejected on failure
             must_match_any_checksum(path, checksum_info)
+            return True
         except PackageRejected:
-            path.unlink()
+            path.unlink(missing_ok=True)
             log.warning("Download '%s' was removed from the output directory", path.name)
+            return False
 
     if dpi:
         if dpi.req_file_checksums:
             download_info["missing_req_file_checksum"] = False
         if dpi.checksums_to_match:
-            _checksum_must_match_or_path_unlink(dpi.path, dpi.checksums_to_match)
+            if not _checksum_must_match_or_path_unlink(dpi.path, dpi.checksums_to_match):
+                return None
         if dpi.package_type == "sdist":
             _check_metadata_in_sdist(dpi.path)
         download_info["package_type"] = dpi.package_type
@@ -314,9 +317,10 @@ def _process_req(
             hashes = req.hashes
             if hashes:
                 download_info["missing_req_file_checksum"] = False
-                _checksum_must_match_or_path_unlink(
+                if not _checksum_must_match_or_path_unlink(
                     download_info["path"], list(map(ChecksumInfo.from_hash, hashes))
-                )
+                ):
+                    return None
 
     log.debug(
         "Successfully processed '%s' in path '%s'",
@@ -337,15 +341,18 @@ def _process_pypi_reqs(
         log.info("Downloading %d PyPI artifacts", len(files))
         asyncio.run(async_download_files(files, get_config().runtime.concurrency_limit))
 
-    return [
-        _process_req(req, requirements_file, pip_deps_dir, dpi.download_info, dpi=dpi)
-        for req, dpi in pypi_artifacts
-    ]
+    download_infos = []
+    for req, dpi in pypi_artifacts:
+        res = _process_req(req, requirements_file, pip_deps_dir, dpi.download_info, dpi=dpi)
+        if res is not None:
+            download_infos.append(res)
+
+    return download_infos
 
 
 def _process_vcs_req(
     req: PipRequirement, pip_deps_dir: RootedPath, **kwargs: Any
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     return _process_req(
         req,
         pip_deps_dir=pip_deps_dir,
@@ -356,13 +363,15 @@ def _process_vcs_req(
 
 def _process_url_req(
     req: PipRequirement, pip_deps_dir: RootedPath, trusted_hosts: set[str], **kwargs: Any
-) -> dict[str, Any]:
+) -> dict[str, Any] | None:
     result = _process_req(
         req,
         pip_deps_dir=pip_deps_dir,
         download_info=_download_url_package(req, pip_deps_dir, trusted_hosts),
         **kwargs,
     )
+    if result is None:
+        return None
     parsed_url = urlparse.urlparse(req.url)
     if parsed_url.path.endswith(WHEEL_FILE_EXTENSION):
         result["package_type"] = "wheel"
@@ -429,7 +438,8 @@ def _download_dependencies(
                 requirements_file=requirements_file,
                 pip_deps_dir=pip_deps_dir,
             )
-            processed.append(download_info)
+            if download_info is not None:
+                processed.append(download_info)
         elif req.kind == "url":
             download_info = _process_url_req(
                 req,
@@ -437,7 +447,8 @@ def _download_dependencies(
                 pip_deps_dir=pip_deps_dir,
                 trusted_hosts=trusted_hosts,
             )
-            processed.append(download_info)
+            if download_info is not None:
+                processed.append(download_info)
         else:
             # Should not happen
             raise RuntimeError(f"Unexpected requirement kind: '{req.kind!r}'")

--- a/hermeto/core/package_managers/pip/package_distributions.py
+++ b/hermeto/core/package_managers/pip/package_distributions.py
@@ -369,10 +369,23 @@ class WheelsFilter(BinaryPackageFilter):
         )
 
         wheel_py_versions = _parse_py_versions(interpreter)
-        compatible_py_version = self.py_version is None or any(
-            v == self.py_version or (v < self.py_version and abi in ("abi3", "none"))
-            for v in wheel_py_versions
+
+        # we compare strings because e.g. '312' is all we get from parsing wheel interpreter tag
+        is_same_major_ver = lambda other, this: str(other)[0] == str(this)[0]
+        is_versions_match = lambda other, this: other == this
+        is_compatible_abi = lambda abi: abi in ("abi3", "none")
+        is_version_superseded = lambda other, this: (other < this) and is_compatible_abi(abi)
+        is_compatible_candidate = lambda other, this: (
+            is_same_major_ver(other, this)
+            and (is_versions_match(other, this) or is_version_superseded(other, this))
         )
+
+        this = self.py_version
+        some_candidate_is_compatible = any(
+            is_compatible_candidate(v, this) for v in wheel_py_versions
+        )
+
+        compatible_py_version = self.py_version is None or some_candidate_is_compatible
 
         return compatible_py_impl and compatible_py_version
 

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -625,7 +625,11 @@ class TestDownload:
             verify_wheel2_checksum_call = mock.call(
                 wheel_2_download, {ChecksumInfo("sha256", "cbafed")}
             )
-            expected_downloads.extend(wheel_downloads)
+            # wheel_0 is OK, wheel_1 is skipped due to mismatch
+            # wheel_2 is skipped if missing_req_file_checksum is True, else it succeeds
+            expected_downloads.append(wheel_downloads[0])
+            if not missing_req_file_checksum:
+                expected_downloads.append(wheel_downloads[2])
 
         bar_pypi_checksum = ChecksumInfo("sha256", "bbbbbb")
         bar_sdist_download = pip_deps.join_within_root("bar-2.0.tar.gz").path
@@ -660,8 +664,9 @@ class TestDownload:
                 None,  # foo_sdist_download
                 None,  # wheel_0_download - checksums OK
                 PackageRejected("", solution=None),  # wheel_1_download - checksums NOK
-                PackageRejected("", solution=None),  # wheel_2_download - no checksums to verify
             ]
+            if missing_req_file_checksum:
+                checksum_side_effects.append(PackageRejected("", solution=None))  # wheel_2_download
         else:
             checksum_side_effects = [
                 None,  # foo_sdist_download
@@ -802,9 +807,12 @@ class TestDownload:
 
         # <call>
         found_download = pip._download_dependencies(rooted_tmp_path, req_file, None)
-        expected_download = [
-            url_download_info | {"kind": "url"},
-        ]
+        if not checksum_match:
+            expected_download = []
+        else:
+            expected_download = [
+                url_download_info | {"kind": "url"},
+            ]
         assert found_download == expected_download
         assert pip_deps.path.is_dir()
         # </call>
@@ -828,10 +836,11 @@ class TestDownload:
 
         # <check basic logging output>
         assert f"-- Processing requirement line '{url_req.download_line}'" in caplog.text
-        assert (
-            f"Successfully processed '{url_req.download_line}' in path 'deps/pip/external-bar/"
-            f"bar-external-sha256-654321.tar.gz'"
-        ) in caplog.text
+        if checksum_match:
+            assert (
+                f"Successfully processed '{url_req.download_line}' in path 'deps/pip/external-bar/"
+                f"bar-external-sha256-654321.tar.gz'"
+            ) in caplog.text
         # </check basic logging output>
 
     @mock.patch("hermeto.core.package_managers.pip.main._download_vcs_package")
@@ -1797,4 +1806,5 @@ def test_process_url_req(
     req = mock_requirement("pkg", "url", url=test_url)
     mock_process_req.return_value = {"package_type": ""}
     result = pip._process_url_req(req, pip_deps_dir=mock.Mock(), trusted_hosts=set())
+    assert result is not None
     assert result.get("package_type") == expected_type


### PR DESCRIPTION
### Problem
When a PyPI sdist package fails checksum validation, it is removed from disk by `_checksum_must_match_or_path_unlink`. However, its processing continued unconditionally to metadata extraction, leading to an unhandled `FileNotFoundError` crash.

### Solution
Following the design that an invalid artifact should be skipped rather than crashing the tool (or returning a silent success with missing files), this PR updates `_process_req` to cleanly return `None` when checksum validation fails and the file is unlinked. The callers are updated to filter out these skipped artifacts so they do not proceed to metadata extraction or SBOM generation.

Fixes #1523
