### PR TITLE
feat(ci): add PR readiness check workflow

### DIFF
--- a/.github/workflows/pr-readiness.yml
+++ b/.github/workflows/pr-readiness.yml
@@ -1,0 +1,160 @@
+# NOTE:
+# We intentionally use pull_request_target to allow commenting on fork PRs.
+# This workflow NEVER checks out or executes PR code.
+# It only reads commit metadata via the GitHub API.
+
+name: PR Readiness Check
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  pr-readiness:
+    name: Review Readiness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR readiness
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pull_number = context.issue.number;
+            const COMMENT_MARKER = "<!-- pr-readiness-check -->";
+            const CONTRIBUTING_URL = `https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md`;
+            const DCO_URL = "https://developercertificate.org/";
+
+            // Fetch all commits in the PR (paginated)
+            const commits = await github.paginate(
+              github.rest.pulls.listCommits,
+              { owner, repo, pull_number }
+            );
+
+            const mergeCommits = [];
+            const missingDCO = [];
+            const emptyMessages = [];
+            const missingDesc = [];
+
+            for (const c of commits) {
+              const msg = c.commit.message;
+              const sha = c.sha.substring(0, 7);
+              const commitLink = `[${sha}](https://github.com/${owner}/${repo}/commit/${c.sha})`;
+              const firstLine = msg.split("\n")[0].trim();
+
+              // 1. Merge commit detection (skip other checks — fix is to remove it)
+              if (firstLine.startsWith("Merge branch") || firstLine.startsWith("Merge remote")) {
+                mergeCommits.push(commitLink);
+                continue;
+              }
+
+              // 2. Missing DCO sign-off
+              const hasDCO = /Signed-off-by:\s+.+<.+@.+>/i.test(msg);
+              if (!hasDCO) {
+                missingDCO.push(commitLink);
+              }
+
+              // 3. Empty or missing commit message description
+              if (firstLine.length === 0) {
+                emptyMessages.push(commitLink);
+              } else {
+                const bodyLines = msg.split("\n").slice(1).join("\n").trim();
+                // Remove trailers (Signed-off-by, Co-authored-by, etc.) to check actual body
+                const bodyWithoutTrailers = bodyLines
+                  .split("\n")
+                  .filter(line => !/^(Signed-off-by|Co-authored-by|Assisted-by|Acked-by|Reviewed-by):/i.test(line.trim()))
+                  .join("\n")
+                  .trim();
+                if (bodyWithoutTrailers.length === 0) {
+                  missingDesc.push(commitLink);
+                }
+              }
+            }
+
+            // Build grouped issues
+            const issues = [];
+            const pl = (arr) => arr.length === 1 ? "commit" : "commits";
+
+            if (mergeCommits.length > 0) {
+              issues.push(
+                `- **Merge commit detected** in ${pl(mergeCommits)} ${mergeCommits.join(", ")}\n` +
+                `  Please rebase your branch to remove merge commits.`
+              );
+            }
+            if (missingDCO.length > 0) {
+              issues.push(
+                `- **Missing DCO** in ${pl(missingDCO)} ${missingDCO.join(", ")}\n` +
+                `  Add \`Signed-off-by\` trailer using \`git commit --amend -s\``
+              );
+            }
+            if (emptyMessages.length > 0) {
+              issues.push(
+                `- **Empty commit message** in ${pl(emptyMessages)} ${emptyMessages.join(", ")}\n` +
+                `  Please provide a meaningful commit message.`
+              );
+            }
+            if (missingDesc.length > 0) {
+              issues.push(
+                `- **Missing commit description** in ${pl(missingDesc)} ${missingDesc.join(", ")}\n` +
+                `  Please add a description explaining what the commit does and why.`
+              );
+            }
+
+            // Build and post/update comment
+            let body;
+
+            if (issues.length > 0) {
+              body = [
+                COMMENT_MARKER,
+                "# PR Readiness Check",
+                "",
+                "## ❌ This PR is not ready for review.",
+                "",
+                "**Issues found:**",
+                "",
+                ...issues,
+                "",
+                "---",
+                "**Please fix the issues above and push again.**",
+                "",
+                `See the [Contributing Guidelines](${CONTRIBUTING_URL}) and [DCO](${DCO_URL}) for more details.`,
+              ].join("\n");
+            } else {
+              body = [
+                COMMENT_MARKER,
+                "# PR Readiness Check",
+                "",
+                "## ✅ All basic checks passed. This PR is ready for review.",
+                "",
+                "Keep up the good work! 🙌",
+              ].join("\n");
+            }
+
+            // Find existing bot comment to update (paginated)
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: pull_number }
+            );
+
+            const existingComment = comments.find(
+              (comment) => comment.body && comment.body.includes(COMMENT_MARKER)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: pull_number,
+                body,
+              });
+            }


### PR DESCRIPTION
Add a GitHub Actions workflow that automatically checks PRs for common issues and posts an actionable comment.

- Missing DCO sign-off
- Empty commit messages
- Missing commit description
- Merge commits 

 The workflow uses `pull_request_target` to comment on fork PRs without checking out or executing PR code. It posts a single comment that updates on each push. It skips DCO/description checks on merge commits (fix is to remove them).
 
 **Groups issues by type to keep comments clean**


 ### Demo

Tested on my fork with different scenarios:

- [Missing DCO](https://github.com/Priyanshu-u07/hermeto/pull/9)
- [All checks passed ](https://github.com/Priyanshu-u07/hermeto/pull/10)
- [Grouped issues (empty msg & missing desc)](https://github.com/Priyanshu-u07/hermeto/pull/11)
- [Merge commit detected](https://github.com/Priyanshu-u07/hermeto/pull/8)


**Note**: 
In addition to the checks discussed in #1521 , I also added a check for missing commit description body, since all merged PRs in the repo follow this convention. Happy to remove if preferred.


Closes #1521
<img width="908" height="276" alt="image" src="https://github.com/user-attachments/assets/d426895d-4b31-4351-bc99-439d8bfecc8f" />
<img width="912" height="567" alt="image" src="https://github.com/user-attachments/assets/e3aff015-5015-45e3-942b-f1e94e9cdd1a" />
