### PR TITLE
chore(tests): remove dead bitbucket cachi-testing refs

### DIFF
--- a/tests/integration/test_data/npm_multiple_packages/.build-config.yaml
+++ b/tests/integration/test_data/npm_multiple_packages/.build-config.yaml
@@ -757,7 +757,6 @@ project_files:
           "version": "1.0.0",
           "license": "ISC",
           "dependencies": {
-            "bitbucket-cachi2-npm-without-deps-second": "",
             "debug": "",
             "express": "^4.18.2",
             "sax": "0.1.1"
@@ -779,10 +778,6 @@ project_files:
           "version": "1.1.1",
           "resolved": "file://${output_dir}/deps/npm/array-flatten-1.1.1.tgz",
           "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
-        },
-        "node_modules/bitbucket-cachi2-npm-without-deps-second": {
-          "version": "2.0.0",
-          "resolved": "file://${output_dir}/deps/npm/bitbucket.org/cachi-testing/cachi2-without-deps-second/cachi2-without-deps-second-external-gitcommit-09992d418fc44a2895b7a9ff27c4e32d6f74a982.tgz"
         },
         "node_modules/body-parser": {
           "version": "1.20.1",
@@ -1446,7 +1441,6 @@ project_files:
       "homepage": "https://github.com/hermetoproject/integration-tests#readme",
       "description": "",
       "dependencies": {
-        "bitbucket-cachi2-npm-without-deps-second": "",
         "debug": "",
         "express": "^4.18.2",
         "sax": "0.1.1"

--- a/tests/integration/test_data/npm_multiple_packages/bom.json
+++ b/tests/integration/test_data/npm_multiple_packages/bom.json
@@ -14,7 +14,6 @@
         "pkg:npm/accepts@1.3.8",
         "pkg:npm/array-flatten@1.1.1",
         "pkg:npm/assertion-error@1.1.0",
-        "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps-second.git%4009992d418fc44a2895b7a9ff27c4e32d6f74a982",
         "pkg:npm/body-parser@1.20.1",
         "pkg:npm/bytes@3.1.2",
         "pkg:npm/call-bind@1.0.2",
@@ -35,7 +34,7 @@
         "pkg:npm/escape-html@1.0.3",
         "pkg:npm/etag@1.8.1",
         "pkg:npm/express@4.18.2",
-        "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a6ca0c49831e42a93e9372049b1d3f93548aae27#third_pkg/fecha-4.2.3.tgz",
+        "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f9dc6f912a74d57d0a9a180a713a3c05c52d3b47#third_pkg/fecha-4.2.3.tgz",
         "pkg:npm/finalhandler@1.2.0",
         "pkg:npm/forwarded@0.2.0",
         "pkg:npm/fresh@0.5.2",
@@ -60,9 +59,9 @@
         "pkg:npm/ms@2.1.2",
         "pkg:npm/ms@2.1.3",
         "pkg:npm/negotiator@0.6.3",
-        "pkg:npm/npm-first-package@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a6ca0c49831e42a93e9372049b1d3f93548aae27#first_pkg",
-        "pkg:npm/npm-second-pkg@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a6ca0c49831e42a93e9372049b1d3f93548aae27#second_pkg",
-        "pkg:npm/npm-third-package@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a6ca0c49831e42a93e9372049b1d3f93548aae27#third_pkg",
+        "pkg:npm/npm-first-package@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f9dc6f912a74d57d0a9a180a713a3c05c52d3b47#first_pkg",
+        "pkg:npm/npm-second-pkg@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f9dc6f912a74d57d0a9a180a713a3c05c52d3b47#second_pkg",
+        "pkg:npm/npm-third-package@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f9dc6f912a74d57d0a9a180a713a3c05c52d3b47#third_pkg",
         "pkg:npm/npm-without-deps@1.0.0?checksum=sha512:8c1abf64841a445eb384c5aa5c26c3a51d54c876db62777a3b5fc3e4debd29e2bf68e4b74fe6fbc322a1d0c4cf02fd2668a5df73aebd4118c54931d18ca086a1&download_url=https://github.com/hermetoproject/integration-tests/archive/b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81.tar.gz",
         "pkg:npm/object-inspect@1.12.3",
         "pkg:npm/on-finished@2.4.1",
@@ -188,19 +187,6 @@
       "purl": "pkg:npm/assertion-error@1.1.0",
       "type": "library",
       "version": "1.1.0"
-    },
-    {
-      "bom-ref": "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps-second.git%4009992d418fc44a2895b7a9ff27c4e32d6f74a982",
-      "name": "bitbucket-cachi2-npm-without-deps-second",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps-second.git%4009992d418fc44a2895b7a9ff27c4e32d6f74a982",
-      "type": "library",
-      "version": "2.0.0"
     },
     {
       "bom-ref": "pkg:npm/body-parser@1.20.1",
@@ -475,7 +461,7 @@
       "version": "4.18.2"
     },
     {
-      "bom-ref": "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a6ca0c49831e42a93e9372049b1d3f93548aae27#third_pkg/fecha-4.2.3.tgz",
+      "bom-ref": "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f9dc6f912a74d57d0a9a180a713a3c05c52d3b47#third_pkg/fecha-4.2.3.tgz",
       "name": "fecha",
       "properties": [
         {
@@ -483,7 +469,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a6ca0c49831e42a93e9372049b1d3f93548aae27#third_pkg/fecha-4.2.3.tgz",
+      "purl": "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f9dc6f912a74d57d0a9a180a713a3c05c52d3b47#third_pkg/fecha-4.2.3.tgz",
       "type": "library",
       "version": "4.2.3"
     },
@@ -804,7 +790,7 @@
       "version": "0.6.3"
     },
     {
-      "bom-ref": "pkg:npm/npm-first-package@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a6ca0c49831e42a93e9372049b1d3f93548aae27#first_pkg",
+      "bom-ref": "pkg:npm/npm-first-package@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f9dc6f912a74d57d0a9a180a713a3c05c52d3b47#first_pkg",
       "name": "npm-first-package",
       "properties": [
         {
@@ -812,12 +798,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/npm-first-package@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a6ca0c49831e42a93e9372049b1d3f93548aae27#first_pkg",
+      "purl": "pkg:npm/npm-first-package@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f9dc6f912a74d57d0a9a180a713a3c05c52d3b47#first_pkg",
       "type": "library",
       "version": "1.0.0"
     },
     {
-      "bom-ref": "pkg:npm/npm-second-pkg@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a6ca0c49831e42a93e9372049b1d3f93548aae27#second_pkg",
+      "bom-ref": "pkg:npm/npm-second-pkg@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f9dc6f912a74d57d0a9a180a713a3c05c52d3b47#second_pkg",
       "name": "npm-second-pkg",
       "properties": [
         {
@@ -825,12 +811,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/npm-second-pkg@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a6ca0c49831e42a93e9372049b1d3f93548aae27#second_pkg",
+      "purl": "pkg:npm/npm-second-pkg@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f9dc6f912a74d57d0a9a180a713a3c05c52d3b47#second_pkg",
       "type": "library",
       "version": "1.0.0"
     },
     {
-      "bom-ref": "pkg:npm/npm-third-package@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a6ca0c49831e42a93e9372049b1d3f93548aae27#third_pkg",
+      "bom-ref": "pkg:npm/npm-third-package@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f9dc6f912a74d57d0a9a180a713a3c05c52d3b47#third_pkg",
       "name": "npm-third-package",
       "properties": [
         {
@@ -838,7 +824,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/npm-third-package@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a6ca0c49831e42a93e9372049b1d3f93548aae27#third_pkg",
+      "purl": "pkg:npm/npm-third-package@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f9dc6f912a74d57d0a9a180a713a3c05c52d3b47#third_pkg",
       "type": "library",
       "version": "1.0.0"
     },

--- a/tests/integration/test_data/npm_smoketest_lockfile2/.build-config.yaml
+++ b/tests/integration/test_data/npm_smoketest_lockfile2/.build-config.yaml
@@ -45,8 +45,7 @@ project_files:
       },
       "homepage": "https://github.com/hermetoproject/integration-tests#readme",
       "dependencies": {
-        "dateformat": "^5.0.3",
-        "bitbucket-cachi2-npm-without-deps": ""
+        "dateformat": "^5.0.3"
       }
     }
 - abspath: ${test_case_tmp_path}/eggs-packages/eggs/package.json
@@ -120,7 +119,6 @@ project_files:
           ],
           "dependencies": {
             "@types/react-dom": "^18.0.1",
-            "bitbucket-cachi2-npm-without-deps-second": "",
             "debug": "",
             "express": "^4.18.2",
             "fecha": "file:fecha-4.2.3.tgz",
@@ -141,7 +139,6 @@ project_files:
           "version": "1.0.0",
           "license": "ISC",
           "dependencies": {
-            "bitbucket-cachi2-npm-without-deps": "",
             "dateformat": "^5.0.3"
           }
         },
@@ -215,14 +212,6 @@ project_files:
         "node_modules/bar": {
           "resolved": "bar",
           "link": true
-        },
-        "node_modules/bitbucket-cachi2-npm-without-deps": {
-          "version": "1.0.0",
-          "resolved": "file://${output_dir}/deps/npm/bitbucket.org/cachi-testing/cachi2-without-deps/cachi2-without-deps-external-gitcommit-9e164b97043a2d91bbeb992f6cc68a3d1015086a.tgz"
-        },
-        "node_modules/bitbucket-cachi2-npm-without-deps-second": {
-          "version": "2.0.0",
-          "resolved": "file://${output_dir}/deps/npm/bitbucket.org/cachi-testing/cachi2-without-deps-second/cachi2-without-deps-second-external-gitcommit-09992d418fc44a2895b7a9ff27c4e32d6f74a982.tgz"
         },
         "node_modules/body-parser": {
           "version": "1.20.1",
@@ -922,14 +911,6 @@ project_files:
             "uuid": "^9.0.0"
           }
         },
-        "bitbucket-cachi2-npm-without-deps": {
-          "version": "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps.git#9e164b97043a2d91bbeb992f6cc68a3d1015086a",
-          "from": "bitbucket-cachi2-npm-without-deps@https://bitbucket.org/cachi-testing/cachi2-without-deps.git"
-        },
-        "bitbucket-cachi2-npm-without-deps-second": {
-          "version": "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps-second.git#09992d418fc44a2895b7a9ff27c4e32d6f74a982",
-          "from": "bitbucket-cachi2-npm-without-deps-second@https://bitbucket.org/cachi-testing/cachi2-without-deps-second.git"
-        },
         "body-parser": {
           "version": "1.20.1",
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
@@ -1230,7 +1211,6 @@ project_files:
         "not-baz": {
           "version": "file:baz",
           "requires": {
-            "bitbucket-cachi2-npm-without-deps": "https://bitbucket.org/cachi-testing/cachi2-without-deps.git",
             "dateformat": "^5.0.3"
           }
         },
@@ -1444,7 +1424,6 @@ project_files:
         "sax": "0.1.1",
         "is-positive": "",
         "npm-without-deps": "",
-        "bitbucket-cachi2-npm-without-deps-second": "",
         "fecha": "file:fecha-4.2.3.tgz"
       }
     }

--- a/tests/integration/test_data/npm_smoketest_lockfile2/bom.json
+++ b/tests/integration/test_data/npm_smoketest_lockfile2/bom.json
@@ -14,9 +14,7 @@
         "pkg:npm/abbrev@2.0.0",
         "pkg:npm/accepts@1.3.8",
         "pkg:npm/array-flatten@1.1.1",
-        "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#bar",
-        "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps-second.git%4009992d418fc44a2895b7a9ff27c4e32d6f74a982",
-        "pkg:npm/bitbucket-cachi2-npm-without-deps@1.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps.git%409e164b97043a2d91bbeb992f6cc68a3d1015086a",
+        "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#bar",
         "pkg:npm/body-parser@1.20.1",
         "pkg:npm/bytes@3.1.2",
         "pkg:npm/call-bind@1.0.2",
@@ -32,14 +30,14 @@
         "pkg:npm/depd@2.0.0",
         "pkg:npm/destroy@1.2.0",
         "pkg:npm/ee-first@1.1.1",
-        "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#eggs-packages/eggs",
+        "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#eggs-packages/eggs",
         "pkg:npm/encodeurl@1.0.2",
         "pkg:npm/escape-html@1.0.3",
         "pkg:npm/etag@1.8.1",
         "pkg:npm/express@4.18.2",
-        "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#fecha-4.2.3.tgz",
+        "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#fecha-4.2.3.tgz",
         "pkg:npm/finalhandler@1.2.0",
-        "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#foo",
+        "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#foo",
         "pkg:npm/forwarded@0.2.0",
         "pkg:npm/fresh@0.5.2",
         "pkg:npm/function-bind@1.1.1",
@@ -60,9 +58,9 @@
         "pkg:npm/ms@2.0.0",
         "pkg:npm/ms@2.1.3",
         "pkg:npm/negotiator@0.6.3",
-        "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#baz",
+        "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#baz",
         "pkg:npm/npm-without-deps@1.0.0?checksum=sha512:8c1abf64841a445eb384c5aa5c26c3a51d54c876db62777a3b5fc3e4debd29e2bf68e4b74fe6fbc322a1d0c4cf02fd2668a5df73aebd4118c54931d18ca086a1&download_url=https://github.com/hermetoproject/integration-tests/archive/b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81.tar.gz",
-        "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb",
+        "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb",
         "pkg:npm/object-inspect@1.12.3",
         "pkg:npm/on-finished@2.4.1",
         "pkg:npm/parseurl@1.3.3",
@@ -78,7 +76,7 @@
         "pkg:npm/serve-static@1.15.0",
         "pkg:npm/setprototypeof@1.2.0",
         "pkg:npm/side-channel@1.0.4",
-        "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#spam-packages/spam",
+        "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#spam-packages/spam",
         "pkg:npm/statuses@2.0.1",
         "pkg:npm/toidentifier@1.0.1",
         "pkg:npm/type-is@1.6.18",
@@ -185,7 +183,7 @@
       "version": "1.1.1"
     },
     {
-      "bom-ref": "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#bar",
+      "bom-ref": "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#bar",
       "name": "bar",
       "properties": [
         {
@@ -193,33 +191,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#bar",
-      "type": "library",
-      "version": "1.0.0"
-    },
-    {
-      "bom-ref": "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps-second.git%4009992d418fc44a2895b7a9ff27c4e32d6f74a982",
-      "name": "bitbucket-cachi2-npm-without-deps-second",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps-second.git%4009992d418fc44a2895b7a9ff27c4e32d6f74a982",
-      "type": "library",
-      "version": "2.0.0"
-    },
-    {
-      "bom-ref": "pkg:npm/bitbucket-cachi2-npm-without-deps@1.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps.git%409e164b97043a2d91bbeb992f6cc68a3d1015086a",
-      "name": "bitbucket-cachi2-npm-without-deps",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps@1.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps.git%409e164b97043a2d91bbeb992f6cc68a3d1015086a",
+      "purl": "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#bar",
       "type": "library",
       "version": "1.0.0"
     },
@@ -419,7 +391,7 @@
       "version": "1.1.1"
     },
     {
-      "bom-ref": "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#eggs-packages/eggs",
+      "bom-ref": "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#eggs-packages/eggs",
       "name": "eggs",
       "properties": [
         {
@@ -427,7 +399,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#eggs-packages/eggs",
+      "purl": "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#eggs-packages/eggs",
       "type": "library",
       "version": "1.0.0"
     },
@@ -484,7 +456,7 @@
       "version": "4.18.2"
     },
     {
-      "bom-ref": "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#fecha-4.2.3.tgz",
+      "bom-ref": "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#fecha-4.2.3.tgz",
       "name": "fecha",
       "properties": [
         {
@@ -492,7 +464,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#fecha-4.2.3.tgz",
+      "purl": "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#fecha-4.2.3.tgz",
       "type": "library",
       "version": "4.2.3"
     },
@@ -510,7 +482,7 @@
       "version": "1.2.0"
     },
     {
-      "bom-ref": "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#foo",
+      "bom-ref": "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#foo",
       "name": "foo",
       "properties": [
         {
@@ -518,7 +490,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#foo",
+      "purl": "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#foo",
       "type": "library",
       "version": "1.0.0"
     },
@@ -783,7 +755,7 @@
       "version": "0.6.3"
     },
     {
-      "bom-ref": "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#baz",
+      "bom-ref": "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#baz",
       "name": "not-baz",
       "properties": [
         {
@@ -791,7 +763,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#baz",
+      "purl": "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#baz",
       "type": "library",
       "version": "1.0.0"
     },
@@ -809,7 +781,7 @@
       "version": "1.0.0"
     },
     {
-      "bom-ref": "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb",
+      "bom-ref": "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb",
       "name": "npm_test",
       "properties": [
         {
@@ -817,7 +789,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb",
+      "purl": "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb",
       "type": "library",
       "version": "1.1.0"
     },
@@ -1017,7 +989,7 @@
       "version": "1.0.4"
     },
     {
-      "bom-ref": "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#spam-packages/spam",
+      "bom-ref": "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#spam-packages/spam",
       "name": "spam",
       "properties": [
         {
@@ -1025,7 +997,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f5409710fe8af4d70b1fa925fcb05a2f6ceb38bb#spam-packages/spam",
+      "purl": "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403c28dbc3e5126aebac74b0fab369391837559cbb#spam-packages/spam",
       "type": "library",
       "version": "1.0.0"
     },

--- a/tests/integration/test_data/npm_smoketest_lockfile3/.build-config.yaml
+++ b/tests/integration/test_data/npm_smoketest_lockfile3/.build-config.yaml
@@ -45,8 +45,7 @@ project_files:
       },
       "homepage": "https://github.com/hermetoproject/integration-tests#readme",
       "dependencies": {
-        "dateformat": "^5.0.3",
-        "bitbucket-cachi2-npm-without-deps": ""
+        "dateformat": "^5.0.3"
       }
     }
 - abspath: ${test_case_tmp_path}/eggs-packages/eggs/package.json
@@ -120,7 +119,6 @@ project_files:
           ],
           "dependencies": {
             "@types/react-dom": "^18.0.1",
-            "bitbucket-cachi2-npm-without-deps-second": "",
             "debug": "",
             "express": "^4.18.2",
             "fecha": "file:fecha-4.2.3.tgz",
@@ -141,7 +139,6 @@ project_files:
           "version": "1.0.0",
           "license": "ISC",
           "dependencies": {
-            "bitbucket-cachi2-npm-without-deps": "",
             "dateformat": "^5.0.3"
           }
         },
@@ -215,14 +212,6 @@ project_files:
         "node_modules/bar": {
           "resolved": "bar",
           "link": true
-        },
-        "node_modules/bitbucket-cachi2-npm-without-deps": {
-          "version": "1.0.0",
-          "resolved": "file://${output_dir}/deps/npm/bitbucket.org/cachi-testing/cachi2-without-deps/cachi2-without-deps-external-gitcommit-9e164b97043a2d91bbeb992f6cc68a3d1015086a.tgz"
-        },
-        "node_modules/bitbucket-cachi2-npm-without-deps-second": {
-          "version": "2.0.0",
-          "resolved": "file://${output_dir}/deps/npm/bitbucket.org/cachi-testing/cachi2-without-deps-second/cachi2-without-deps-second-external-gitcommit-09992d418fc44a2895b7a9ff27c4e32d6f74a982.tgz"
         },
         "node_modules/body-parser": {
           "version": "1.20.1",
@@ -904,7 +893,6 @@ project_files:
         "sax": "0.1.1",
         "is-positive": "",
         "npm-without-deps": "",
-        "bitbucket-cachi2-npm-without-deps-second": "",
         "fecha": "file:fecha-4.2.3.tgz"
       }
     }

--- a/tests/integration/test_data/npm_smoketest_lockfile3/bom.json
+++ b/tests/integration/test_data/npm_smoketest_lockfile3/bom.json
@@ -14,9 +14,7 @@
         "pkg:npm/abbrev@2.0.0",
         "pkg:npm/accepts@1.3.8",
         "pkg:npm/array-flatten@1.1.1",
-        "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#bar",
-        "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps-second.git%4009992d418fc44a2895b7a9ff27c4e32d6f74a982",
-        "pkg:npm/bitbucket-cachi2-npm-without-deps@1.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps.git%409e164b97043a2d91bbeb992f6cc68a3d1015086a",
+        "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#bar",
         "pkg:npm/body-parser@1.20.1",
         "pkg:npm/bytes@3.1.2",
         "pkg:npm/call-bind@1.0.2",
@@ -32,14 +30,14 @@
         "pkg:npm/depd@2.0.0",
         "pkg:npm/destroy@1.2.0",
         "pkg:npm/ee-first@1.1.1",
-        "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#eggs-packages/eggs",
+        "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#eggs-packages/eggs",
         "pkg:npm/encodeurl@1.0.2",
         "pkg:npm/escape-html@1.0.3",
         "pkg:npm/etag@1.8.1",
         "pkg:npm/express@4.18.2",
-        "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#fecha-4.2.3.tgz",
+        "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#fecha-4.2.3.tgz",
         "pkg:npm/finalhandler@1.2.0",
-        "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#foo",
+        "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#foo",
         "pkg:npm/forwarded@0.2.0",
         "pkg:npm/fresh@0.5.2",
         "pkg:npm/function-bind@1.1.1",
@@ -60,9 +58,9 @@
         "pkg:npm/ms@2.0.0",
         "pkg:npm/ms@2.1.3",
         "pkg:npm/negotiator@0.6.3",
-        "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#baz",
+        "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#baz",
         "pkg:npm/npm-without-deps@1.0.0?checksum=sha512:8c1abf64841a445eb384c5aa5c26c3a51d54c876db62777a3b5fc3e4debd29e2bf68e4b74fe6fbc322a1d0c4cf02fd2668a5df73aebd4118c54931d18ca086a1&download_url=https://github.com/hermetoproject/integration-tests/archive/b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81.tar.gz",
-        "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b",
+        "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49",
         "pkg:npm/object-inspect@1.12.3",
         "pkg:npm/on-finished@2.4.1",
         "pkg:npm/parseurl@1.3.3",
@@ -78,7 +76,7 @@
         "pkg:npm/serve-static@1.15.0",
         "pkg:npm/setprototypeof@1.2.0",
         "pkg:npm/side-channel@1.0.4",
-        "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#spam-packages/spam",
+        "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#spam-packages/spam",
         "pkg:npm/statuses@2.0.1",
         "pkg:npm/toidentifier@1.0.1",
         "pkg:npm/type-is@1.6.18",
@@ -185,7 +183,7 @@
       "version": "1.1.1"
     },
     {
-      "bom-ref": "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#bar",
+      "bom-ref": "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#bar",
       "name": "bar",
       "properties": [
         {
@@ -193,33 +191,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#bar",
-      "type": "library",
-      "version": "1.0.0"
-    },
-    {
-      "bom-ref": "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps-second.git%4009992d418fc44a2895b7a9ff27c4e32d6f74a982",
-      "name": "bitbucket-cachi2-npm-without-deps-second",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps-second.git%4009992d418fc44a2895b7a9ff27c4e32d6f74a982",
-      "type": "library",
-      "version": "2.0.0"
-    },
-    {
-      "bom-ref": "pkg:npm/bitbucket-cachi2-npm-without-deps@1.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps.git%409e164b97043a2d91bbeb992f6cc68a3d1015086a",
-      "name": "bitbucket-cachi2-npm-without-deps",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps@1.0.0?vcs_url=git%2Bssh://git%40bitbucket.org/cachi-testing/cachi2-without-deps.git%409e164b97043a2d91bbeb992f6cc68a3d1015086a",
+      "purl": "pkg:npm/bar@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#bar",
       "type": "library",
       "version": "1.0.0"
     },
@@ -419,7 +391,7 @@
       "version": "1.1.1"
     },
     {
-      "bom-ref": "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#eggs-packages/eggs",
+      "bom-ref": "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#eggs-packages/eggs",
       "name": "eggs",
       "properties": [
         {
@@ -427,7 +399,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#eggs-packages/eggs",
+      "purl": "pkg:npm/eggs@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#eggs-packages/eggs",
       "type": "library",
       "version": "1.0.0"
     },
@@ -484,7 +456,7 @@
       "version": "4.18.2"
     },
     {
-      "bom-ref": "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#fecha-4.2.3.tgz",
+      "bom-ref": "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#fecha-4.2.3.tgz",
       "name": "fecha",
       "properties": [
         {
@@ -492,7 +464,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#fecha-4.2.3.tgz",
+      "purl": "pkg:npm/fecha@4.2.3?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#fecha-4.2.3.tgz",
       "type": "library",
       "version": "4.2.3"
     },
@@ -510,7 +482,7 @@
       "version": "1.2.0"
     },
     {
-      "bom-ref": "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#foo",
+      "bom-ref": "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#foo",
       "name": "foo",
       "properties": [
         {
@@ -518,7 +490,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#foo",
+      "purl": "pkg:npm/foo@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#foo",
       "type": "library",
       "version": "1.0.0"
     },
@@ -783,7 +755,7 @@
       "version": "0.6.3"
     },
     {
-      "bom-ref": "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#baz",
+      "bom-ref": "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#baz",
       "name": "not-baz",
       "properties": [
         {
@@ -791,7 +763,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#baz",
+      "purl": "pkg:npm/not-baz@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#baz",
       "type": "library",
       "version": "1.0.0"
     },
@@ -809,7 +781,7 @@
       "version": "1.0.0"
     },
     {
-      "bom-ref": "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b",
+      "bom-ref": "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49",
       "name": "npm_test",
       "properties": [
         {
@@ -817,7 +789,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b",
+      "purl": "pkg:npm/npm_test@1.1.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49",
       "type": "library",
       "version": "1.1.0"
     },
@@ -1017,7 +989,7 @@
       "version": "1.0.4"
     },
     {
-      "bom-ref": "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#spam-packages/spam",
+      "bom-ref": "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#spam-packages/spam",
       "name": "spam",
       "properties": [
         {
@@ -1025,7 +997,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40e4a94b1b667e868f1ac23f1c3f57f332ac64433b#spam-packages/spam",
+      "purl": "pkg:npm/spam@1.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%400e0e83e7cbaf8e8ac75434b5a9fc3a4442bccd49#spam-packages/spam",
       "type": "library",
       "version": "1.0.0"
     },

--- a/tests/integration/test_data/yarn_e2e/bom.json
+++ b/tests/integration/test_data/yarn_e2e/bom.json
@@ -22,14 +22,13 @@
         "pkg:npm/ansi-regex@3.0.1",
         "pkg:npm/ansi-regex@5.0.1",
         "pkg:npm/ansi-regex@6.0.1",
-        "pkg:npm/ansi-regex@6.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#external-packages/ansi-regex",
+        "pkg:npm/ansi-regex@6.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#external-packages/ansi-regex",
         "pkg:npm/ansi-styles@4.3.0",
         "pkg:npm/ansi-styles@6.2.1",
         "pkg:npm/aproba@2.0.0",
         "pkg:npm/are-we-there-yet@3.0.1",
         "pkg:npm/balanced-match@1.0.2",
-        "pkg:npm/berryscary?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0",
-        "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?checksum=sha512:b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d&download_url=https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
+        "pkg:npm/berryscary?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639",
         "pkg:npm/brace-expansion@1.1.11",
         "pkg:npm/brace-expansion@2.0.1",
         "pkg:npm/cacache@17.1.3",
@@ -68,7 +67,7 @@
         "pkg:npm/graceful-fs@4.2.11",
         "pkg:npm/has-flag@4.0.0",
         "pkg:npm/has-unicode@2.0.1",
-        "pkg:npm/holy-hand-grenade?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#book-of-armaments",
+        "pkg:npm/holy-hand-grenade?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#book-of-armaments",
         "pkg:npm/http-cache-semantics@4.1.1",
         "pkg:npm/http-proxy-agent@5.0.0",
         "pkg:npm/https-proxy-agent@5.0.1",
@@ -111,9 +110,9 @@
         "pkg:npm/nopt@6.0.0",
         "pkg:npm/npm-without-deps@1.0.0?checksum=sha512:da9ab3e8fcea43cf17fba24e5add8675bfa4002050b32853b8348588515d2bed19e4866d2071010048b170c129897eb1c4919239885c6a0eaf2bbf490ed840f8&download_url=https://github.com/hermetoproject/integration-tests/archive/b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81.tar.gz",
         "pkg:npm/npmlog@6.0.2",
-        "pkg:npm/old-man-from-scene-24?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#packages/old-man-from-scene-24",
+        "pkg:npm/old-man-from-scene-24?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#packages/old-man-from-scene-24",
         "pkg:npm/once@1.4.0",
-        "pkg:npm/once@1.4.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#external-packages/once",
+        "pkg:npm/once@1.4.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#external-packages/once",
         "pkg:npm/p-map@4.0.0",
         "pkg:npm/path-is-absolute@1.0.1",
         "pkg:npm/path-key@3.1.1",
@@ -139,13 +138,13 @@
         "pkg:npm/string-width@4.2.3",
         "pkg:npm/string-width@5.1.2",
         "pkg:npm/string_decoder@1.3.0",
-        "pkg:npm/strip-ansi@4.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#external-packages/strip-ansi-4.0.0.tgz",
+        "pkg:npm/strip-ansi@4.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#external-packages/strip-ansi-4.0.0.tgz",
         "pkg:npm/strip-ansi@6.0.1",
         "pkg:npm/strip-ansi@7.1.0",
         "pkg:npm/supports-color@7.2.0",
-        "pkg:npm/supports-hyperlinks@3.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#external-packages/supports-hyperlinks",
+        "pkg:npm/supports-hyperlinks@3.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#external-packages/supports-hyperlinks",
         "pkg:npm/tar@6.1.15",
-        "pkg:npm/the-answer?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#packages/the-answer",
+        "pkg:npm/the-answer?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#packages/the-answer",
         "pkg:npm/tree-sitter-json@0.20.0",
         "pkg:npm/typescript@5.1.6",
         "pkg:npm/unique-filename@3.0.0",
@@ -363,7 +362,7 @@
       "version": "6.0.1"
     },
     {
-      "bom-ref": "pkg:npm/ansi-regex@6.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#external-packages/ansi-regex",
+      "bom-ref": "pkg:npm/ansi-regex@6.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#external-packages/ansi-regex",
       "name": "ansi-regex",
       "properties": [
         {
@@ -371,7 +370,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/ansi-regex@6.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#external-packages/ansi-regex",
+      "purl": "pkg:npm/ansi-regex@6.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#external-packages/ansi-regex",
       "type": "library",
       "version": "6.0.1"
     },
@@ -441,7 +440,7 @@
       "version": "1.0.2"
     },
     {
-      "bom-ref": "pkg:npm/berryscary?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0",
+      "bom-ref": "pkg:npm/berryscary?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639",
       "name": "berryscary",
       "properties": [
         {
@@ -449,21 +448,8 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/berryscary?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0",
+      "purl": "pkg:npm/berryscary?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639",
       "type": "library"
-    },
-    {
-      "bom-ref": "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?checksum=sha512:b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d&download_url=https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
-      "name": "bitbucket-cachi2-npm-without-deps-second",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?checksum=sha512:b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d&download_url=https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
-      "type": "library",
-      "version": "2.0.0"
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -862,7 +848,7 @@
         "patches": [
           {
             "diff": {
-              "url": "git+https://github.com/hermetoproject/integration-tests.git@144754d226ab1add2e6dbfd25b2510afa94155d0#my-patches/fsevents.patch"
+              "url": "git+https://github.com/hermetoproject/integration-tests.git@76b311b7c4594bee833401a1618d3b706ec8c639#my-patches/fsevents.patch"
             },
             "type": "unofficial"
           },
@@ -976,7 +962,7 @@
       "version": "2.0.1"
     },
     {
-      "bom-ref": "pkg:npm/holy-hand-grenade?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#book-of-armaments",
+      "bom-ref": "pkg:npm/holy-hand-grenade?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#book-of-armaments",
       "name": "holy-hand-grenade",
       "properties": [
         {
@@ -984,7 +970,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/holy-hand-grenade?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#book-of-armaments",
+      "purl": "pkg:npm/holy-hand-grenade?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#book-of-armaments",
       "type": "library"
     },
     {
@@ -1202,13 +1188,13 @@
         "patches": [
           {
             "diff": {
-              "url": "git+https://github.com/hermetoproject/integration-tests.git@144754d226ab1add2e6dbfd25b2510afa94155d0#my-patches/left-pad.patch"
+              "url": "git+https://github.com/hermetoproject/integration-tests.git@76b311b7c4594bee833401a1618d3b706ec8c639#my-patches/left-pad.patch"
             },
             "type": "unofficial"
           },
           {
             "diff": {
-              "url": "git+https://github.com/hermetoproject/integration-tests.git@144754d226ab1add2e6dbfd25b2510afa94155d0#my-patches/left-pad-2.patch"
+              "url": "git+https://github.com/hermetoproject/integration-tests.git@76b311b7c4594bee833401a1618d3b706ec8c639#my-patches/left-pad-2.patch"
             },
             "type": "unofficial"
           }
@@ -1530,7 +1516,7 @@
         "patches": [
           {
             "diff": {
-              "url": "git+https://github.com/hermetoproject/integration-tests.git@144754d226ab1add2e6dbfd25b2510afa94155d0#.yarn/patches/ccto-wo-deps-git@github.com-e0fce8c89c.patch"
+              "url": "git+https://github.com/hermetoproject/integration-tests.git@76b311b7c4594bee833401a1618d3b706ec8c639#.yarn/patches/ccto-wo-deps-git@github.com-e0fce8c89c.patch"
             },
             "type": "unofficial"
           }
@@ -1560,7 +1546,7 @@
       "version": "6.0.2"
     },
     {
-      "bom-ref": "pkg:npm/old-man-from-scene-24?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#packages/old-man-from-scene-24",
+      "bom-ref": "pkg:npm/old-man-from-scene-24?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#packages/old-man-from-scene-24",
       "name": "old-man-from-scene-24",
       "properties": [
         {
@@ -1568,7 +1554,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/old-man-from-scene-24?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#packages/old-man-from-scene-24",
+      "purl": "pkg:npm/old-man-from-scene-24?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#packages/old-man-from-scene-24",
       "type": "library"
     },
     {
@@ -1585,7 +1571,7 @@
       "version": "1.4.0"
     },
     {
-      "bom-ref": "pkg:npm/once@1.4.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#external-packages/once",
+      "bom-ref": "pkg:npm/once@1.4.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#external-packages/once",
       "name": "once",
       "properties": [
         {
@@ -1593,7 +1579,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/once@1.4.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#external-packages/once",
+      "purl": "pkg:npm/once@1.4.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#external-packages/once",
       "type": "library",
       "version": "1.4.0"
     },
@@ -1923,7 +1909,7 @@
       "version": "1.3.0"
     },
     {
-      "bom-ref": "pkg:npm/strip-ansi@4.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#external-packages/strip-ansi-4.0.0.tgz",
+      "bom-ref": "pkg:npm/strip-ansi@4.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#external-packages/strip-ansi-4.0.0.tgz",
       "name": "strip-ansi",
       "properties": [
         {
@@ -1931,7 +1917,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/strip-ansi@4.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#external-packages/strip-ansi-4.0.0.tgz",
+      "purl": "pkg:npm/strip-ansi@4.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#external-packages/strip-ansi-4.0.0.tgz",
       "type": "library",
       "version": "4.0.0"
     },
@@ -1975,7 +1961,7 @@
       "version": "7.2.0"
     },
     {
-      "bom-ref": "pkg:npm/supports-hyperlinks@3.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#external-packages/supports-hyperlinks",
+      "bom-ref": "pkg:npm/supports-hyperlinks@3.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#external-packages/supports-hyperlinks",
       "name": "supports-hyperlinks",
       "properties": [
         {
@@ -1983,7 +1969,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/supports-hyperlinks@3.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#external-packages/supports-hyperlinks",
+      "purl": "pkg:npm/supports-hyperlinks@3.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#external-packages/supports-hyperlinks",
       "type": "library",
       "version": "3.0.0"
     },
@@ -2001,7 +1987,7 @@
       "version": "6.1.15"
     },
     {
-      "bom-ref": "pkg:npm/the-answer?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#packages/the-answer",
+      "bom-ref": "pkg:npm/the-answer?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#packages/the-answer",
       "name": "the-answer",
       "properties": [
         {
@@ -2009,7 +1995,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/the-answer?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40144754d226ab1add2e6dbfd25b2510afa94155d0#packages/the-answer",
+      "purl": "pkg:npm/the-answer?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4076b311b7c4594bee833401a1618d3b706ec8c639#packages/the-answer",
       "type": "library"
     },
     {

--- a/tests/integration/test_data/yarn_v4/bom.json
+++ b/tests/integration/test_data/yarn_v4/bom.json
@@ -22,14 +22,13 @@
         "pkg:npm/ansi-regex@3.0.1",
         "pkg:npm/ansi-regex@5.0.1",
         "pkg:npm/ansi-regex@6.0.1",
-        "pkg:npm/ansi-regex@6.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#external-packages/ansi-regex",
+        "pkg:npm/ansi-regex@6.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#external-packages/ansi-regex",
         "pkg:npm/ansi-styles@4.3.0",
         "pkg:npm/ansi-styles@6.2.1",
         "pkg:npm/aproba@2.0.0",
         "pkg:npm/are-we-there-yet@3.0.1",
         "pkg:npm/balanced-match@1.0.2",
-        "pkg:npm/berryscary?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149",
-        "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?checksum=sha512:b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d&download_url=https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
+        "pkg:npm/berryscary?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89",
         "pkg:npm/brace-expansion@1.1.11",
         "pkg:npm/brace-expansion@2.0.1",
         "pkg:npm/cacache@17.1.3",
@@ -68,7 +67,7 @@
         "pkg:npm/graceful-fs@4.2.11",
         "pkg:npm/has-flag@4.0.0",
         "pkg:npm/has-unicode@2.0.1",
-        "pkg:npm/holy-hand-grenade?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#book-of-armaments",
+        "pkg:npm/holy-hand-grenade?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#book-of-armaments",
         "pkg:npm/http-cache-semantics@4.1.1",
         "pkg:npm/http-proxy-agent@5.0.0",
         "pkg:npm/https-proxy-agent@5.0.1",
@@ -111,9 +110,9 @@
         "pkg:npm/nopt@6.0.0",
         "pkg:npm/npm-without-deps@1.0.0?checksum=sha512:da9ab3e8fcea43cf17fba24e5add8675bfa4002050b32853b8348588515d2bed19e4866d2071010048b170c129897eb1c4919239885c6a0eaf2bbf490ed840f8&download_url=https://github.com/hermetoproject/integration-tests/archive/b7dacdbf112ce0ea17a75c389e9e0f2f70f5be81.tar.gz",
         "pkg:npm/npmlog@6.0.2",
-        "pkg:npm/old-man-from-scene-24?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#packages/old-man-from-scene-24",
+        "pkg:npm/old-man-from-scene-24?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#packages/old-man-from-scene-24",
         "pkg:npm/once@1.4.0",
-        "pkg:npm/once@1.4.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#external-packages/once",
+        "pkg:npm/once@1.4.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#external-packages/once",
         "pkg:npm/p-map@4.0.0",
         "pkg:npm/path-is-absolute@1.0.1",
         "pkg:npm/path-key@3.1.1",
@@ -139,13 +138,13 @@
         "pkg:npm/string-width@4.2.3",
         "pkg:npm/string-width@5.1.2",
         "pkg:npm/string_decoder@1.3.0",
-        "pkg:npm/strip-ansi@4.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#external-packages/strip-ansi-4.0.0.tgz",
+        "pkg:npm/strip-ansi@4.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#external-packages/strip-ansi-4.0.0.tgz",
         "pkg:npm/strip-ansi@6.0.1",
         "pkg:npm/strip-ansi@7.1.0",
         "pkg:npm/supports-color@7.2.0",
-        "pkg:npm/supports-hyperlinks@3.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#external-packages/supports-hyperlinks",
+        "pkg:npm/supports-hyperlinks@3.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#external-packages/supports-hyperlinks",
         "pkg:npm/tar@6.1.15",
-        "pkg:npm/the-answer?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#packages/the-answer",
+        "pkg:npm/the-answer?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#packages/the-answer",
         "pkg:npm/tree-sitter-json@0.20.0",
         "pkg:npm/typescript@5.1.6",
         "pkg:npm/unique-filename@3.0.0",
@@ -363,7 +362,7 @@
       "version": "6.0.1"
     },
     {
-      "bom-ref": "pkg:npm/ansi-regex@6.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#external-packages/ansi-regex",
+      "bom-ref": "pkg:npm/ansi-regex@6.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#external-packages/ansi-regex",
       "name": "ansi-regex",
       "properties": [
         {
@@ -371,7 +370,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/ansi-regex@6.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#external-packages/ansi-regex",
+      "purl": "pkg:npm/ansi-regex@6.0.1?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#external-packages/ansi-regex",
       "type": "library",
       "version": "6.0.1"
     },
@@ -441,7 +440,7 @@
       "version": "1.0.2"
     },
     {
-      "bom-ref": "pkg:npm/berryscary?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149",
+      "bom-ref": "pkg:npm/berryscary?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89",
       "name": "berryscary",
       "properties": [
         {
@@ -449,21 +448,8 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/berryscary?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149",
+      "purl": "pkg:npm/berryscary?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89",
       "type": "library"
-    },
-    {
-      "bom-ref": "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?checksum=sha512:b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d&download_url=https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
-      "name": "bitbucket-cachi2-npm-without-deps-second",
-      "properties": [
-        {
-          "name": "hermeto:found_by",
-          "value": "hermeto"
-        }
-      ],
-      "purl": "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0?checksum=sha512:b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d&download_url=https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
-      "type": "library",
-      "version": "2.0.0"
     },
     {
       "bom-ref": "pkg:npm/brace-expansion@1.1.11",
@@ -862,7 +848,7 @@
         "patches": [
           {
             "diff": {
-              "url": "git+https://github.com/hermetoproject/integration-tests.git@019dc22eb5238d908907b167fa960c8a5fa96149#my-patches/fsevents.patch"
+              "url": "git+https://github.com/hermetoproject/integration-tests.git@2e9799eb0817e297cb045fc690505ce963cf3a89#my-patches/fsevents.patch"
             },
             "type": "unofficial"
           },
@@ -976,7 +962,7 @@
       "version": "2.0.1"
     },
     {
-      "bom-ref": "pkg:npm/holy-hand-grenade?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#book-of-armaments",
+      "bom-ref": "pkg:npm/holy-hand-grenade?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#book-of-armaments",
       "name": "holy-hand-grenade",
       "properties": [
         {
@@ -984,7 +970,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/holy-hand-grenade?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#book-of-armaments",
+      "purl": "pkg:npm/holy-hand-grenade?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#book-of-armaments",
       "type": "library"
     },
     {
@@ -1202,13 +1188,13 @@
         "patches": [
           {
             "diff": {
-              "url": "git+https://github.com/hermetoproject/integration-tests.git@019dc22eb5238d908907b167fa960c8a5fa96149#my-patches/left-pad.patch"
+              "url": "git+https://github.com/hermetoproject/integration-tests.git@2e9799eb0817e297cb045fc690505ce963cf3a89#my-patches/left-pad.patch"
             },
             "type": "unofficial"
           },
           {
             "diff": {
-              "url": "git+https://github.com/hermetoproject/integration-tests.git@019dc22eb5238d908907b167fa960c8a5fa96149#my-patches/left-pad-2.patch"
+              "url": "git+https://github.com/hermetoproject/integration-tests.git@2e9799eb0817e297cb045fc690505ce963cf3a89#my-patches/left-pad-2.patch"
             },
             "type": "unofficial"
           }
@@ -1530,7 +1516,7 @@
         "patches": [
           {
             "diff": {
-              "url": "git+https://github.com/hermetoproject/integration-tests.git@019dc22eb5238d908907b167fa960c8a5fa96149#.yarn/patches/ccto-wo-deps-git@github.com-e0fce8c89c.patch"
+              "url": "git+https://github.com/hermetoproject/integration-tests.git@2e9799eb0817e297cb045fc690505ce963cf3a89#.yarn/patches/ccto-wo-deps-git@github.com-e0fce8c89c.patch"
             },
             "type": "unofficial"
           }
@@ -1560,7 +1546,7 @@
       "version": "6.0.2"
     },
     {
-      "bom-ref": "pkg:npm/old-man-from-scene-24?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#packages/old-man-from-scene-24",
+      "bom-ref": "pkg:npm/old-man-from-scene-24?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#packages/old-man-from-scene-24",
       "name": "old-man-from-scene-24",
       "properties": [
         {
@@ -1568,7 +1554,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/old-man-from-scene-24?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#packages/old-man-from-scene-24",
+      "purl": "pkg:npm/old-man-from-scene-24?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#packages/old-man-from-scene-24",
       "type": "library"
     },
     {
@@ -1585,7 +1571,7 @@
       "version": "1.4.0"
     },
     {
-      "bom-ref": "pkg:npm/once@1.4.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#external-packages/once",
+      "bom-ref": "pkg:npm/once@1.4.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#external-packages/once",
       "name": "once",
       "properties": [
         {
@@ -1593,7 +1579,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/once@1.4.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#external-packages/once",
+      "purl": "pkg:npm/once@1.4.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#external-packages/once",
       "type": "library",
       "version": "1.4.0"
     },
@@ -1923,7 +1909,7 @@
       "version": "1.3.0"
     },
     {
-      "bom-ref": "pkg:npm/strip-ansi@4.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#external-packages/strip-ansi-4.0.0.tgz",
+      "bom-ref": "pkg:npm/strip-ansi@4.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#external-packages/strip-ansi-4.0.0.tgz",
       "name": "strip-ansi",
       "properties": [
         {
@@ -1931,7 +1917,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/strip-ansi@4.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#external-packages/strip-ansi-4.0.0.tgz",
+      "purl": "pkg:npm/strip-ansi@4.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#external-packages/strip-ansi-4.0.0.tgz",
       "type": "library",
       "version": "4.0.0"
     },
@@ -1975,7 +1961,7 @@
       "version": "7.2.0"
     },
     {
-      "bom-ref": "pkg:npm/supports-hyperlinks@3.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#external-packages/supports-hyperlinks",
+      "bom-ref": "pkg:npm/supports-hyperlinks@3.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#external-packages/supports-hyperlinks",
       "name": "supports-hyperlinks",
       "properties": [
         {
@@ -1983,7 +1969,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/supports-hyperlinks@3.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#external-packages/supports-hyperlinks",
+      "purl": "pkg:npm/supports-hyperlinks@3.0.0?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#external-packages/supports-hyperlinks",
       "type": "library",
       "version": "3.0.0"
     },
@@ -2001,7 +1987,7 @@
       "version": "6.1.15"
     },
     {
-      "bom-ref": "pkg:npm/the-answer?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#packages/the-answer",
+      "bom-ref": "pkg:npm/the-answer?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#packages/the-answer",
       "name": "the-answer",
       "properties": [
         {
@@ -2009,7 +1995,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:npm/the-answer?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40019dc22eb5238d908907b167fa960c8a5fa96149#packages/the-answer",
+      "purl": "pkg:npm/the-answer?vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%402e9799eb0817e297cb045fc690505ce963cf3a89#packages/the-answer",
       "type": "library"
     },
     {

--- a/tests/unit/package_managers/npm/test_resolver.py
+++ b/tests/unit/package_managers/npm/test_resolver.py
@@ -647,17 +647,17 @@ def test_resolve_npm_unsupported_lockfileversion(rooted_tmp_path: RootedPath) ->
 def test_clone_repo_pack_archive(
     mock_clone_as_tarball: mock.Mock, rooted_tmp_path: RootedPath
 ) -> None:
-    vcs = NormalizedUrl("git+ssh://bitbucket.org/cachi-testing/cachi2-without-deps.git#9e164b9")
+    vcs = NormalizedUrl("git+ssh://bitbucket.org/example-org/example-repo.git#9e164b9")
     download_path = _clone_repo_pack_archive(vcs, rooted_tmp_path)
     expected_path = rooted_tmp_path.join_within_root(
         "bitbucket.org",
-        "cachi-testing",
-        "cachi2-without-deps",
-        "cachi2-without-deps-external-gitcommit-9e164b9.tgz",
+        "example-org",
+        "example-repo",
+        "example-repo-external-gitcommit-9e164b9.tgz",
     )
     assert download_path.path.parent.is_dir()
     mock_clone_as_tarball.assert_called_once_with(
-        "ssh://bitbucket.org/cachi-testing/cachi2-without-deps.git", "9e164b9", expected_path.path
+        "ssh://bitbucket.org/example-org/example-repo.git", "9e164b9", expected_path.path
     )
 
 
@@ -896,9 +896,9 @@ def test_update_package_json_files(
                     "version": "2.0.0",
                     "integrity": "sha512-YOLO33333==",
                 },
-                "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps-second.git#09992d418fc44a2895b7a9ff27c4e32d6f74a982": {
+                "git+ssh://git@bitbucket.org/example-org/example-repo-second.git#09992d418fc44a2895b7a9ff27c4e32d6f74a982": {
                     "version": "2.0.0",
-                    "name": "cachi2-without-deps-second",
+                    "name": "example-repo-second",
                 },
                 # Test short representation of git reference
                 "git+ssh://git@github.com/kevva/is-positive.git#97edff6f": {
@@ -914,7 +914,7 @@ def test_update_package_json_files(
             {
                 "https://github.com/hermetoproject/ms-1.0.0.tgz": "external-ms/ms-external-sha256-YOLO1111.tgz",
                 "https://github.com/hermetoproject/ms-2.0.0.tgz": "external-ms/ms-external-sha256-YOLO2222.tgz",
-                "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps-second.git#09992d418fc44a2895b7a9ff27c4e32d6f74a982": "bitbucket.org/cachi-testing/cachi2-without-deps-second/cachi2-without-deps-second-external-gitcommit-09992d418fc44a2895b7a9ff27c4e32d6f74a982.tgz",
+                "git+ssh://git@bitbucket.org/example-org/example-repo-second.git#09992d418fc44a2895b7a9ff27c4e32d6f74a982": "bitbucket.org/example-org/example-repo-second/example-repo-second-external-gitcommit-09992d418fc44a2895b7a9ff27c4e32d6f74a982.tgz",
                 "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.0.11.tgz": "types-react-dom-18.0.11.tgz",
                 "https://registry.yarnpkg.com/abbrev/-/abbrev-2.0.0.tgz": "abbrev-2.0.0.tgz",
                 "git+ssh://git@github.com/kevva/is-positive.git#97edff6f": "github.com/kevva/is-positive/is-positive-external-gitcommit-97edff6f.tgz",
@@ -982,9 +982,9 @@ def test_npm_settings_rejects_proxy_urls_containing_credentials(
                     "version": "1.0.0",
                     "integrity": "completely-fake",
                 },
-                "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps-second.git#09992d418fc44a2895b7a9ff27c4e32d6f74a982": {
+                "git+ssh://git@bitbucket.org/example-org/example-repo-second.git#09992d418fc44a2895b7a9ff27c4e32d6f74a982": {
                     "version": "2.0.0",
-                    "name": "cachi2-without-deps-second",
+                    "name": "example-repo-second",
                 },
                 "git+ssh://git@github.com/kevva/is-positive.git#97edff6f": {
                     "integrity": "completely-fake",

--- a/tests/unit/package_managers/npm/test_utils.py
+++ b/tests/unit/package_managers/npm/test_utils.py
@@ -30,13 +30,13 @@ def test_is_from_npm_registry_can_parse_incorrect_registry_urls() -> None:
     "vcs, expected",
     [
         (
-            (f"git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps.git#{GIT_REF}"),
+            (f"git+ssh://git@bitbucket.org/example-org/example-repo.git#{GIT_REF}"),
             {
-                "url": "ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps.git",
+                "url": "ssh://git@bitbucket.org/example-org/example-repo.git",
                 "ref": GIT_REF,
                 "host": "bitbucket.org",
-                "namespace": "cachi-testing",
-                "repo": "cachi2-without-deps",
+                "namespace": "example-org",
+                "repo": "example-repo",
             },
         ),
     ],
@@ -46,10 +46,9 @@ def test_extract_git_info_npm(vcs: NormalizedUrl, expected: dict[str, str]) -> N
 
 
 def test_extract_git_info_with_missing_ref() -> None:
-    vcs = NormalizedUrl("git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps.git")
+    vcs = NormalizedUrl("git+ssh://git@bitbucket.org/example-org/example-repo.git")
     expected_error = (
-        "ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps.git "
-        "is not valid VCS url. ref is missing."
+        "ssh://git@bitbucket.org/example-org/example-repo.git is not valid VCS url. ref is missing."
     )
     with pytest.raises(UnexpectedFormat, match=expected_error):
         extract_git_info_npm(vcs)
@@ -64,8 +63,8 @@ def test_extract_git_info_with_missing_ref() -> None:
         ),
         ("github:kevva/is-positive", "git+ssh://git@github.com/kevva/is-positive.git"),
         (
-            "bitbucket:cachi-testing/cachi2-without-deps#9e164b9",
-            "git+ssh://git@bitbucket.org/cachi-testing/cachi2-without-deps.git#9e164b9",
+            "bitbucket:example-org/example-repo#9e164b9",
+            "git+ssh://git@bitbucket.org/example-org/example-repo.git#9e164b9",
         ),
         ("gitlab:foo/bar#YOLO", "git+ssh://git@gitlab.com/foo/bar.git#YOLO"),
     ],

--- a/tests/unit/package_managers/yarn/test_locators.py
+++ b/tests/unit/package_managers/yarn/test_locators.py
@@ -40,7 +40,7 @@ SUPPORTED_LOCATORS = [
     "strip-ansi-tarball@file:../../external-packages/strip-ansi-4.0.0.tgz::locator=the-answer%40workspace%3Apackages%2Fthe-answer",
     "strip-ansi-tarball@file:external-packages/strip-ansi-4.0.0.tgz::locator=berryscary%40workspace%3A.",
     # https dep
-    "c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
+    "c2-wo-deps-2@https://bitbucket.org/example-org/example-repo-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
     # optional custom patch for a registry dep
     "left-pad@npm:1.3.0",
     "left-pad@patch:left-pad@npm%3A1.3.0#~./my-patches/left-pad.patch::version=1.3.0&hash=629bda&locator=berryscary%40workspace%3A.",
@@ -69,7 +69,7 @@ UNSUPPORTED_LOCATORS = [
     # exec dep
     "holy-hand-grenade@exec:./generate-holy-hand-grenade.js#./generate-holy-hand-grenade.js::hash=3b5cbd&locator=berryscary%40workspace%3A.",
     # git deps
-    "c2-wo-deps@https://bitbucket.org/cachi-testing/cachi2-without-deps.git#commit=9e164b97043a2d91bbeb992f6cc68a3d1015086a",
+    "c2-wo-deps@https://bitbucket.org/example-org/example-repo.git#commit=9e164b97043a2d91bbeb992f6cc68a3d1015086a",
     "is-positive@git@github.com:kevva/is-positive.git#commit=97edff6f525f192a3f83cea1944765f769ae2678",
     # specific workspace of a git dep
     "npm-lifecycle-scripts@https://github.com/chmeliik/js-lifecycle-scripts.git#workspace=my-workspace&commit=0e786c88d5aca79a68428dadaed4b096bf2ae3e0",
@@ -181,12 +181,12 @@ PARSED_LOCATORS_AND_REFERENCES = [
         _ParsedLocator(
             scope=None,
             name="c2-wo-deps-2",
-            raw_reference="https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
+            raw_reference="https://bitbucket.org/example-org/example-repo-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
         ),
         _ParsedReference(
             protocol="https:",
             source=None,
-            selector="//bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
+            selector="//bitbucket.org/example-org/example-repo-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
             params=None,
         ),
     ),
@@ -365,11 +365,11 @@ PARSED_LOCATORS_AND_REFERENCES = [
         _ParsedLocator(
             scope=None,
             name="c2-wo-deps",
-            raw_reference="https://bitbucket.org/cachi-testing/cachi2-without-deps.git#commit=9e164b97043a2d91bbeb992f6cc68a3d1015086a",
+            raw_reference="https://bitbucket.org/example-org/example-repo.git#commit=9e164b97043a2d91bbeb992f6cc68a3d1015086a",
         ),
         _ParsedReference(
             protocol="https:",
-            source="//bitbucket.org/cachi-testing/cachi2-without-deps.git",
+            source="//bitbucket.org/example-org/example-repo.git",
             selector="commit=9e164b97043a2d91bbeb992f6cc68a3d1015086a",
             params=None,
         ),
@@ -451,7 +451,7 @@ PARSED_SUPPORTED_LOCATORS = [
         locator=WorkspaceLocator(scope=None, name="berryscary", relpath=Path(".")),
     ),
     HttpsLocator(
-        url="https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz"
+        url="https://bitbucket.org/example-org/example-repo-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz"
     ),
     NpmLocator(scope=None, name="left-pad", version="1.3.0"),
     PatchLocator(

--- a/tests/unit/package_managers/yarn/test_resolver.py
+++ b/tests/unit/package_managers/yarn/test_resolver.py
@@ -74,7 +74,7 @@ YARN_INFO_OUTPUTS = [
         },
     },
     {
-        "value": "c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
+        "value": "c2-wo-deps-2@https://bitbucket.org/example-org/example-repo-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
         "children": {
             "Version": "2.0.0",
             "Cache": {
@@ -164,7 +164,7 @@ EXPECT_PACKAGES = [
     ),
     Package(raw_locator="berryscary@workspace:.", version=None, checksum=None, cache_path=None),
     Package(
-        raw_locator="c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
+        raw_locator="c2-wo-deps-2@https://bitbucket.org/example-org/example-repo-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
         version="2.0.0",
         checksum="b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d",
         cache_path="{repo_dir}/.yarn/cache/c2-wo-deps-2-https-4261b189d8-b194fd1f4a.zip",
@@ -549,27 +549,27 @@ def mock_project(project_dir: RootedPath) -> Project:
         pytest.param(
             MockedPackage(
                 Package(
-                    raw_locator="@hermeto/c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
+                    raw_locator="@hermeto/c2-wo-deps-2@https://bitbucket.org/example-org/example-repo-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
                     version="2.0.0",
                     checksum="b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d",
                     cache_path="cache/directory/c2-wo-deps-2-https-4261b189d8-b194fd1f4a.zip",
                 ),
                 is_hardlink=True,
                 packjson_path="node_modules/@hermeto/c2-wo-deps-2/package.json",
-                packjson_content=json.dumps({"name": "bitbucket-cachi2-npm-without-deps-second"}),
+                packjson_content=json.dumps({"name": "bitbucket-example-repo-second"}),
             ),
             Component(
-                name="bitbucket-cachi2-npm-without-deps-second",
+                name="bitbucket-example-repo-second",
                 version="2.0.0",
                 purl=(
-                    "pkg:npm/bitbucket-cachi2-npm-without-deps-second@2.0.0"
+                    "pkg:npm/bitbucket-example-repo-second@2.0.0"
                     "?checksum=sha512:b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d"
-                    "&download_url=https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz"
+                    "&download_url=https://bitbucket.org/example-org/example-repo-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz"
                 ),
             ),
             [
                 (
-                    "@hermeto/c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz: "
+                    "@hermeto/c2-wo-deps-2@https://bitbucket.org/example-org/example-repo-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz: "
                     "reading package name from cache/directory/c2-wo-deps-2-https-4261b189d8-b194fd1f4a.zip"
                 ),
             ],
@@ -918,7 +918,7 @@ def test_create_components_patched_packages_with_multiple_paths(
         pytest.param(
             MockedPackage(
                 Package(
-                    raw_locator="@hermeto/c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
+                    raw_locator="@hermeto/c2-wo-deps-2@https://bitbucket.org/example-org/example-repo-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz",
                     version="2.0.0",
                     checksum="b194fd1f4a79472a332fec936818d1713a222157e845a8d466a239fdc950130a7ad9b77c212d69d2947c07bce0c911446496ff47dec5a73b4368f0a9c9432b1d",
                     cache_path=None,
@@ -927,7 +927,7 @@ def test_create_components_patched_packages_with_multiple_paths(
             ),
             (
                 "Failed to resolve the name and version for "
-                "@hermeto/c2-wo-deps-2@https://bitbucket.org/cachi-testing/cachi2-without-deps-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz: "
+                "@hermeto/c2-wo-deps-2@https://bitbucket.org/example-org/example-repo-second/get/09992d418fc44a2895b7a9ff27c4e32d6f74a982.tar.gz: "
                 "expected a zip archive in the cache but 'yarn info' says there is none"
             ),
             id="https_no_cache_path",


### PR DESCRIPTION
Regenerate integration test data and replace refs in unit tests with example-org/example-repo due to disappearance of bitbucket.
