### PR TITLE
docs(usage): document JSON file input for fetch-deps

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,7 +70,7 @@ The main parameter (PKG) can handle different types of definitions
   "subpath/to/other/module", "type": "<package manager>"}]`
 - JSON object with flags: `{"packages": [{"path": ".", "type": "<package
   manager>"}], "flags": ["cgo-disable"]}`
-- JSON file path: `./input.json`, where the file contains any supported JSON input
+- JSON file path: `/path/to/input-file.json`, where the file contains any supported JSON input
 
 See also `hermeto fetch-deps --help`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,6 +70,7 @@ The main parameter (PKG) can handle different types of definitions
   "subpath/to/other/module", "type": "<package manager>"}]`
 - JSON object with flags: `{"packages": [{"path": ".", "type": "<package
   manager>"}], "flags": ["cgo-disable"]}`
+- JSON file path: `./input.json`, where the file contains any supported JSON input
 
 See also `hermeto fetch-deps --help`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -70,7 +70,8 @@ The main parameter (PKG) can handle different types of definitions
   "subpath/to/other/module", "type": "<package manager>"}]`
 - JSON object with flags: `{"packages": [{"path": ".", "type": "<package
   manager>"}], "flags": ["cgo-disable"]}`
-- JSON file path: `/path/to/input-file.json`, where the file contains any supported JSON input
+- JSON file path: `/path/to/input-file.json`, where the file contains
+  any supported JSON input
 
 See also `hermeto fetch-deps --help`.
 


### PR DESCRIPTION
Closes #1559

Added a mention to the `fetch-deps` usage documentation that JSON input can also be provided through a JSON file path.

Changes:
* Document JSON file path input support for `fetch-deps`
* Add `./input.json` usage example to the supported input definitions list