### PR TITLE
feat(logging): add colored log levels and --log-color CLI option

### DIFF
--- a/hermeto/interface/cli.py
+++ b/hermeto/interface/cli.py
@@ -184,13 +184,18 @@ def main(  # noqa: D103 -- docstring becomes part of --help message
         case_sensitive=False,
         help="Set log level.",
     ),
+    color: bool | None = typer.Option(
+        None,
+        "--color/--no-color",
+        help="Force colored log output on or off (default: auto - terminal is a TTY).",
+    ),
     mode: Mode = typer.Option(  # noqa: ARG001
         Mode.STRICT,
         "--mode",
         help="Treat input requirements violations as errors or warnings (may affect SBOM accuracy).",
     ),
 ) -> None:
-    setup_logging(log_level)
+    setup_logging(log_level, color=color)
     if config_file:
         config = set_config(config_file)
     else:

--- a/hermeto/interface/logging.py
+++ b/hermeto/interface/logging.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 import enum
 import logging
+import os
 from collections.abc import Iterable
 from typing import Any, TextIO
 
@@ -18,18 +19,33 @@ LEVEL_COLORS: dict[int, str] = {
 RESET = "\033[0m"
 
 
+def _is_env_set(name: str) -> bool:
+    return bool(os.environ.get(name))
+
+
+def _resolve_color_from_env(stream: TextIO | None) -> bool:
+    """Determine whether to use color based on NO_COLOR/FORCE_COLOR env vars and TTY status.
+
+    Precedence: FORCE_COLOR > NO_COLOR > TTY auto-detection.
+    See https://no-color.org/ and https://force-color.org/
+    """
+    if _is_env_set("FORCE_COLOR"):
+        return True
+    if _is_env_set("NO_COLOR"):
+        return False
+    return stream is not None and stream.isatty()
+
+
 class ColoredFormatter(logging.Formatter):
     """Formatter that colorizes the log level name when the output stream supports color."""
 
     def __init__(self, fmt: str, stream: TextIO | None = None, color: bool | None = None) -> None:
         """Initialize the formatter, deciding whether to use color based on stream and mode."""
         super().__init__(fmt)
-        if color is True:
-            self._use_color = True
-        elif color is False:
-            self._use_color = False
+        if color is not None:
+            self._use_color = color
         else:
-            self._use_color = stream is not None and stream.isatty()
+            self._use_color = _resolve_color_from_env(stream)
 
     def format(self, record: logging.LogRecord) -> str:
         """Format the record, wrapping the level name in ANSI color codes if enabled."""

--- a/hermeto/interface/logging.py
+++ b/hermeto/interface/logging.py
@@ -2,11 +2,42 @@
 import enum
 import logging
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, TextIO
 
 from hermeto.core.constants import Mode
 
 LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
+
+LEVEL_COLORS: dict[int, str] = {
+    logging.DEBUG: "\033[90m",  # gray
+    logging.INFO: "\033[34m",  # blue
+    logging.WARNING: "\033[33m",  # orange/yellow
+    logging.ERROR: "\033[31m",  # red
+    logging.CRITICAL: "\033[1;31m",  # bold red
+}
+RESET = "\033[0m"
+
+
+class ColoredFormatter(logging.Formatter):
+    """Formatter that colorizes the log level name when the output stream supports color."""
+
+    def __init__(self, fmt: str, stream: TextIO | None = None, color: bool | None = None) -> None:
+        """Initialize the formatter, deciding whether to use color based on stream and mode."""
+        super().__init__(fmt)
+        if color is True:
+            self._use_color = True
+        elif color is False:
+            self._use_color = False
+        else:
+            self._use_color = stream is not None and stream.isatty()
+
+    def format(self, record: logging.LogRecord) -> str:
+        """Format the record, wrapping the level name in ANSI color codes if enabled."""
+        if self._use_color:
+            color = LEVEL_COLORS.get(record.levelno, "")
+            record = logging.makeLogRecord(record.__dict__)
+            record.levelname = f"{color}{record.levelname}{RESET}"
+        return super().format(record)
 
 
 class LogLevel(str, enum.Enum):
@@ -44,10 +75,14 @@ class EnforcingModeLoggerAdapter(logging.LoggerAdapter):
             self.error(msg, *args, **kwargs)
 
 
-def setup_logging(level: LogLevel, additional_modules: Iterable[str] = ()) -> None:
+def setup_logging(
+    level: LogLevel,
+    color: bool | None = None,
+    additional_modules: Iterable[str] = (),
+) -> None:
     """Set up logging. By default, enables only the application root logger."""
     handler = logging.StreamHandler()
-    handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    handler.setFormatter(ColoredFormatter(LOG_FORMAT, stream=handler.stream, color=color))
 
     for module in ["hermeto", *additional_modules]:
         logger = logging.getLogger(module)

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -45,18 +45,33 @@ class TestColoredFormatter:
         assert f"{expected_color}{level_name}{RESET}" in result
 
     @pytest.mark.parametrize(
-        "color, stream, expect_color",
+        "color, stream, env, expect_color",
         [
-            (None, FakeTTY(), True),
-            (None, FakeNonTTY(), False),
-            (None, None, False),
-            (True, FakeNonTTY(), True),
-            (False, FakeTTY(), False),
+            (None, FakeTTY(), {}, True),
+            (None, FakeNonTTY(), {}, False),
+            (None, None, {}, False),
+            (True, FakeNonTTY(), {}, True),
+            (False, FakeTTY(), {}, False),
+            (None, FakeTTY(), {"NO_COLOR": "1"}, False),
+            (None, FakeNonTTY(), {"FORCE_COLOR": "1"}, True),
+            (None, FakeNonTTY(), {"NO_COLOR": "1", "FORCE_COLOR": "1"}, True),
+            (None, FakeTTY(), {"NO_COLOR": ""}, True),
+            (True, FakeNonTTY(), {"NO_COLOR": "1"}, True),
+            (False, FakeTTY(), {"FORCE_COLOR": "1"}, False),
         ],
     )
     def test_color_mode(
-        self, color: bool | None, stream: StringIO | None, expect_color: bool
+        self,
+        color: bool | None,
+        stream: StringIO | None,
+        env: dict[str, str],
+        expect_color: bool,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        for var in ("NO_COLOR", "FORCE_COLOR"):
+            monkeypatch.delenv(var, raising=False)
+        for name, value in env.items():
+            monkeypatch.setenv(name, value)
         fmt = ColoredFormatter(FMT, stream=stream, color=color)
         result = fmt.format(_make_record(logging.INFO))
         if expect_color:

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: GPL-3.0-only
+import logging
+from io import StringIO
+
+import pytest
+
+from hermeto.interface.logging import (
+    RESET,
+    ColoredFormatter,
+)
+
+
+class FakeTTY(StringIO):
+    def isatty(self) -> bool:
+        return True
+
+
+class FakeNonTTY(StringIO):
+    def isatty(self) -> bool:
+        return False
+
+
+def _make_record(level: int, message: str = "test message") -> logging.LogRecord:
+    return logging.LogRecord("test", level, "", 0, message, (), None)
+
+
+FMT = "%(levelname)s %(message)s"
+
+
+class TestColoredFormatter:
+    @pytest.mark.parametrize(
+        "level, expected_color",
+        [
+            (logging.DEBUG, "\033[90m"),
+            (logging.INFO, "\033[34m"),
+            (logging.WARNING, "\033[33m"),
+            (logging.ERROR, "\033[31m"),
+            (logging.CRITICAL, "\033[1;31m"),
+        ],
+    )
+    def test_all_levels_have_color_mapping(self, level: int, expected_color: str) -> None:
+        fmt = ColoredFormatter(FMT, stream=FakeTTY())
+        result = fmt.format(_make_record(level))
+        level_name = logging.getLevelName(level)
+        assert f"{expected_color}{level_name}{RESET}" in result
+
+    @pytest.mark.parametrize(
+        "color, stream, expect_color",
+        [
+            (None, FakeTTY(), True),
+            (None, FakeNonTTY(), False),
+            (None, None, False),
+            (True, FakeNonTTY(), True),
+            (False, FakeTTY(), False),
+        ],
+    )
+    def test_color_mode(
+        self, color: bool | None, stream: StringIO | None, expect_color: bool
+    ) -> None:
+        fmt = ColoredFormatter(FMT, stream=stream, color=color)
+        result = fmt.format(_make_record(logging.INFO))
+        if expect_color:
+            assert f"\033[34mINFO{RESET}" in result
+        else:
+            assert "\033[" not in result
+            assert "INFO" in result
+
+    def test_does_not_mutate_original_record(self) -> None:
+        fmt = ColoredFormatter(FMT, stream=FakeTTY(), color=True)
+        record = _make_record(logging.ERROR)
+        original_levelname = record.levelname
+        fmt.format(record)
+        assert record.levelname == original_levelname
+
+    def test_message_is_not_colorized(self) -> None:
+        fmt = ColoredFormatter(FMT, stream=FakeTTY(), color=True)
+        result = fmt.format(_make_record(logging.INFO, "hello world"))
+        assert result.endswith("hello world")


### PR DESCRIPTION
Colorize log level names in terminal output (DEBUG=gray, INFO=blue, WARNING=orange, ERROR/CRITICAL=red). Only the level label is colored, not the entire message. Add --log-color option (auto/on/off) to control behavior; auto (default) enables color only when stderr is a TTY.