### PR TITLE
feat(http): Add retry logs to sync and async downloads

### DIFF
--- a/hermeto/core/package_managers/general.py
+++ b/hermeto/core/package_managers/general.py
@@ -2,8 +2,10 @@
 import asyncio
 import logging
 import ssl
+import types
 from collections.abc import Mapping
-from typing import Any
+from types import TracebackType
+from typing import Any, cast
 from urllib.parse import urlparse
 
 import aiohttp
@@ -12,6 +14,9 @@ import requests
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.auth import AuthBase
+from typing_extensions import Self
+from urllib3.connectionpool import ConnectionPool
+from urllib3.response import BaseHTTPResponse
 from urllib3.util.retry import Retry
 
 from hermeto.core.config import get_config
@@ -26,6 +31,50 @@ BACKOFF_FACTOR = 1.3
 STATUS_FORCELIST = (500, 502, 503, 504)
 
 
+log = logging.getLogger(__name__)
+
+
+class SyncLoggingRetry(Retry):
+    """
+    Retry subclass that emits a hermeto-style debug log on each retry.
+    """
+
+    def increment(
+        self,
+        method: str | None = None,
+        url: str | None = None,
+        response: BaseHTTPResponse | None = None,
+        error: Exception | None = None,
+        _pool: ConnectionPool | None = None,
+        _stacktrace: TracebackType | None = None,
+    ) -> Self:
+        """
+        Log retry attempt at DEBUG level.
+        """
+        # retry object - Named to match urllib3.Retry internal logic.
+        new_retry = super().increment(
+            method=method,
+            url=url,
+            response=response,
+            error=error,
+            _pool=_pool,
+            _stacktrace=_stacktrace,
+        )
+        retry_number = len(new_retry.history)
+        status = response.status if response else "N/A"
+        backoff = new_retry.get_backoff_time()
+        total = retry_number + cast(int, self.total) - 1
+        log.debug(
+            "Retrying request: retry=%d/%d url=%s status=%s backoff=%.1fs",
+            retry_number,
+            total,
+            url,
+            status,
+            backoff,
+        )
+        return new_retry
+
+
 def _get_pkg_requests_session() -> requests.Session:
     """
     A lazy initialised, module-level requests.Session with retry config.
@@ -35,7 +84,7 @@ def _get_pkg_requests_session() -> requests.Session:
         max_retries = get_config().http.max_retries
         _pkg_requests_session = Session()
         adapter = HTTPAdapter(
-            max_retries=Retry(
+            max_retries=SyncLoggingRetry(
                 backoff_factor=BACKOFF_FACTOR,
                 status_forcelist=STATUS_FORCELIST,
                 allowed_methods=SAFE_REQUEST_METHODS,
@@ -46,9 +95,6 @@ def _get_pkg_requests_session() -> requests.Session:
         _pkg_requests_session.mount("https://", adapter)
 
     return _pkg_requests_session
-
-
-log = logging.getLogger(__name__)
 
 
 def download_binary_file(
@@ -142,6 +188,53 @@ async def _async_download_binary_file(
     log.debug(f"Download completed - {url}")
 
 
+def _aiohttp_create_retry_trace_config(
+    retry_options: aiohttp_retry.JitterRetry,
+) -> aiohttp.TraceConfig:
+    """
+    Creates a TraceConfig that logs retry attempts using the provided retry options.
+    """
+
+    trace_config = aiohttp.TraceConfig()
+
+    async def on_request_end(
+        _session: aiohttp.ClientSession,
+        trace_config_ctx: types.SimpleNamespace,
+        params: aiohttp.TraceRequestEndParams,
+    ) -> None:
+        attempt = trace_config_ctx.trace_request_ctx["current_attempt"]
+        if attempt > 1 and params.response.status in retry_options.statuses:
+            file_name = params.url.name
+            log.debug(
+                "Retrying request: retry=%d/%d file=%s status=%d",
+                attempt - 1,
+                retry_options.attempts - 1,
+                file_name,
+                params.response.status,
+            )
+
+    async def on_request_exception(
+        _session: aiohttp.ClientSession,
+        trace_config_ctx: types.SimpleNamespace,
+        params: aiohttp.TraceRequestExceptionParams,
+    ) -> None:
+        attempt = trace_config_ctx.trace_request_ctx["current_attempt"]
+        exception_valid = any(isinstance(params.exception, exc) for exc in retry_options.exceptions)
+        if attempt > 1 and exception_valid:
+            file_name = params.url.name
+            log.debug(
+                "Retrying request: retry=%d/%d file=%s exception=%s",
+                attempt - 1,
+                retry_options.attempts - 1,
+                file_name,
+                type(params.exception).__name__,
+            )
+
+    trace_config.on_request_exception.append(on_request_exception)
+    trace_config.on_request_end.append(on_request_end)
+    return trace_config
+
+
 async def async_download_files(
     files_to_download: Mapping[str, StrPath],
     concurrency_limit: int,
@@ -155,7 +248,7 @@ async def async_download_files(
     :param ssl_context: Optional SSL context for the requests.
     :param headers: Optional per-URL headers mapping (URL -> headers dict).
     """
