### PR TITLE
feat(http): make retry count configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Any settings specified will override the default values present in the
 - `http.read_timeout` read timeout (seconds) for HTTP requests (default: 300).
   Long-running downloads can take arbitrarily long as long as bytes keep
   flowing.
+- `http.max_retries` maximum number of retries for HTTP requests (default: 5)
 - `http.timeout` (deprecated) automatically migrated to `http.read_timeout`.
 - `runtime.concurrency_limit` max concurrent operations.
 - `runtime.subprocess_timeout` timeout (seconds) for subprocess commands.

--- a/hermeto/core/config.py
+++ b/hermeto/core/config.py
@@ -147,6 +147,7 @@ class HttpSettings(BaseModel, extra="forbid"):
 
     connect_timeout: int = 30
     read_timeout: int = 300
+    max_retries: int = 5
 
 
 class RuntimeSettings(BaseModel, extra="forbid"):

--- a/hermeto/core/http_requests.py
+++ b/hermeto/core/http_requests.py
@@ -12,9 +12,6 @@ ALL_REQUEST_METHODS = frozenset(
 # The set includes only methods which don't modify state of the service.
 SAFE_REQUEST_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE"})
 DEFAULT_RETRY_OPTIONS: dict[str, Any] = {
-    "total": 5,
-    "read": 5,
-    "connect": 5,
     "backoff_factor": 1.3,
     "status_forcelist": (500, 502, 503, 504),
 }

--- a/hermeto/core/http_requests.py
+++ b/hermeto/core/http_requests.py
@@ -2,10 +2,6 @@
 import logging
 from typing import Any
 
-from requests import Session
-from requests.adapters import HTTPAdapter
-from urllib3.util.retry import Retry
-
 log = logging.getLogger(__name__)
 
 # The set is extended version of constant Retry.DEFAULT_ALLOWED_METHODS
@@ -22,21 +18,3 @@ DEFAULT_RETRY_OPTIONS: dict[str, Any] = {
     "backoff_factor": 1.3,
     "status_forcelist": (500, 502, 503, 504),
 }
-
-
-def get_requests_session(retry_options: dict | None = None) -> Session:
-    """
-    Create a requests session with retries.
-
-    :param dict retry_options: overwrite options for initialization of Retry instance
-    :return: the configured requests session
-    :rtype: requests.Session
-    """
-    if retry_options is None:
-        retry_options = {}
-    session = Session()
-    retry_options = {**DEFAULT_RETRY_OPTIONS, **retry_options}
-    adapter = HTTPAdapter(max_retries=Retry(**retry_options))
-    session.mount("http://", adapter)
-    session.mount("https://", adapter)
-    return session

--- a/hermeto/core/package_managers/general.py
+++ b/hermeto/core/package_managers/general.py
@@ -9,19 +9,42 @@ from urllib.parse import urlparse
 import aiohttp
 import aiohttp_retry
 import requests
+from requests import Session
+from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
+from urllib3.util.retry import Retry
 
 from hermeto.core.config import get_config
 from hermeto.core.errors import FetchError
 from hermeto.core.http_requests import (
     DEFAULT_RETRY_OPTIONS,
     SAFE_REQUEST_METHODS,
-    get_requests_session,
 )
 from hermeto.core.scm import get_repo_id
 from hermeto.core.type_aliases import StrPath
 
-pkg_requests_session = get_requests_session(retry_options={"allowed_methods": SAFE_REQUEST_METHODS})
+_pkg_requests_session: requests.Session | None = None
+
+
+def _get_pkg_requests_session() -> requests.Session:
+    """
+    A lazy initialised, module-level requests.Session with retry config.
+    """
+    global _pkg_requests_session
+    if _pkg_requests_session is None:
+        max_retries = get_config().http.max_retries
+        retry_options = {
+            **DEFAULT_RETRY_OPTIONS,
+            "allowed_methods": SAFE_REQUEST_METHODS,
+            "total": max_retries,
+        }
+        _pkg_requests_session = Session()
+        adapter = HTTPAdapter(max_retries=Retry(**retry_options))
+        _pkg_requests_session.mount("http://", adapter)
+        _pkg_requests_session.mount("https://", adapter)
+
+    return _pkg_requests_session
+
 
 log = logging.getLogger(__name__)
 
@@ -46,7 +69,7 @@ def download_binary_file(
     config = get_config()
     timeout = (config.http.connect_timeout, config.http.read_timeout)
     try:
-        resp = pkg_requests_session.get(
+        resp = _get_pkg_requests_session().get(
             url, stream=True, verify=not insecure, auth=auth, timeout=timeout
         )
         resp.raise_for_status()
@@ -130,10 +153,12 @@ async def async_download_files(
     :param auth: Optional authorization data for proxies.
     """
     trace_config = aiohttp.TraceConfig()
-    num_attempts: int = int(DEFAULT_RETRY_OPTIONS["total"])
+    max_retries = get_config().http.max_retries
+    # aiohttp uses n calls (1 call, n-1 retries).
+    max_retries = max_retries + 1
     retry_options = aiohttp_retry.JitterRetry(
         start_timeout=DEFAULT_RETRY_OPTIONS["backoff_factor"],
-        attempts=num_attempts,
+        attempts=max_retries,
         statuses=set(DEFAULT_RETRY_OPTIONS["status_forcelist"]),
         exceptions={
             aiohttp.ClientConnectionError,

--- a/tests/unit/package_managers/test_general.py
+++ b/tests/unit/package_managers/test_general.py
@@ -10,6 +10,7 @@ import aiohttp
 import aiohttp_retry
 import pytest
 import requests
+from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase, HTTPBasicAuth
 
 from hermeto.core.config import get_config
@@ -17,9 +18,9 @@ from hermeto.core.errors import FetchError
 from hermeto.core.package_managers import general
 from hermeto.core.package_managers.general import (
     _async_download_binary_file,
+    _get_pkg_requests_session,
     async_download_files,
     download_binary_file,
-    pkg_requests_session,
 )
 from tests.common_utils import GIT_REF
 
@@ -27,35 +28,55 @@ from tests.common_utils import GIT_REF
 @pytest.mark.parametrize("auth", [None, HTTPBasicAuth("user", "password")])
 @pytest.mark.parametrize("insecure", [True, False])
 @pytest.mark.parametrize("chunk_size", [1024, 2048])
-@mock.patch.object(pkg_requests_session, "get")
 def test_download_binary_file(
-    mock_get: Any, auth: AuthBase | None, insecure: bool, chunk_size: int, tmp_path: Path
+    auth: AuthBase | None, insecure: bool, chunk_size: int, tmp_path: Path
 ) -> None:
     config = get_config()
     timeout = (config.http.connect_timeout, config.http.read_timeout)
     url = "http://example.org/example.tar.gz"
     content = b"file content"
 
-    mock_response = mock_get.return_value
+    mock_session = mock.MagicMock()
+    mock_response = mock_session.get.return_value
+    mock_response.raise_for_status.return_value = None
     mock_response.iter_content.return_value = [content]
 
-    download_path = tmp_path.joinpath("example.tar.gz")
-    download_binary_file(
-        url, str(download_path), auth=auth, insecure=insecure, chunk_size=chunk_size
-    )
+    with mock.patch(
+        "hermeto.core.package_managers.general._get_pkg_requests_session",
+        return_value=mock_session,
+    ):
+        download_path = tmp_path.joinpath("example.tar.gz")
+        download_binary_file(
+            url, str(download_path), auth=auth, insecure=insecure, chunk_size=chunk_size
+        )
 
     assert download_path.read_bytes() == content
-    mock_get.assert_called_with(url, stream=True, verify=not insecure, auth=auth, timeout=timeout)
+    mock_session.get.assert_called_once_with(
+        url, stream=True, verify=not insecure, auth=auth, timeout=timeout
+    )
     mock_response.iter_content.assert_called_with(chunk_size=chunk_size)
 
 
-@mock.patch.object(pkg_requests_session, "get")
-def test_download_binary_file_failed(mock_get: Any) -> None:
-    mock_get.side_effect = [requests.RequestException("Something went wrong")]
-
-    expected = "Could not download http://example.org/example.tar.gz: Something went wrong"
-    with pytest.raises(FetchError, match=expected):
+@mock.patch("hermeto.core.package_managers.general._get_pkg_requests_session")
+def test_download_binary_file_failed(mock_get_pkg_requests_session: MagicMock) -> None:
+    mock_get_pkg_requests_session.return_value.get.side_effect = requests.RequestException()
+    with pytest.raises(FetchError, match="Could not download http://example.org/example.tar.gz"):
         download_binary_file("http://example.org/example.tar.gz", "/example.tar.gz")
+
+
+def test_max_retries_propagated_to_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that max_retries config value is propagated to the requests session."""
+    monkeypatch.setenv("HERMETO_HTTP__MAX_RETRIES", "7")
+    monkeypatch.setattr("hermeto.core.package_managers.general._pkg_requests_session", None)
+
+    monkeypatch.setattr("hermeto.core.config.config", None)
+    config = get_config()
+    assert config.http.max_retries == 7
+
+    session = _get_pkg_requests_session()
+    adapter = session.get_adapter("https://example.com")
+    assert isinstance(adapter, HTTPAdapter)
+    assert adapter.max_retries.total == 7
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #1551

## Description
- Added `max_retries` to `HttpSettings`
  - env var: `HERMETO_HTTP__MAX_RETRIES`
  - config file: `http.max_retries`
  - default is 5.

- removed hardcoded count from `DEFAULT_RETRY_OPTIONS`, both `get_requests_session` and `async_download_files` now read from config at call time

- Before `pkg_requests_session` was created at module import time, so config file overrides were ignored. replaced with `_get_pkg_requests_session` that builds the session on first download call instead.

## Testing

ran manually with `http.max_retries: 10` in config file, confirmed the session picked up the value correctly.