### PR TITLE
Add Feature request and Bug report issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: |
+  Report unexpected behavior from Hermeto.
+  For security vulnerabilities see "Report a security vulnerability" in the templates.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: issue-description
+    attributes:
+      label: Describe the issue
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: latest-version
+    attributes:
+      label: Version
+      options:
+        - label: I have reproduced this issue on the latest version from the main branch
+          required: true
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Steps to reproduce
+      description: |
+        Provide a short example of the steps needed to reproduce the issue.
+        It should be self-contained and copy-pastable in a terminal.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        List your operating system, deployment method (containerized or localhost),
+        and any other relevant tools together with their versions.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: How does this issue affect you, or how did you find it?
+      description: |
+        Explain how this issue concretely affects you or others.
+        If it does not directly impact you, how did you find it?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,17 @@
+name: Feature request
+description: Request a new feature
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Not sure whether your requested feature fits into Hermeto?
+        Consider starting a [Discussion](https://github.com/orgs/hermetoproject/discussions) on GitHub.
+
+  - type: textarea
+    id: request
+    attributes:
+      label: "Requested new feature or change"
+      description: Describe the motivation for the feature in detail.
+    validations:
+      required: true


### PR DESCRIPTION
The process of reporting issues is not very well documented. This leads to inconsistency between issues and missing information.

Add templates for the two most common types of issues.

Inspired by issue templates from:
- numpy/numpy[1]
- npm/cli[2]

## Screenshots

### Issue selection
<img width="911" height="329" alt="image" src="https://github.com/user-attachments/assets/c8591a7e-f21d-4f84-8f17-192c1f9141f2" />

### Bug report
<img width="1172" height="1558" alt="image" src="https://github.com/user-attachments/assets/8f498bbe-a2e3-4455-a78c-765bd283f836" />

### Feature request
<img width="1180" height="577" alt="image" src="https://github.com/user-attachments/assets/ded6e726-b896-4728-94d2-a0816cc81d7b" />


[1]: https://github.com/numpy/numpy/tree/a20ef194d474ed8c499502944c2025bd77d3f61b/.github/ISSUE_TEMPLATE
[2]: https://github.com/npm/cli/tree/c5292fa8a09a56b25394d393faf21e47ffb096c0/.github/ISSUE_TEMPLATE

Resolves #1493 