-    trace_config = aiohttp.TraceConfig()
+
     max_retries = get_config().http.max_retries
     # aiohttp uses n calls (1 call, n-1 retries).
     max_retries = max_retries + 1
@@ -168,9 +261,10 @@ async def async_download_files(
             aiohttp.ClientPayloadError,
         },
     )
+
     retry_client = aiohttp_retry.RetryClient(
         retry_options=retry_options,
-        trace_configs=[trace_config],
+        trace_configs=[_aiohttp_create_retry_trace_config(retry_options)],
         # respect proxy settings and .netrc
         trust_env=True,
         # preserve percent-encoding in redirect URLs (e.g. signed CloudFront URLs)

--- a/hermeto/core/package_managers/general.py
+++ b/hermeto/core/package_managers/general.py
@@ -117,6 +117,7 @@ def download_binary_file(
     config = get_config()
     timeout = (config.http.connect_timeout, config.http.read_timeout)
     try:
+        log.debug("requests.get(url: %s)", url)
         resp = _get_pkg_requests_session().get(
             url, stream=True, verify=not insecure, auth=auth, timeout=timeout
         )
@@ -127,6 +128,8 @@ def download_binary_file(
     with open(download_path, "wb") as f:
         for chunk in resp.iter_content(chunk_size=chunk_size):
             f.write(chunk)
+
+    log.debug("Download completed - %s", url)
 
 
 def _get_aiohttp_timeout() -> aiohttp.ClientTimeout:


### PR DESCRIPTION
Fixes: #1552

## Summary
Both sync and async download paths produced no log output when retrying failed HTTP requests, making a download that fails after multiple retries look like a single slow request that errored out.

## Changes
**Sync path:** Introduces `_LoggingRetry`, a `urllib3.Retry` subclass that overrides `increment()` to log each retry at DEBUG level with retry count, total retries, URL, HTTP status, and backoff duration.

**Async path:** Introduces an `on_request_end` TraceConfig callback that logs each retry at DEBUG level with retry count, total retries, filename, and HTTP status. Backoff duration is unavailable at the TraceConfig callback point as it is computed by `aiohttp_retry` after the callback fires.

The async retry logging is inspired by [this](https://github.com/hermetoproject/hermeto/commit/c7f3de8cf32faacf3c4f4f142b56bf3f29fa53d1) earlier implementation which was [removed ](https://github.com/hermetoproject/hermeto/commit/3215e8de029f04b91e9bc1cda512e0ae43f778a7) due to no explanation about the code. This implementation switches from `on_request_start` to `on_request_end` to make the HTTP status code available in the log output.

## Example output
**Sync**
```
DEBUG hermeto.core.http_requests Retrying request: retry=1/5 url=/deps/pip/package-1.0.tar.gz status=503 backoff=1.3s
```
**Async**
```
DEBUG hermeto.core.package_managers.general Retrying request: retry=1/5 file=lodash-4.17.21.tgz status=503
```