### PR TITLE
fix(sbom): preserve pedigree patches in SPDX conversion

### DIFF
--- a/docs/sbom.md
+++ b/docs/sbom.md
@@ -107,6 +107,15 @@ actually used (some backends cannot provide that). It is represented as follows:
 - **SPDX**: The same information is mapped to the package field `sourceInfo`
   (semicolon-separated when there are several).
 
+**Patch provenance** &mdash; When a dependency has applied patches, Hermeto records
+patch URLs in CycloneDX pedigree and maps them to SPDX security external
+references:
+
+- **CycloneDX**: `component.pedigree.patches[].diff.url`
+- **SPDX**: `externalRefs[]` entries with
+  `referenceCategory=SECURITY`, `referenceType=fix`,
+  `referenceLocator=<patch_url>`
+
 ## Main package representation
 
 The SBOM does **not** mark which dependency is the main package. All are
@@ -172,6 +181,7 @@ translation used when SPDX output is requested (e.g. via
 | `properties` | Package `annotations`: each property encoded as JSON `{"name":"...","value":"..."}` in `comment`; `annotator` is `Tool: hermeto:jsonencoded`. |
 | Top-level `annotations` (by bom-ref) | Per-package annotations containing the same values as CycloneDX top-level annotations: `comment` = annotation text |
 | ExternalReference (`type=distribution`, `comment=proxy URL`) | `sourceInfo` (semicolon-separated if multiple) |
+| `pedigree.patches[].diff.url` | `externalRefs`: one entry per patch with `referenceCategory=SECURITY`, `referenceType=fix`, `referenceLocator=<patch_url>` |
 | (no root in CycloneDX) | A synthetic root package `SPDXRef-DocumentRoot-File-` is created with `name=""` and `versionInfo=""`. The document describes the root; the root contains every package. |
 | `metadata.tools` | `creationInfo.creators` (`Tool:` / `Organization:`) |
 
@@ -188,6 +198,8 @@ CycloneDX one), the following applies:
   properties; others are stored as top-level annotations.
 - `sourceInfo` is converted back to ExternalReferences with `type=distribution`
   and `comment=proxy URL`.
+- `externalRefs` entries with `referenceCategory=SECURITY`,
+  `referenceType=fix` are converted to `pedigree.patches[].diff.url`.
 
 **Limitation**: An SPDX package that has multiple PURLs in `externalRefs` becomes
 multiple CycloneDX components when converted to CycloneDX, because CycloneDX does

--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -398,6 +398,14 @@ class Sbom(pydantic.BaseModel):
                 is_proxy = lambda ref: ref.type == PROXY_REF_TYPE and ref.comment == PROXY_COMMENT
                 return sorted(ref.url for ref in component.external_references if is_proxy(ref))
 
+            def fix_refs(component: Component) -> list[dict[str, str]]:
+                if component.pedigree is None:
+                    return []
+
+                ref_base = dict(referenceCategory="SECURITY", referenceType="fix")
+                patch_urls = sorted({patch.diff.url for patch in component.pedigree.patches})
+                return [dict(referenceLocator=patch_url, **ref_base) for patch_url in patch_urls]
+
             packages = []
 
             hashdict = lambda c: dict(name=c.name, version=c.version, purl=c.purl)
@@ -420,7 +428,7 @@ class Sbom(pydantic.BaseModel):
                         ),
                         name=component.name,
                         versionInfo=component.version,
-                        externalRefs=[erefdict(component)],
+                        externalRefs=[erefdict(component), *fix_refs(component)],
                         annotations=generate_package_annotations(
                             properties=component.properties, bom_ref=component.bom_ref
                         ),
@@ -521,13 +529,22 @@ class SPDXPackageExternalRefSecurityPURL(
     referenceType: Literal["cpe23Type"]
 
 
+class SPDXPackageExternalRefSecurityFix(
+    SPDXPackageExternalRefSecurity, SPDXPackageExternalRefReferenceLocatorURI
+):
+    """SPDX Package External Reference for category security and type fix."""
+
+    referenceCategory: Literal["SECURITY"]
+    referenceType: Literal["fix"]
+
+
 SPDXPackageExternalRefPackageManagerType = Annotated[
     SPDXPackageExternalRefPackageManagerPURL,
     pydantic.Field(discriminator="referenceType"),
 ]
 
 SPDXPackageExternalRefSecurityType = Annotated[
-    SPDXPackageExternalRefSecurityPURL,
+    SPDXPackageExternalRefSecurityPURL | SPDXPackageExternalRefSecurityFix,
     pydantic.Field(discriminator="referenceType"),
 ]
 
@@ -815,6 +832,17 @@ class SPDXSbom(pydantic.BaseModel):
         eref_rest = dict(type=PROXY_REF_TYPE, comment=PROXY_COMMENT)
         for package in self.packages:
             purls = _extract_purls(package.externalRefs)
+            fix_urls = sorted(
+                {
+                    ref.referenceLocator
+                    for ref in package.externalRefs
+                    if ref.referenceCategory == "SECURITY" and ref.referenceType == "fix"
+                }
+            )
+            pedigree = None
+            if fix_urls:
+                patches = [Patch(type="unofficial", diff=PatchDiff(url=url)) for url in fix_urls]
+                pedigree = Pedigree(patches=patches)
 
             properties = []
             for ann in package.annotations:
@@ -841,6 +869,7 @@ class SPDXSbom(pydantic.BaseModel):
                 version=package.versionInfo,
                 properties=properties,
                 external_references=exrefs,
+                pedigree=pedigree,
             )
 
             # cyclonedx doesn't support multiple purls, therefore

