### PR TITLE
Dockerfile: Use COPY --link for multi-stage copies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,11 +48,11 @@ FROM base
 LABEL maintainer="Red Hat"
 
 # copy Go SDK and Node.js installation from official images
-COPY --from=golang /usr/local/go /usr/local/go
-COPY --from=node /usr/local/lib/node_modules/corepack /usr/local/lib/corepack
-COPY --from=node /usr/local/bin/node /usr/local/bin/node
-COPY --from=rust /usr/local/rustup/toolchains/*/bin/cargo /usr/bin/cargo
-COPY --from=builder /venv /venv
+COPY --link --from=golang /usr/local/go /usr/local/go
+COPY --link --from=node /usr/local/lib/node_modules/corepack /usr/local/lib/corepack
+COPY --link --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --link --from=rust /usr/local/rustup/toolchains/*/bin/cargo /usr/bin/cargo
+COPY --link --from=builder /venv /venv
 
 # link corepack, yarn, and go to standard PATH location
 RUN ln -s /usr/local/lib/corepack/dist/corepack.js /usr/local/bin/corepack && \


### PR DESCRIPTION
COPY --link creates each layer independently of previous layers, which improves cache reuse [1] when the base image or earlier instructions change. From the docs:

    This also means you can easily rebase your images when the base
    images receive updates, without having to execute the whole build
    again.
    ...
    When using --link the COPY/ADD commands are not allowed to read any
    files from the previous state. This means that if in previous state
    the destination directory was a path that contained a symlink,
    COPY/ADD can not follow it.

Since none of the destination paths resolve through symlinks (/usr/local/bin, /usr/bin, etc.), this is safe to use here.

[1] https://docs.docker.com/reference/dockerfile/#copy