### PR TITLE
Artifact registry proxy support in gomod

### DIFF
--- a/hermeto/core/config.py
+++ b/hermeto/core/config.py
@@ -134,10 +134,12 @@ class YarnSettings(ProxyMixin, extra="forbid"):
     enabled: bool = True
 
 
-class GomodSettings(BaseModel, extra="forbid"):
+class GomodSettings(ProxyMixin, extra="forbid"):
     """Settings for Go modules."""
 
-    proxy_url: str = "https://proxy.golang.org,direct"
+    # TODO: refactor typesystem to trivially include comma-separated lists of URLs.
+    # Ignore type error until that happens.
+    proxy_url: str = "https://proxy.golang.org,direct"  # type: ignore
     download_max_tries: int = 5
     environment_variables: dict[str, str] = {}
 

--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -55,7 +55,7 @@ from hermeto.core.package_managers.gomod.go import (
 )
 from hermeto.core.package_managers.gomod.utils import _clean_go_modcache, _go_exec_env
 from hermeto.core.rooted_path import RootedPath
-from hermeto.core.scm import GitRepo, get_repo_for_path, get_repo_id
+from hermeto.core.scm import GitRepo, RepoID, get_repo_for_path, get_repo_id
 from hermeto.core.utils import GIT_PRISTINE_ENV, load_json_stream
 from hermeto.interface.logging import EnforcingModeLoggerAdapter
 
@@ -127,6 +127,8 @@ class Module(NamedTuple):
         had a checksum for this module but didn't
     proxy: the list of custom proxy URLs used to fetch this module, or None if the module was
         fetched directly from VCS or only via the canonical Go proxy (proxy.golang.org).
+    repo_id: optional RepoID to carry data necessary to construct vcs_url
+    local_replace: a flag to mark Modules which were obtained via a replace with a local path.
     """
 
     name: str
@@ -136,6 +138,8 @@ class Module(NamedTuple):
     main: bool = False
     missing_hash_in_file: Path | None = None
     proxy: list[str] | None = None
+    repo_id: RepoID | None = None
+    local_replace: bool = False
 
     @property
     def purl(self) -> str:
@@ -144,7 +148,7 @@ class Module(NamedTuple):
             type="golang",
             name=self.real_path,
             version=self.version,
-            qualifiers={"type": "module"},
+            qualifiers={"type": "module"} | _vcs_url_if_needed(self),
         )
         return purl.to_string()
 
@@ -204,13 +208,24 @@ class Package(NamedTuple):
             type="golang",
             name=self.real_path,
             version=self.module.version,
-            qualifiers={"type": "package"},
+            qualifiers={"type": "package"} | _vcs_url_if_needed(self.module),
         )
         return purl.to_string()
 
     def to_component(self) -> Component:
         """Create a SBOM component for this package."""
         return Component(name=self.name, version=self.module.version, purl=self.purl)
+
+
+def _vcs_url_if_needed(module: Module) -> dict:
+    """Determine whether a vcs_url qualifier is necessary and provide one."""
+    if (module.main or module.local_replace) and (module.repo_id is not None):
+        # The main module is always consumed from a local filesystem and it is always
+        # a clone of a repository, thus adding vcs_url to it.
+        # Local replaces need a vcs_url as well and are supposed to be consumed from the file
+        # system too.
+        return {"vcs_url": module.repo_id.as_vcs_url_qualifier()}
+    return dict()
 
 
 class StandardPackage(NamedTuple):
@@ -296,6 +311,7 @@ def _create_modules_from_parsed_data(
         original_name = module.path
         missing_hash_in_file = None
 
+        repo_id, proxy, local_replace = None, None, False
         if not version_or_path.startswith("."):
             version = version_or_path
             real_path = name
@@ -314,7 +330,8 @@ def _create_modules_from_parsed_data(
             resolved_replacement_path = main_module_dir.join_within_root(version_or_path)
             version = version_resolver.get_golang_version(module.path, resolved_replacement_path)
             real_path = _resolve_path_for_local_replacement(module)
-            proxy = None
+            local_replace = True
+            repo_id = get_repo_id(main_module_dir.path)
 
         return Module(
             name=name,
@@ -323,6 +340,8 @@ def _create_modules_from_parsed_data(
             real_path=real_path,
             missing_hash_in_file=missing_hash_in_file,
             proxy=proxy,
+            local_replace=local_replace,
+            repo_id=repo_id,
         )
 
     def _resolve_path_for_local_replacement(module: ParsedModule) -> str:
@@ -561,10 +580,13 @@ def _create_main_module_from_parsed_data(
     if repo_name is None:
         # PERMISSIVE mode without git repo - use the module path as resolved_path
         resolved_path = parsed_main_module.path
+        repo_id = None
     elif str(resolved_subpath) == ".":
         resolved_path = repo_name
+        repo_id = get_repo_id(main_module_dir)
     else:
         resolved_path = f"{repo_name}/{resolved_subpath}"
+        repo_id = get_repo_id(main_module_dir)
 
     if not parsed_main_module.version:
         # Should not happen, since the version is always resolved from the Git repo
@@ -576,6 +598,7 @@ def _create_main_module_from_parsed_data(
         version=parsed_main_module.version,
         real_path=resolved_path,
         main=True,
+        repo_id=repo_id,
     )
 
 

--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -227,7 +227,7 @@ class Package(NamedTuple):
         )
 
 
-def _vcs_url_if_needed(module: Module) -> dict:
+def _vcs_url_if_needed(module: Module) -> dict[str, str]:
     """Determine whether a vcs_url qualifier is necessary and provide one."""
     if (module.main or module.local_replace) and (module.repo_id is not None):
         # The main module is always consumed from a local filesystem and it is always
@@ -728,6 +728,82 @@ def _parse_packages(
     return iter(all_packages)
 
 
+def _determine_cache_path(should_vendor: bool, tmp_dir: Path) -> str:
+    if should_vendor:
+        # Even though we do not perform a "go mod download" when vendoring is detected, some
+        # go commands still download dependencies as a side effect. Since we don't want those
+        # copied to the output dir, we need to set the GOMODCACHE to a different directory.
+        return f"{tmp_dir}/vendor-cache"
+    return f"{tmp_dir}/pkg/mod"
+
+
+def _prepare_run_params(
+    request_flags: Iterable[str],
+    should_vendor: bool,
+    tmp_dir: Path,
+    app_dir: RootedPath,
+    temp_netrc_dir: Path,
+) -> dict:
+    config = get_config()
+    gomod_cache = _determine_cache_path(should_vendor, tmp_dir)
+
+    go_vars: dict[str, str] = {
+        "GOPATH": str(tmp_dir),
+        "GO111MODULE": "on",
+        "GOCACHE": str(tmp_dir),
+        "GOMODCACHE": gomod_cache,
+        "GOSUMDB": "sum.golang.org",
+        "GOTOOLCHAIN": "auto",
+    }
+    if config.gomod.proxy_url:
+        go_vars["GOPROXY"] = config.gomod.proxy_url
+
+    if config.gomod.proxy_login is not None:
+        # This is supposed to be happening only in systems utilizing artifact registry proxies.
+        if "," in config.gomod.proxy_url:
+            raise InvalidInput(
+                "proxy_url must contain exactly one URL when login is present. "
+                f"Contains now: {config.gomod.proxy_url}"
+            )
+        path_to_netrc = inject_netrc(prepare_netrc_contents(), temp_netrc_dir)
+        go_vars["NETRC"] = path_to_netrc
+        if os.environ.get("NETRC", ""):
+            log.warning(
+                "Proxy login was specified, at the same time a custom .netrc file path was"
+                " provided via environment. A new .netrc will be generated from proxy"
+                " parameters and will shadow the environment one. Please disable proxy"
+                " support if you intend to use the .netrc from environment."
+            )
+
+    if "cgo-disable" in request_flags:
+        go_vars["CGO_ENABLED"] = "0"
+
+    env = _go_exec_env(**go_vars)
+    run_params = {"env": env, "cwd": app_dir}
+
+    return run_params
+
+
+def _determine_which_modules_go_in_go_sum(
+    app_dir: RootedPath,
+    go_work: GoWork | None,
+) -> frozenset[ModuleID]:
+    if go_work:
+        return _parse_go_sum_from_workspaces(go_work)
+    return _parse_go_sum(app_dir.join_within_root("go.sum"))
+
+
+def _acquire_modules(
+    should_vendor: bool, go: Go, app_dir: RootedPath, go_work: GoWork | None, run_params: dict
+) -> Iterable[ParsedModule]:
+    # Vendor dependencies if the gomod-vendor flag is set
+    if should_vendor:
+        return _vendor_deps(go, app_dir, bool(go_work), run_params)
+    log.info("Downloading the gomod dependencies")
+    json_stream = go(["mod", "download", "-json"], run_params, retry=True)
+    return (ParsedModule.model_validate(obj) for obj in load_json_stream(json_stream))
+
+
 def _resolve_gomod(
     app_dir: RootedPath,
     request: Request,
@@ -750,86 +826,31 @@ def _resolve_gomod(
     :raises PackageManagerError: if fetching dependencies fails
     """
     _protect_against_symlinks(app_dir)