--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -402,9 +402,15 @@ class Sbom(pydantic.BaseModel):
                 if component.pedigree is None:
                     return []
 
-                ref_base = dict(referenceCategory="SECURITY", referenceType="fix")
                 patch_urls = sorted({patch.diff.url for patch in component.pedigree.patches})
-                return [dict(referenceLocator=patch_url, **ref_base) for patch_url in patch_urls]
+                return [
+                    {
+                        "referenceCategory": "SECURITY",
+                        "referenceType": "fix",
+                        "referenceLocator": patch_url,
+                    }
+                    for patch_url in patch_urls
+                ]
 
             packages = []
 

--- a/tests/unit/models/test_sbom.py
+++ b/tests/unit/models/test_sbom.py
@@ -22,6 +22,7 @@ from hermeto.core.models.sbom import (
     SPDXPackage,
     SPDXPackageAnnotation,
     SPDXPackageExternalRefPackageManagerPURL,
+    SPDXPackageExternalRefSecurityFix,
     SPDXPackageExternalRefType,
     SPDXRelation,
     SPDXSbom,
@@ -635,6 +636,52 @@ class TestSbom:
 
         assert the_only_package.sourceInfo == expected_package_source_info
 
+    def test_spdx_correctly_converts_cydx_pedigree_to_fix_external_references(
+        self, mock_spdx_now: str
+    ) -> None:
+        sbom = Sbom(
+            components=[
+                {
+                    "name": "github.com/org/A",
+                    "version": "v1.0.0",
+                    "purl": "pkg:golang/github.com/org/A@v1.0.0",
+                    "pedigree": {
+                        "patches": [
+                            {
+                                "type": "unofficial",
+                                "diff": {"url": "https://example.com/patch-2.diff"},
+                            },
+                            {
+                                "type": "unofficial",
+                                "diff": {"url": "https://example.com/patch-1.diff"},
+                            },
+                        ]
+                    },
+                }
+            ],
+        )
+
+        spdx_sbom = sbom.to_spdx("NOASSERTION")
+        the_only_package = [p for p in spdx_sbom.packages if "DocumentRoot" not in p.SPDXID][0]
+
+        assert the_only_package.externalRefs == [
+            SPDXPackageExternalRefSecurityFix(
+                referenceCategory="SECURITY",
+                referenceLocator="https://example.com/patch-1.diff",
+                referenceType="fix",
+            ),
+            SPDXPackageExternalRefSecurityFix(
+                referenceCategory="SECURITY",
+                referenceLocator="https://example.com/patch-2.diff",
+                referenceType="fix",
+            ),
+            SPDXPackageExternalRefPackageManagerPURL(
+                referenceCategory="PACKAGE-MANAGER",
+                referenceLocator="pkg:golang/github.com/org/A@v1.0.0",
+                referenceType="purl",
+            ),
+        ]
+
 
 # Some partially constructed objects to streamline test cases definitions.
 STOCK_ANNOTATION = {
@@ -1126,6 +1173,44 @@ class TestSPDXSbom:
 
         with pytest.raises(UnexpectedFormat, match="Invalid JSON in annotation"):
             sbom.to_cyclonedx()
+
+    def test_to_cyclonedx_with_fix_external_ref(self, mock_spdx_now: str) -> None:
+        sbom = SPDXSbom(
+            documentNamespace="NOASSERTION",
+            creationInfo={
+                "creators": [f"Tool: {APP_NAME}", "Organization: hermetoproject"],
+                "created": SPDX_EPOCH_STRFTIME,
+            },
+            packages=[
+                {
+                    "SPDXID": "SPDXRef-Package-test-abc123",
+                    "name": "test-package",
+                    "versionInfo": "1.0.0",
+                    "externalRefs": [
+                        _gen_ref("pkg:npm/test-package@1.0.0"),
+                        {
+                            "referenceCategory": "SECURITY",
+                            "referenceLocator": "https://example.com/fix.patch",
+                            "referenceType": "fix",
+                        },
+                    ],
+                },
+            ],
+        )
+
+        cyclonedx = sbom.to_cyclonedx()
+        assert cyclonedx.components == [
+            Component(
+                name="test-package",
+                purl="pkg:npm/test-package@1.0.0",
+                version="1.0.0",
+                pedigree={
+                    "patches": [
+                        {"type": "unofficial", "diff": {"url": "https://example.com/fix.patch"}}
+                    ]
+                },
+            )
+        ]
 
     # SPDX SBOM objects are very verbose and it is rather hard to tell the
     # difference between them at a glance. It is unavoidable when a SBOM is


### PR DESCRIPTION
Closes #1583

**Summary**

Implements bidirectional mapping between CycloneDX `pedigree.patches` and SPDX `externalRefs[SECURITY/fix]` to preserve patch provenance metadata during SBOM format conversion.

**Issue**

CycloneDX SBOMs record applied patches in `component.pedigree.patches[].diff.url`, but this metadata was silently dropped when converting to SPDX format. This loses critical supply chain security information about patches applied to dependencies.

**Limitations**

Patch `type` field (backport/cherry-pick/monkey/unofficial) is not preserved during SPDX round-trip since SPDX v2.3 spec doesn't define a standard field for it. All patches are reconstructed with `type: "unofficial"` when converting from SPDX back to CycloneDX.