-
-    config = get_config()
-
     should_vendor = app_dir.join_within_root("vendor").path.is_dir()
 
-    if should_vendor:
-        # Even though we do not perform a "go mod download" when vendoring is detected, some
-        # go commands still download dependencies as a side effect. Since we don't want those
-        # copied to the output dir, we need to set the GOMODCACHE to a different directory.
-        gomod_cache = f"{tmp_dir}/vendor-cache"
-    else:
-        gomod_cache = f"{tmp_dir}/pkg/mod"
-
-    go_vars: dict[str, str] = {
-        "GOPATH": str(tmp_dir),
-        "GO111MODULE": "on",
-        "GOCACHE": str(tmp_dir),
-        "GOMODCACHE": gomod_cache,
-        "GOSUMDB": "sum.golang.org",
-        "GOTOOLCHAIN": "auto",
-    }
-    if config.gomod.proxy_url:
-        go_vars["GOPROXY"] = config.gomod.proxy_url
-
-    temp_netrc_dir = TemporaryDirectory()
-    if config.gomod.proxy_login is not None:
-        # This is supposed to be happening only in systems utilizing artifact registry proxies.
-        if "," in config.gomod.proxy_url:
-            raise InvalidInput(
-                "proxy_url must contain exactly one URL when login is present. "
-                f"Contains now: {config.gomod.proxy_url}"
-            )
-        path_to_netrc = inject_netrc(prepare_netrc_contents(), Path(temp_netrc_dir.name))
-        go_vars["NETRC"] = path_to_netrc
-        if os.environ.get("NETRC", ""):
-            log.warning(
-                "Proxy login was specified, at the same time a custom .netrc file path was"
-                " provided via environment. A new .netrc will be generated from proxy"
-                " parameters and will shadow the environment one. Please disable proxy"
-                " support if you intend to use the .netrc from environment."
-            )
-
-    if "cgo-disable" in request.flags:
-        go_vars["CGO_ENABLED"] = "0"
-
-    env = _go_exec_env(**go_vars)
-    run_params = {"env": env, "cwd": app_dir}
-
-    # Explicitly disable toolchain telemetry for go >= 1.23
-    _disable_telemetry(go, run_params)
-
-    if go_work:
-        modules_in_go_sum = _parse_go_sum_from_workspaces(go_work)
-    else:
-        modules_in_go_sum = _parse_go_sum(app_dir.join_within_root("go.sum"))
-
-    # Vendor dependencies if the gomod-vendor flag is set
-    if should_vendor:
-        downloaded_modules = _vendor_deps(go, app_dir, bool(go_work), run_params)
-    else:
-        log.info("Downloading the gomod dependencies")
-        downloaded_modules = (
-            ParsedModule.model_validate(obj)
-            for obj in load_json_stream(go(["mod", "download", "-json"], run_params, retry=True))
+    with TemporaryDirectory() as temp_netrc_dir:
+        run_params = _prepare_run_params(
+            request.flags, should_vendor, tmp_dir, app_dir, Path(temp_netrc_dir)
         )
 
-    main_module, workspace_modules = _parse_local_modules(
-        go_work, go, run_params, app_dir, version_resolver
-    )
+        # Explicitly disable toolchain telemetry for go >= 1.23
+        _disable_telemetry(go, run_params)
+        modules_in_go_sum = _determine_which_modules_go_in_go_sum(app_dir, go_work)
+        downloaded_modules = _acquire_modules(should_vendor, go, app_dir, go_work, run_params)
 
-    deps = _go_list_deps(go, "all", run_params)
-    package_modules = [pkg.module for pkg in deps if pkg.module and not pkg.module.main]
-    package_modules.extend(workspace_modules)
-    all_modules = _deduplicate_resolved_modules(package_modules, downloaded_modules)
-    _validate_local_replacements(all_modules, app_dir)
+        main_module, workspace_modules = _parse_local_modules(
+            go_work, go, run_params, app_dir, version_resolver
+        )
 
-    log.info("Retrieving the list of packages")
-    all_packages = _parse_packages(go_work, go, run_params)
+        deps = _go_list_deps(go, "all", run_params)
+        package_modules = [pkg.module for pkg in deps if pkg.module and not pkg.module.main]
+        package_modules.extend(workspace_modules)
+        all_modules = _deduplicate_resolved_modules(package_modules, downloaded_modules)
+        _validate_local_replacements(all_modules, app_dir)
 
-    temp_netrc_dir.cleanup()
+        log.info("Retrieving the list of packages")
+        all_packages = _parse_packages(go_work, go, run_params)
+
     return ResolvedGoModule(main_module, all_modules, all_packages, modules_in_go_sum)
 
 

--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -575,6 +575,7 @@ def _create_main_module_from_parsed_data(
         original_name=parsed_main_module.path,
         version=parsed_main_module.version,
         real_path=resolved_path,
+        main=True,
     )
 
 

--- a/hermeto/core/package_managers/gomod/main.py
+++ b/hermeto/core/package_managers/gomod/main.py
@@ -4,11 +4,13 @@ import os
 import re
 import shutil
 import tempfile
+import urllib
 from collections.abc import Iterable, Iterator
 from datetime import datetime, timezone
 from functools import cached_property
 from itertools import chain
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from types import TracebackType
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NoReturn, Optional
 
@@ -26,6 +28,7 @@ from hermeto.core.config import get_config
 from hermeto.core.errors import (
     FetchError,
     GitError,
+    InvalidInput,
     LockfileNotFound,
     NotAGitRepo,
     PackageManagerError,
@@ -152,6 +155,13 @@ class Module(NamedTuple):
         )
         return purl.to_string()
 
+    def get_external_refs(self) -> list[ExternalReference] | None:
+        """Get external references for a module."""
+        ref_rest = dict(type=PROXY_REF_TYPE, comment=PROXY_COMMENT)
+        if self.proxy:
+            return [ExternalReference(url=p, **ref_rest) for p in self.proxy]
+        return None
+
     def to_component(self) -> Component:
         """Create a SBOM component for this module."""
         if self.missing_hash_in_file:
@@ -159,12 +169,7 @@ class Module(NamedTuple):
         else:
             missing_hash_in_file = frozenset()
 
-        ref_rest = dict(type=PROXY_REF_TYPE, comment=PROXY_COMMENT)
-
-        if self.proxy:
-            refs = [ExternalReference(url=p, **ref_rest) for p in self.proxy]
-        else:
-            refs = None
+        refs = self.get_external_refs()
 
         return Component(
             name=self.name,
@@ -214,7 +219,12 @@ class Package(NamedTuple):
 
     def to_component(self) -> Component:
         """Create a SBOM component for this package."""
-        return Component(name=self.name, version=self.module.version, purl=self.purl)
+        return Component(
+            name=self.name,
+            version=self.module.version,
+            purl=self.purl,
+            external_references=self.module.get_external_refs(),
+        )
 
 
 def _vcs_url_if_needed(module: Module) -> dict:
@@ -244,6 +254,8 @@ class StandardPackage(NamedTuple):
 
     def to_component(self) -> Component:
         """Create a SBOM component for this package."""
+        # Note, these components come from the standard lib, they lack version, they
+        # are not collected from a repository and are not present in the output directory.
         return Component(name=self.name, purl=self.purl)
 
 
@@ -762,6 +774,24 @@ def _resolve_gomod(
     if config.gomod.proxy_url:
         go_vars["GOPROXY"] = config.gomod.proxy_url
 
+    temp_netrc_dir = TemporaryDirectory()
+    if config.gomod.proxy_login is not None:
+        # This is supposed to be happening only in systems utilizing artifact registry proxies.
+        if "," in config.gomod.proxy_url:
+            raise InvalidInput(
+                "proxy_url must contain exactly one URL when login is present. "
+                f"Contains now: {config.gomod.proxy_url}"
+            )
+        path_to_netrc = inject_netrc(prepare_netrc_contents(), Path(temp_netrc_dir.name))
+        go_vars["NETRC"] = path_to_netrc
+        if os.environ.get("NETRC", ""):
+            log.warning(
+                "Proxy login was specified, at the same time a custom .netrc file path was"
+                " provided via environment. A new .netrc will be generated from proxy"
+                " parameters and will shadow the environment one. Please disable proxy"
+                " support if you intend to use the .netrc from environment."
+            )
+
     if "cgo-disable" in request.flags:
         go_vars["CGO_ENABLED"] = "0"
 
@@ -799,6 +829,7 @@ def _resolve_gomod(
     log.info("Retrieving the list of packages")
     all_packages = _parse_packages(go_work, go, run_params)
 
+    temp_netrc_dir.cleanup()
     return ResolvedGoModule(main_module, all_modules, all_packages, modules_in_go_sum)
 
 
@@ -1442,3 +1473,30 @@ def _vendor_changed(context_dir: RootedPath) -> bool:
         repo.git.reset("--", context_relative_path)
 
     return False
+
+
+def prepare_netrc_contents() -> str:
+    """Prepare .netrc contents."""
+    config = get_config()
+    # It should be `machine foo.bar.baz` in netrc, but is
+    # set to https://foo.bar.baz/repository/go-proxy/ via a variable.
+    # Another thing to note: go mod allows specifying multiple proxy URLs by
+    # separating them with commas. This routine, however, is supposed to be
+    # used in an artifact registry proxy path. Such a proxy should exist as a
+    # uniquely addressable entity, having any backups here would jeopardize
+    # fetch integrity.
+    machine = urllib.parse.urlparse(config.gomod.proxy_url).netloc
+    return f"""machine {machine}
+        login {config.gomod.proxy_login}
+        password {config.gomod.proxy_password}"""
+
+
+def inject_netrc(netrc_stuff: str, temp_netrc_dir: Path) -> str:
+    """Inject a temporary .netrc."""
+    netrc = temp_netrc_dir / ".netrc"
+    old_mask = os.umask(0)
+    netrc_fd = os.open(path=netrc, flags=(os.O_WRONLY | os.O_CREAT | os.O_TRUNC), mode=0o600)
+    with open(netrc_fd, "w") as f:
+        f.write(netrc_stuff)
+    os.umask(old_mask)
+    return str(netrc)

--- a/tests/integration/proxy.py
+++ b/tests/integration/proxy.py
@@ -39,6 +39,9 @@ DEFAULT_LOCAL_NEXUS_PROXY_ENV: dict[str, str] = {
     f"{APP_NAME}_YARN__PROXY_URL": f"{_NEXUS_BASE_URL}/repository/npm-proxy/",
     f"{APP_NAME}_YARN__PROXY_LOGIN": _DEFAULT_PROXY_LOGIN,
     f"{APP_NAME}_YARN__PROXY_PASSWORD": _DEFAULT_PROXY_PASSWORD,
+    f"{APP_NAME}_GOMOD__PROXY_URL": f"{_NEXUS_BASE_URL}/repository/go-proxy/",
+    f"{APP_NAME}_GOMOD__PROXY_LOGIN": _DEFAULT_PROXY_LOGIN,
+    f"{APP_NAME}_GOMOD__PROXY_PASSWORD": _DEFAULT_PROXY_PASSWORD,
 }
 
 _DIRECT_SOURCE_QUALIFIERS = frozenset({"vcs_url", "download_url", "repository_url"})
@@ -95,7 +98,17 @@ def _is_registry_component(component: Component) -> bool:
         p.name == PropertyEnum.PROP_CDX_NPM_PACKAGE_BUNDLED and p.value == "true"
         for p in component.properties
     )
-    if is_bundled:
+
+    # This tuple will contain conditions to skip a Component for all package managers
+    # which use artifact registry proxies.
+    is_local = (
+        (  # local traits for go mod:
+            component.purl.startswith("pkg:golang")
+            and (component.version is None or "vcs_url" in component.purl)
+        ),
+    )
+
+    if is_bundled or any(is_local):
         return False
 
     purl = PackageURL.from_string(component.purl)

--- a/tests/integration/test_data/gomod_correct_vendor_in_submodule_passes_vendor_check/bom.json
+++ b/tests/integration/test_data/gomod_correct_vendor_in_submodule_passes_vendor_check/bom.json
@@ -11,8 +11,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests%400543a5034b687df174c6b12b7b6b9c04770a856f",
+        "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests%400543a5034b687df174c6b12b7b6b9c04770a856f",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -136,7 +136,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests%400543a5034b687df174c6b12b7b6b9c04770a856f",
       "name": "github.com/cachito-testing/gomod-vendor-check-pass",
       "properties": [
         {
@@ -144,12 +144,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests%400543a5034b687df174c6b12b7b6b9c04770a856f",
       "type": "library",
       "version": "v0.0.0-20250910180432-ddc935adef13"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests%400543a5034b687df174c6b12b7b6b9c04770a856f",
       "name": "github.com/cachito-testing/gomod-vendor-check-pass",
       "properties": [
         {
@@ -157,7 +157,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/integration-tests@v0.0.0-20250910180432-ddc935adef13?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests%400543a5034b687df174c6b12b7b6b9c04770a856f",
       "type": "library",
       "version": "v0.0.0-20250910180432-ddc935adef13"
     },

--- a/tests/integration/test_data/gomod_correct_vendor_passes_vendor_check/bom.json
+++ b/tests/integration/test_data/gomod_correct_vendor_passes_vendor_check/bom.json
@@ -11,8 +11,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40acda5b87da2406406ad4ddb1b77c1129eb9a7faf",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40acda5b87da2406406ad4ddb1b77c1129eb9a7faf",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -136,7 +136,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40acda5b87da2406406ad4ddb1b77c1129eb9a7faf",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -144,12 +144,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40acda5b87da2406406ad4ddb1b77c1129eb9a7faf",
       "type": "library",
       "version": "v0.0.0-20260311161302-acda5b87da24"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40acda5b87da2406406ad4ddb1b77c1129eb9a7faf",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -157,7 +157,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161302-acda5b87da24?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40acda5b87da2406406ad4ddb1b77c1129eb9a7faf",
       "type": "library",
       "version": "v0.0.0-20260311161302-acda5b87da24"
     },

--- a/tests/integration/test_data/gomod_e2e_1.18/bom.json
+++ b/tests/integration/test_data/gomod_e2e_1.18/bom.json
@@ -94,10 +94,10 @@
         "pkg:golang/fmt?type=package",
         "pkg:golang/github.com/Masterminds/semver@v1.4.2?type=module",
         "pkg:golang/github.com/Masterminds/semver@v1.4.2?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20230109085255-c3496edd5d45?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20230109085255-c3496edd5d45?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
+        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
         "pkg:golang/github.com/kr/pretty@v0.1.0?type=module",
         "pkg:golang/github.com/op/go-logging@v0.0.0-20160315200505-970db520ece7?type=module",
         "pkg:golang/github.com/op/go-logging@v0.0.0-20160315200505-970db520ece7?type=package",
@@ -1287,7 +1287,7 @@
       "version": "v1.4.2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20230109085255-c3496edd5d45?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "name": "github.com/release-engineering/retrodep/v2/retrodep/glide",
       "properties": [
         {
@@ -1295,12 +1295,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20230109085255-c3496edd5d45?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "type": "library",
       "version": "v2.0.0-20230109085255-c3496edd5d45"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20230109085255-c3496edd5d45?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "name": "github.com/release-engineering/retrodep/v2/retrodep",
       "properties": [
         {
@@ -1308,12 +1308,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20230109085255-c3496edd5d45?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "type": "library",
       "version": "v2.0.0-20230109085255-c3496edd5d45"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "name": "github.com/release-engineering/retrodep/v2",
       "properties": [
         {
@@ -1321,12 +1321,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "type": "library",
       "version": "v2.0.0-20230109085255-c3496edd5d45"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "name": "github.com/release-engineering/retrodep/v2",
       "properties": [
         {
@@ -1334,7 +1334,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20230109085255-c3496edd5d45?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c3496edd5d45523a1ed300de1575a212b86d00d3",
       "type": "library",
       "version": "v2.0.0-20230109085255-c3496edd5d45"
     },

--- a/tests/integration/test_data/gomod_e2e_1.21/bom.json
+++ b/tests/integration/test_data/gomod_e2e_1.21/bom.json
@@ -94,10 +94,10 @@
         "pkg:golang/fmt?type=package",
         "pkg:golang/github.com/Masterminds/semver@v1.4.2?type=module",
         "pkg:golang/github.com/Masterminds/semver@v1.4.2?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20240308152237-d0c316edef82?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20240308152237-d0c316edef82?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
+        "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
         "pkg:golang/github.com/kr/pretty@v0.1.0?type=module",
         "pkg:golang/github.com/op/go-logging@v0.0.0-20160315200505-970db520ece7?type=module",
         "pkg:golang/github.com/op/go-logging@v0.0.0-20160315200505-970db520ece7?type=package",
@@ -1287,7 +1287,7 @@
       "version": "v1.4.2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20240308152237-d0c316edef82?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "name": "github.com/release-engineering/retrodep/v2/retrodep/glide",
       "properties": [
         {
@@ -1295,12 +1295,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20240308152237-d0c316edef82?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep/glide@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "type": "library",
       "version": "v2.0.0-20240308152237-d0c316edef82"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20240308152237-d0c316edef82?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "name": "github.com/release-engineering/retrodep/v2/retrodep",
       "properties": [
         {
@@ -1308,12 +1308,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20240308152237-d0c316edef82?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/retrodep@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "type": "library",
       "version": "v2.0.0-20240308152237-d0c316edef82"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "name": "github.com/release-engineering/retrodep/v2",
       "properties": [
         {
@@ -1321,12 +1321,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "type": "library",
       "version": "v2.0.0-20240308152237-d0c316edef82"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "name": "github.com/release-engineering/retrodep/v2",
       "properties": [
         {
@@ -1334,7 +1334,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v2.0.0-20240308152237-d0c316edef82?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40d0c316edef82e527fed5713f9960cfe7f7c29945",
       "type": "library",
       "version": "v2.0.0-20240308152237-d0c316edef82"
     },

--- a/tests/integration/test_data/gomod_e2e_1.21_dirty/bom.json
+++ b/tests/integration/test_data/gomod_e2e_1.21_dirty/bom.json
@@ -12,8 +12,8 @@
         "pkg:golang/fmt?type=package",
         "pkg:golang/github.com/cachito-testing/cachi2-gomod/twentyone@v0.0.0?type=module",
         "pkg:golang/github.com/cachito-testing/cachi2-gomod/twentyone@v0.0.0?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403353e452672851079f1926b6b2d7372447104b31",
+        "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403353e452672851079f1926b6b2d7372447104b31",
         "pkg:golang/internal/abi?type=package",
         "pkg:golang/internal/asan?type=package",
         "pkg:golang/internal/bisect?type=package",
@@ -142,7 +142,7 @@
       "version": "v0.0.0"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403353e452672851079f1926b6b2d7372447104b31",
       "name": "github.com/cachito-testing/cachi2-gomod/twenty",
       "properties": [
         {
@@ -150,12 +150,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403353e452672851079f1926b6b2d7372447104b31",
       "type": "library",
       "version": "v0.0.0-20240321211820-3353e4526728"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403353e452672851079f1926b6b2d7372447104b31",
       "name": "github.com/cachito-testing/cachi2-gomod/twenty",
       "properties": [
         {
@@ -163,7 +163,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/twenty@v0.0.0-20240321211820-3353e4526728?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%403353e452672851079f1926b6b2d7372447104b31",
       "type": "library",
       "version": "v0.0.0-20240321211820-3353e4526728"
     },

--- a/tests/integration/test_data/gomod_e2e_1.22_workspace_vendoring/bom.json
+++ b/tests/integration/test_data/gomod_e2e_1.22_workspace_vendoring/bom.json
@@ -94,13 +94,13 @@
         "pkg:golang/github.com/davecgh/go-spew@v1.1.1?type=module",
         "pkg:golang/github.com/golang-jwt/jwt@v3.2.2%2Bincompatible?type=module",
         "pkg:golang/github.com/golang-jwt/jwt@v3.2.2%2Bincompatible?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo/middleware@v4.0.0-20240626062917-5aabb6779a32?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo/middleware@v4.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
+        "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
         "pkg:golang/github.com/labstack/gommon/bytes@v0.4.2?type=package",
         "pkg:golang/github.com/labstack/gommon/color@v0.4.2?type=package",
         "pkg:golang/github.com/labstack/gommon/log@v0.4.2?type=package",
@@ -1307,7 +1307,7 @@
       "version": "v3.2.2+incompatible"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo/middleware@v4.0.0-20240626062917-5aabb6779a32?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo/middleware@v4.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "github.com/labstack/echo/v4/middleware",
       "properties": [
         {
@@ -1315,12 +1315,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo/middleware@v4.0.0-20240626062917-5aabb6779a32?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo/middleware@v4.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v4.0.0-20240626062917-5aabb6779a32"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "github.com/labstack/echo/v4",
       "properties": [
         {
@@ -1328,12 +1328,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v4.0.0-20240626062917-5aabb6779a32"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "github.com/labstack/echo/v4",
       "properties": [
         {
@@ -1341,12 +1341,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/echo@v4.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v4.0.0-20240626062917-5aabb6779a32"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "example.com/hello",
       "properties": [
         {
@@ -1354,12 +1354,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v0.0.0-20240626062917-5aabb6779a32"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "example.com/hello",
       "properties": [
         {
@@ -1367,12 +1367,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii/hello@v0.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v0.0.0-20240626062917-5aabb6779a32"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "example.com/hiii",
       "properties": [
         {
@@ -1380,12 +1380,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v0.0.0-20240626062917-5aabb6779a32"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "name": "example.com/hiii",
       "properties": [
         {
@@ -1393,7 +1393,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/hi/hiii@v0.0.0-20240626062917-5aabb6779a32?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%405aabb6779a3263103d77f2829cdc8d083fe7e1c5",
       "type": "library",
       "version": "v0.0.0-20240626062917-5aabb6779a32"
     },

--- a/tests/integration/test_data/gomod_e2e_multiple_modules/bom.json
+++ b/tests/integration/test_data/gomod_e2e_multiple_modules/bom.json
@@ -11,11 +11,11 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161342-30959439437a?type=module",
+        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
+        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
+        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
+        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -141,7 +141,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "name": "github.com/hermetoproject/integration-tests/eggs-module",
       "properties": [
         {
@@ -149,12 +149,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "type": "library",
       "version": "v0.0.0-20260311161342-30959439437a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "name": "github.com/hermetoproject/integration-tests/eggs-module",
       "properties": [
         {
@@ -162,12 +162,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161342-30959439437a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "type": "library",
       "version": "v0.0.0-20260311161342-30959439437a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "name": "github.com/hermetoproject/integration-tests/spam-module",
       "properties": [
         {
@@ -175,12 +175,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "type": "library",
       "version": "v0.0.0-20260311161342-30959439437a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "name": "github.com/hermetoproject/integration-tests/spam-module",
       "properties": [
         {
@@ -188,12 +188,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161342-30959439437a?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "type": "library",
       "version": "v0.0.0-20260311161342-30959439437a"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161342-30959439437a?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -201,7 +201,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161342-30959439437a?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161342-30959439437a?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4030959439437a299d12b082ab1738e6ea64c2979c",
       "type": "library",
       "version": "v0.0.0-20260311161342-30959439437a"
     },

--- a/tests/integration/test_data/gomod_e2e_vendor_nonvendor_module_mix_ordering_1/bom.json
+++ b/tests/integration/test_data/gomod_e2e_vendor_nonvendor_module_mix_ordering_1/bom.json
@@ -51,11 +51,11 @@
         "pkg:golang/fmt?type=package",
         "pkg:golang/github.com/google/uuid@v1.6.0?type=module",
         "pkg:golang/github.com/google/uuid@v1.6.0?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module/utils@v0.0.0-20251031153824-281b55caebf2?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
+        "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
+        "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module/utils@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
+        "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
+        "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
         "pkg:golang/hash?type=package",
         "pkg:golang/internal/abi?type=package",
         "pkg:golang/internal/asan?type=package",
@@ -665,7 +665,7 @@
       "version": "v1.6.0"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "name": "github.com/hermetoproject/integration-tests/gomod-vendor-non-vendor-mix/non-vendored-module",
       "properties": [
         {
@@ -673,12 +673,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "type": "library",
       "version": "v0.0.0-20251031153824-281b55caebf2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "name": "github.com/hermetoproject/integration-tests/gomod-vendor-non-vendor-mix/non-vendored-module",
       "properties": [
         {
@@ -686,12 +686,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/non-vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "type": "library",
       "version": "v0.0.0-20251031153824-281b55caebf2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module/utils@v0.0.0-20251031153824-281b55caebf2?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module/utils@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "name": "github.com/hermetoproject/integration-tests/gomod-vendor-non-vendor-mix/vendored-module/utils",
       "properties": [
         {
@@ -699,12 +699,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module/utils@v0.0.0-20251031153824-281b55caebf2?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module/utils@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "type": "library",
       "version": "v0.0.0-20251031153824-281b55caebf2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "name": "github.com/hermetoproject/integration-tests/gomod-vendor-non-vendor-mix/vendored-module",
       "properties": [
         {
@@ -712,12 +712,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "type": "library",
       "version": "v0.0.0-20251031153824-281b55caebf2"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "name": "github.com/hermetoproject/integration-tests/gomod-vendor-non-vendor-mix/vendored-module",
       "properties": [
         {
@@ -725,7 +725,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/vendored-module@v0.0.0-20251031153824-281b55caebf2?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40281b55caebf267c57e0ae0526458df9c1c58a0df",
       "type": "library",
       "version": "v0.0.0-20251031153824-281b55caebf2"
     },

--- a/tests/integration/test_data/gomod_empty_vendor_passes_vendor_check_in_permissive_mode/bom.json
+++ b/tests/integration/test_data/gomod_empty_vendor_passes_vendor_check_in_permissive_mode/bom.json
@@ -11,8 +11,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -95,8 +95,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -220,7 +220,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -228,12 +228,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
       "type": "library",
       "version": "v0.0.0-20260311161306-60f1ba765d09"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -241,7 +241,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161306-60f1ba765d09?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4060f1ba765d091d323c964868bf026fa705adce72",
       "type": "library",
       "version": "v0.0.0-20260311161306-60f1ba765d09"
     },

--- a/tests/integration/test_data/gomod_generate_imported/bom.json
+++ b/tests/integration/test_data/gomod_generate_imported/bom.json
@@ -14,10 +14,10 @@
         "pkg:golang/encoding?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
+        "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
         "pkg:golang/internal/abi?type=package",
         "pkg:golang/internal/asan?type=package",
         "pkg:golang/internal/bisect?type=package",
@@ -171,7 +171,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "name": "github.com/hermetoproject/integration-tests/foobar",
       "properties": [
         {
@@ -179,12 +179,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/foobar@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "type": "library",
       "version": "v0.0.0-20260415150945-27ab4eeb7cc6"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "name": "github.com/hermetoproject/integration-tests/internal/generate",
       "properties": [
         {
@@ -192,12 +192,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/internal/generate@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "type": "library",
       "version": "v0.0.0-20260415150945-27ab4eeb7cc6"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -205,12 +205,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "type": "library",
       "version": "v0.0.0-20260415150945-27ab4eeb7cc6"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -218,7 +218,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150945-27ab4eeb7cc6?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4027ab4eeb7cc6352962da81f9e30c00cf0e7e49b0",
       "type": "library",
       "version": "v0.0.0-20260415150945-27ab4eeb7cc6"
     },

--- a/tests/integration/test_data/gomod_local_deps/bom.json
+++ b/tests/integration/test_data/gomod_local_deps/bom.json
@@ -10,11 +10,11 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20260415150948-a311d3903a7b?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
+        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
+        "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
         "pkg:golang/internal/abi?type=package",
         "pkg:golang/internal/asan?type=package",
         "pkg:golang/internal/bisect?type=package",
@@ -117,7 +117,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20260415150948-a311d3903a7b?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "name": "github.com/hermetoproject/some-module/some-package",
       "properties": [
         {
@@ -125,12 +125,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20260415150948-a311d3903a7b?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module/some-package@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "type": "library",
       "version": "v0.0.0-20260415150948-a311d3903a7b"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "name": "github.com/hermetoproject/some-module",
       "properties": [
         {
@@ -138,12 +138,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "type": "library",
       "version": "v0.0.0-20260415150948-a311d3903a7b"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "name": "github.com/hermetoproject/some-module",
       "properties": [
         {
@@ -151,12 +151,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/staging/src/some-module@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "type": "library",
       "version": "v0.0.0-20260415150948-a311d3903a7b"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -164,12 +164,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "type": "library",
       "version": "v0.0.0-20260415150948-a311d3903a7b"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -177,7 +177,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150948-a311d3903a7b?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40a311d3903a7bcf046a2e16b88951f5f9acd8e8a3",
       "type": "library",
       "version": "v0.0.0-20260415150948-a311d3903a7b"
     },

--- a/tests/integration/test_data/gomod_missing_checksums/bom.json
+++ b/tests/integration/test_data/gomod_missing_checksums/bom.json
@@ -9,11 +9,11 @@
       "subjects": [
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161108-98375b8401ea?type=module",
+        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
+        "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
+        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
+        "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
         "pkg:golang/internal/abi?type=package",
@@ -109,7 +109,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "name": "github.com/hermetoproject/integration-tests/eggs-module",
       "properties": [
         {
@@ -117,12 +117,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "type": "library",
       "version": "v0.0.0-20260311161108-98375b8401ea"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "name": "github.com/hermetoproject/integration-tests/eggs-module",
       "properties": [
         {
@@ -130,12 +130,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/eggs-module@v0.0.0-20260311161108-98375b8401ea?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "type": "library",
       "version": "v0.0.0-20260311161108-98375b8401ea"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "name": "github.com/hermetoproject/integration-tests/spam-module",
       "properties": [
         {
@@ -143,12 +143,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "type": "library",
       "version": "v0.0.0-20260311161108-98375b8401ea"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "name": "github.com/hermetoproject/integration-tests/spam-module",
       "properties": [
         {
@@ -156,12 +156,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/spam-module@v0.0.0-20260311161108-98375b8401ea?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "type": "library",
       "version": "v0.0.0-20260311161108-98375b8401ea"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161108-98375b8401ea?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -169,7 +169,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161108-98375b8401ea?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260311161108-98375b8401ea?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%4098375b8401ea173ef544ea0b4a736154fc0255e3",
       "type": "library",
       "version": "v0.0.0-20260311161108-98375b8401ea"
     },

--- a/tests/integration/test_data/gomod_with_deps/bom.json
+++ b/tests/integration/test_data/gomod_with_deps/bom.json
@@ -11,8 +11,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c1f6ac11dc73b44ede3dcc05555a586969b43c50",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c1f6ac11dc73b44ede3dcc05555a586969b43c50",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -136,7 +136,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c1f6ac11dc73b44ede3dcc05555a586969b43c50",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -144,12 +144,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c1f6ac11dc73b44ede3dcc05555a586969b43c50",
       "type": "library",
       "version": "v0.0.0-20260306125704-c1f6ac11dc73"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c1f6ac11dc73b44ede3dcc05555a586969b43c50",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -157,7 +157,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260306125704-c1f6ac11dc73?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40c1f6ac11dc73b44ede3dcc05555a586969b43c50",
       "type": "library",
       "version": "v0.0.0-20260306125704-c1f6ac11dc73"
     },

--- a/tests/integration/test_data/gomod_without_deps/bom.json
+++ b/tests/integration/test_data/gomod_without_deps/bom.json
@@ -7,8 +7,8 @@
         }
       },
       "subjects": [
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=package"
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408e5cec9c6ec56396a7443dc57e088d099c1b0113",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408e5cec9c6ec56396a7443dc57e088d099c1b0113"
       ],
       "text": "hermeto:backend:gomod",
       "timestamp": "2025-01-01T00:00:00Z"
@@ -17,7 +17,7 @@
   "bomFormat": "CycloneDX",
   "components": [
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408e5cec9c6ec56396a7443dc57e088d099c1b0113",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -25,12 +25,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408e5cec9c6ec56396a7443dc57e088d099c1b0113",
       "type": "library",
       "version": "v0.0.0-20260415150951-8e5cec9c6ec5"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408e5cec9c6ec56396a7443dc57e088d099c1b0113",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -38,7 +38,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150951-8e5cec9c6ec5?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408e5cec9c6ec56396a7443dc57e088d099c1b0113",
       "type": "library",
       "version": "v0.0.0-20260415150951-8e5cec9c6ec5"
     }

--- a/tests/integration/test_data/gomod_workspaces/bom.json
+++ b/tests/integration/test_data/gomod_workspaces/bom.json
@@ -94,13 +94,13 @@
         "pkg:golang/github.com/davecgh/go-spew@v1.1.1?type=module",
         "pkg:golang/github.com/golang-jwt/jwt@v3.2.2%2Bincompatible?type=module",
         "pkg:golang/github.com/golang-jwt/jwt@v3.2.2%2Bincompatible?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo/middleware@v4.0.0-20240626205759-b97aca303b29?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo/middleware@v4.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
+        "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
         "pkg:golang/github.com/labstack/gommon/bytes@v0.4.2?type=package",
         "pkg:golang/github.com/labstack/gommon/color@v0.4.2?type=package",
         "pkg:golang/github.com/labstack/gommon/log@v0.4.2?type=package",
@@ -1311,7 +1311,7 @@
       "version": "v3.2.2+incompatible"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo/middleware@v4.0.0-20240626205759-b97aca303b29?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo/middleware@v4.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "github.com/labstack/echo/v4/middleware",
       "properties": [
         {
@@ -1319,12 +1319,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo/middleware@v4.0.0-20240626205759-b97aca303b29?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo/middleware@v4.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v4.0.0-20240626205759-b97aca303b29"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "github.com/labstack/echo/v4",
       "properties": [
         {
@@ -1332,12 +1332,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v4.0.0-20240626205759-b97aca303b29"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "github.com/labstack/echo/v4",
       "properties": [
         {
@@ -1345,12 +1345,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/echo@v4.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v4.0.0-20240626205759-b97aca303b29"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "example.com/hiii",
       "properties": [
         {
@@ -1358,12 +1358,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v0.0.0-20240626205759-b97aca303b29"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "example.com/hiii",
       "properties": [
         {
@@ -1371,12 +1371,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello/hi/hiii@v0.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v0.0.0-20240626205759-b97aca303b29"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "example.com/hello",
       "properties": [
         {
@@ -1384,12 +1384,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v0.0.0-20240626205759-b97aca303b29"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "name": "example.com/hello",
       "properties": [
         {
@@ -1397,7 +1397,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/workspace_modules/hello@v0.0.0-20240626205759-b97aca303b29?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40b97aca303b29dca71b89185da6935249b0deef68",
       "type": "library",
       "version": "v0.0.0-20240626205759-b97aca303b29"
     },

--- a/tests/integration/test_data/gomod_wrong_vendor_passes_vendor_check_in_permissive_mode/bom.json
+++ b/tests/integration/test_data/gomod_wrong_vendor_passes_vendor_check_in_permissive_mode/bom.json
@@ -11,8 +11,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -95,8 +95,8 @@
         "pkg:golang/cmp?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
+        "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
         "pkg:golang/golang.org/x/text/internal/tag@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text/language@v0.0.0-20170915032832-14c0d48ead0c?type=package",
         "pkg:golang/golang.org/x/text@v0.0.0-20170915032832-14c0d48ead0c?type=module",
@@ -220,7 +220,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -228,12 +228,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
       "type": "library",
       "version": "v0.0.0-20260415150954-f802197aba69"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
       "name": "github.com/hermetoproject/integration-tests",
       "properties": [
         {
@@ -241,7 +241,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests@v0.0.0-20260415150954-f802197aba69?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%40f802197aba692332c20332e181c0d6b929f22f8d",
       "type": "library",
       "version": "v0.0.0-20260415150954-f802197aba69"
     },

--- a/tests/integration/test_data/multiple_gomod_and_npm/bom.json
+++ b/tests/integration/test_data/multiple_gomod_and_npm/bom.json
@@ -17,8 +17,8 @@
         "pkg:golang/encoding?type=package",
         "pkg:golang/errors?type=package",
         "pkg:golang/fmt?type=package",
-        "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=module",
-        "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=package",
+        "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408c76c8dc8c615c25cb48211d95b24d9d171291ff",
+        "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408c76c8dc8c615c25cb48211d95b24d9d171291ff",
         "pkg:golang/github.com/sirupsen/logrus@v1.9.3?type=module",
         "pkg:golang/github.com/sirupsen/logrus@v1.9.3?type=package",
         "pkg:golang/github.com/stretchr/testify@v1.10.0?type=module",
@@ -266,7 +266,7 @@
       "type": "library"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=module",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408c76c8dc8c615c25cb48211d95b24d9d171291ff",
       "name": "example.com/greetings",
       "properties": [
         {
@@ -274,12 +274,12 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=module",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=module&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408c76c8dc8c615c25cb48211d95b24d9d171291ff",
       "type": "library",
       "version": "v0.0.0-20250515150126-8c76c8dc8c61"
     },
     {
-      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=package",
+      "bom-ref": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408c76c8dc8c615c25cb48211d95b24d9d171291ff",
       "name": "example.com/greetings",
       "properties": [
         {
@@ -287,7 +287,7 @@
           "value": "hermeto"
         }
       ],
-      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=package",
+      "purl": "pkg:golang/github.com/hermetoproject/integration-tests/gomod-package@v0.0.0-20250515150126-8c76c8dc8c61?type=package&vcs_url=git%2Bhttps://github.com/hermetoproject/integration-tests.git%408c76c8dc8c615c25cb48211d95b24d9d171291ff",
       "type": "library",
       "version": "v0.0.0-20250515150126-8c76c8dc8c61"
     },

--- a/tests/nexusserver/repositories.py
+++ b/tests/nexusserver/repositories.py
@@ -63,9 +63,17 @@ class YumProxyConfig(ProxyRepositoryConfig):
     format: str = field(default="yum", init=False)
 
 
+@dataclass
+class GomodProxyConfig(ProxyRepositoryConfig):
+    """Configuration for a Go proxy repository."""
+
+    format: str = field(default="go", init=False)
+
+
 DEFAULT_REPOSITORIES: list[ProxyRepositoryConfig] = [
     NpmProxyConfig(name="npm-proxy", remote_url="https://registry.npmjs.org"),
     PypiProxyConfig(name="pypi-proxy", remote_url="https://pypi.org"),
+    GomodProxyConfig(name="go-proxy", remote_url="https://proxy.golang.org"),
     YumProxyConfig(
         name="yum-proxy",
         remote_url="https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi9/9",

--- a/tests/unit/package_managers/gomod/test_main.py
+++ b/tests/unit/package_managers/gomod/test_main.py
@@ -446,13 +446,17 @@ def test_get_go_sum_files(
 
 @pytest.mark.parametrize("has_workspaces", (False, True))
 @mock.patch("hermeto.core.package_managers.gomod.main.ModuleVersionResolver")
+@mock.patch("hermeto.core.package_managers.gomod.main.get_repo_id")
 def test_create_modules_from_parsed_data(
+    mock_get_repo_id: mock.Mock,
     mock_version_resolver: mock.Mock,
     has_workspaces: bool,
     rooted_tmp_path: RootedPath,
 ) -> None:
     main_module_dir = rooted_tmp_path.join_within_root("target-module")
     mock_version_resolver.get_golang_version.return_value = "v1.5.0"
+
+    mock_get_repo_id.return_value = None
 
     go_work = None
 
@@ -462,6 +466,7 @@ def test_create_modules_from_parsed_data(
         original_name="github.com/my-org/my-repo/target-module",
         real_path="github.com/my-org/my-repo/target-module",
         main=True,
+        local_replace=False,
     )
 
     parsed_modules = [
@@ -523,12 +528,14 @@ def test_create_modules_from_parsed_data(
             version="v1.5.0",
             original_name="github.com/some-org/this-other-module",
             real_path="github.com/my-org/my-repo/target-module/local-path",
+            local_replace=True,
         ),
         Module(
             name="github.com/some-org/yet-another-module",
             version="v1.5.0",
             original_name="github.com/some-org/yet-another-module",
             real_path="github.com/my-org/my-repo/sibling-path",
+            local_replace=True,
         ),
     ]
 
@@ -1255,7 +1262,7 @@ def test_missing_gomod_file(
             [
                 Component(
                     name="github.com/my-org/my-repo",
-                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=module",
+                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=module&vcs_url=git%2Bhttps://github.com/org/repo.git%40c0ffee",
                     version="v1.0.0",
                 ),
                 Component(
@@ -1273,7 +1280,7 @@ def test_missing_gomod_file(
                 ),
                 Component(
                     name="github.com/my-org/my-repo",
-                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=package",
+                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=package&vcs_url=git%2Bhttps://github.com/org/repo.git%40c0ffee",
                     version="v1.0.0",
                 ),
                 Component(
@@ -1317,12 +1324,12 @@ def test_missing_gomod_file(
             [
                 Component(
                     name="github.com/my-org/my-repo",
-                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=module",
+                    purl="pkg:golang/github.com/my-org/my-repo@v1.0.0?type=module&vcs_url=git%2Bhttps://github.com/org/repo.git%40c0ffee",
                     version="v1.0.0",
                 ),
                 Component(
                     name="github.com/my-org/my-repo/path",
-                    purl="pkg:golang/github.com/my-org/my-repo/path@v1.0.0?type=module",
+                    purl="pkg:golang/github.com/my-org/my-repo/path@v1.0.0?type=module&vcs_url=git%2Bhttps://github.com/org/repo.git%40c0ffee",
                     version="v1.0.0",
                 ),
                 Component(
@@ -1352,7 +1359,9 @@ def test_missing_gomod_file(
 @mock.patch("hermeto.core.package_managers.gomod.main._get_go_work_path")
 @mock.patch("hermeto.core.package_managers.gomod.main._vendor_changed")
 @mock.patch("hermeto.core.package_managers.gomod.main.create_backend_annotation")
+@mock.patch("hermeto.core.package_managers.gomod.main.get_repo_id")
 def test_fetch_gomod_source(
+    mock_get_repo_id: mock.Mock,
     mock_create_annotation: mock.Mock,
     mock_vendor_changed: mock.Mock,
     mock_get_go_work_path: mock.Mock,
@@ -1380,6 +1389,9 @@ def test_fetch_gomod_source(
         return packages_output_by_path[
             app_dir.path.relative_to(gomod_request.source_dir).as_posix()
         ]
+
+    repo_id = RepoID("https://github.com/org/repo.git", "c0ffee")
+    mock_get_repo_id.return_value = repo_id
 
     mock_gomod_annotation = Annotation(
         subjects=set(),

--- a/tests/unit/package_managers/gomod/test_main.py
+++ b/tests/unit/package_managers/gomod/test_main.py
@@ -1222,6 +1222,7 @@ def test_missing_gomod_file(
 @pytest.mark.parametrize(
     "gomod_input_packages, packages_output_by_path, expect_components",
     (
+        # First scenario
         (
             [{"type": "gomod", "path": "."}],
             {
@@ -1290,6 +1291,7 @@ def test_missing_gomod_file(
                 ),
             ],
         ),
+        # Second scenario
         (
             [{"type": "gomod", "path": "."}, {"type": "gomod", "path": "./path"}],
             {


### PR DESCRIPTION
This PR introduces necessary changes to support fetching dependencies via an artifact registry proxies in gomod.