### PR TITLE
Refactor pip backend to use typed package classes

### DIFF
--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -275,63 +275,17 @@ def _get_pip_metadata(package_dir: RootedPath) -> tuple[str, str | None]:
     return name, version
 
 
-def _process_req(
-    req: PipRequirement,
-    requirements_file: PipRequirementsFile,
-    pip_deps_dir: RootedPath,
-    download_info: dict[str, Any],
-    dpi: DistributionPackageInfo | None = None,
-) -> dict[str, Any] | None:
-    download_info["kind"] = req.kind
-    download_info["requirement_file"] = str(requirements_file.file_path.subpath_from_root)
-    download_info["missing_req_file_checksum"] = True
-    download_info["package_type"] = ""
-
-    def _checksum_must_match_or_path_unlink(
-        path: Path, checksum_info: Iterable[ChecksumInfo]
-    ) -> bool:
-        try:
-            # returns None, raises PackageRejected on failure
-            must_match_any_checksum(path, checksum_info)
-            return True
-        except PackageRejected:
-            path.unlink(missing_ok=True)
-            log.warning("Download '%s' was removed from the output directory", path.name)
-            return False
-
-    if dpi:
-        if dpi.req_file_checksums:
-            download_info["missing_req_file_checksum"] = False
-        if dpi.checksums_to_match:
-            if not _checksum_must_match_or_path_unlink(dpi.path, dpi.checksums_to_match):
-                return None
-        if dpi.package_type == "sdist":
-            _check_metadata_in_sdist(dpi.path)
-        download_info["package_type"] = dpi.package_type
-        download_info["index_url"] = dpi.index_url
-    elif req.kind == "vcs":
-        # `missing_req_file_checksum` is *always* True for VCS deps
-        pass
-    else:
-        if req.kind == "url":
-            hashes = req.hashes
-            if hashes:
-                download_info["missing_req_file_checksum"] = False
-                if not _checksum_must_match_or_path_unlink(
-                    download_info["path"], list(map(ChecksumInfo.from_hash, hashes))
-                ):
-                    return None
-
-    log.debug(
-        "Successfully processed '%s' in path '%s'",
-        req.download_line,
-        download_info["path"].relative_to(pip_deps_dir.root),
-    )
-
-    return download_info
+def _checksum_must_match_or_path_unlink(path: Path, checksum_info: Iterable[ChecksumInfo]) -> bool:
+    try:
+        must_match_any_checksum(path, checksum_info)
+        return True
+    except PackageRejected:
+        path.unlink(missing_ok=True)
+        log.warning("Download '%s' was removed from the output directory", path.name)
+        return False
 
 
-def _process_pypi_reqs(
+def _download_pypi_packages(
     requirements_file: PipRequirementsFile,
     pip_deps_dir: RootedPath,
     pypi_artifacts: list[_PyPIArtifact],
@@ -341,42 +295,119 @@ def _process_pypi_reqs(
         log.info("Downloading %d PyPI artifacts", len(files))
         asyncio.run(async_download_files(files, get_config().runtime.concurrency_limit))
 
-    download_infos = []
+    result: list[dict[str, Any]] = []
     for req, dpi in pypi_artifacts:
-        res = _process_req(req, requirements_file, pip_deps_dir, dpi.download_info, dpi=dpi)
-        if res is not None:
-            download_infos.append(res)
+        missing_req_file_checksum = not bool(dpi.req_file_checksums)
+        if dpi.checksums_to_match:
+            if not _checksum_must_match_or_path_unlink(dpi.path, dpi.checksums_to_match):
+                continue
+        if dpi.package_type == "sdist":
+            _check_metadata_in_sdist(dpi.path)
 
-    return download_infos
-
-
-def _process_vcs_req(
-    req: PipRequirement, pip_deps_dir: RootedPath, **kwargs: Any
-) -> dict[str, Any] | None:
-    return _process_req(
-        req,
-        pip_deps_dir=pip_deps_dir,
-        download_info=_download_vcs_package(req, pip_deps_dir),
-        **kwargs,
-    )
-
-
-def _process_url_req(
-    req: PipRequirement, pip_deps_dir: RootedPath, trusted_hosts: set[str], **kwargs: Any
-) -> dict[str, Any] | None:
-    result = _process_req(
-        req,
-        pip_deps_dir=pip_deps_dir,
-        download_info=_download_url_package(req, pip_deps_dir, trusted_hosts),
-        **kwargs,
-    )
-    if result is None:
-        return None
-    parsed_url = urlparse.urlparse(req.url)
-    if parsed_url.path.endswith(WHEEL_FILE_EXTENSION):
-        result["package_type"] = "wheel"
-
+        download_info: dict[str, Any] = {
+            "package": dpi.name,
+            "path": dpi.path,
+            "kind": "pypi",
+            "requirement_file": str(requirements_file.file_path.subpath_from_root),
+            "missing_req_file_checksum": missing_req_file_checksum,
+            "package_type": dpi.package_type,
+            "version": dpi.version,
+            "index_url": dpi.index_url,
+        }
+        log.debug(
+            "Successfully processed '%s' in path '%s'",
+            req.download_line,
+            download_info["path"].relative_to(pip_deps_dir.root),
+        )
+        result.append(download_info)
     return result
+
+
+def _download_vcs_package(
+    req: PipRequirement,
+    requirements_file: PipRequirementsFile,
+    pip_deps_dir: RootedPath,
+) -> dict[str, Any]:
+    """Fetch a Python package from VCS (only git is supported)."""
+    git_info = extract_git_info(req.url)
+
+    download_to = pip_deps_dir.join_within_root(_get_external_requirement_filepath(req))
+    download_to.path.parent.mkdir(exist_ok=True, parents=True)
+
+    clone_as_tarball(git_info["url"], git_info["ref"], to_path=download_to.path)
+
+    download_info: dict[str, Any] = {
+        "package": req.package,
+        "path": download_to.path,
+        "kind": "vcs",
+        "requirement_file": str(requirements_file.file_path.subpath_from_root),
+        "missing_req_file_checksum": True,
+        "package_type": "",
+        **git_info,
+    }
+    log.debug(
+        "Successfully processed '%s' in path '%s'",
+        req.download_line,
+        download_info["path"].relative_to(pip_deps_dir.root),
+    )
+    return download_info
+
+
+def _download_url_package(
+    req: PipRequirement,
+    requirements_file: PipRequirementsFile,
+    pip_deps_dir: RootedPath,
+    trusted_hosts: set[str],
+) -> dict[str, Any] | None:
+    """Download a Python package from a URL.
+
+    :param trusted_hosts: if host (or host:port) is trusted, do not verify SSL
+    """
+    parsed_url = urlparse.urlparse(req.url)
+
+    download_to = pip_deps_dir.join_within_root(_get_external_requirement_filepath(req))
+    download_to.path.parent.mkdir(exist_ok=True, parents=True)
+
+    if parsed_url.port is not None and f"{parsed_url.hostname}:{parsed_url.port}" in trusted_hosts:
+        log.debug(
+            "Disabling SSL verification, %s:%s is a --trusted-host",
+            parsed_url.hostname,
+            parsed_url.port,
+        )
+        insecure = True
+    elif parsed_url.hostname in trusted_hosts:
+        log.debug("Disabling SSL verification, %s is a --trusted-host", parsed_url.hostname)
+        insecure = True
+    else:
+        insecure = False
+
+    download_binary_file(req.url, download_to.path, insecure=insecure)
+
+    hashes = req.hashes
+    missing_req_file_checksum = True
+    if hashes:
+        missing_req_file_checksum = False
+        if not _checksum_must_match_or_path_unlink(
+            download_to.path, list(map(ChecksumInfo.from_hash, hashes))
+        ):
+            return None
+
+    download_info: dict[str, Any] = {
+        "package": req.package,
+        "path": download_to.path,
+        "kind": "url",
+        "requirement_file": str(requirements_file.file_path.subpath_from_root),
+        "missing_req_file_checksum": missing_req_file_checksum,
+        "package_type": "wheel" if parsed_url.path.endswith(WHEEL_FILE_EXTENSION) else "",
+        "original_url": req.url,
+        "checksum": req.hashes[0],
+    }
+    log.debug(
+        "Successfully processed '%s' in path '%s'",
+        req.download_line,
+        download_info["path"].relative_to(pip_deps_dir.root),
+    )
+    return download_info
 
 
 async def _resolve_pypi_distributions(
@@ -433,19 +464,10 @@ def _download_dependencies(
             pypi_reqs.append(req)
             continue
         elif req.kind == "vcs":
-            download_info = _process_vcs_req(
-                req,
-                requirements_file=requirements_file,
-                pip_deps_dir=pip_deps_dir,
-            )
-            if download_info is not None:
-                processed.append(download_info)
+            processed.append(_download_vcs_package(req, requirements_file, pip_deps_dir))
         elif req.kind == "url":
-            download_info = _process_url_req(
-                req,
-                requirements_file=requirements_file,
-                pip_deps_dir=pip_deps_dir,
-                trusted_hosts=trusted_hosts,
+            download_info = _download_url_package(
+                req, requirements_file, pip_deps_dir, trusted_hosts
             )
             if download_info is not None:
                 processed.append(download_info)
@@ -466,68 +488,9 @@ def _download_dependencies(
         pypi_dpis = asyncio.run(_resolve_pypi_distributions(pypi_reqs, resolve_callback))
         reqs_dpis_zipped = zip(pypi_reqs, pypi_dpis)
         pypi_artifacts = [_PyPIArtifact(req, dpi) for req, dpis in reqs_dpis_zipped for dpi in dpis]
-        processed.extend(_process_pypi_reqs(requirements_file, pip_deps_dir, pypi_artifacts))
+        processed.extend(_download_pypi_packages(requirements_file, pip_deps_dir, pypi_artifacts))
 
     return processed
-
-
-def _download_vcs_package(requirement: PipRequirement, pip_deps_dir: RootedPath) -> dict[str, Any]:
-    """
-    Fetch the source for a Python package from VCS (only git is supported).
-
-    :param PipRequirement requirement: VCS requirement from a requirements.txt file
-    :param RootedPath pip_deps_dir: The deps/pip directory in an application request bundle
-
-    :return: Dict with package name, download path and git info
-    """
-    git_info = extract_git_info(requirement.url)
-
-    download_to = pip_deps_dir.join_within_root(_get_external_requirement_filepath(requirement))
-    download_to.path.parent.mkdir(exist_ok=True, parents=True)
-
-    clone_as_tarball(git_info["url"], git_info["ref"], to_path=download_to.path)
-
-    return {
-        "package": requirement.package,
-        "path": download_to.path,
-        **git_info,
-    }
-
-
-def _download_url_package(
-    requirement: PipRequirement, pip_deps_dir: RootedPath, trusted_hosts: set[str]
-) -> dict[str, Any]:
-    """
-    Download a Python package from a URL.
-
-    :param PipRequirement requirement: URL requirement from a requirements.txt file
-    :param RootedPath pip_deps_dir: The deps/pip directory in an application request bundle
-    :param set[str] trusted_hosts: If host (or host:port) is trusted, do not verify SSL
-
-    :return: Dict with package name, download path, original URL and URL with hash
-    """
-    url = urlparse.urlparse(requirement.url)
-
-    download_to = pip_deps_dir.join_within_root(_get_external_requirement_filepath(requirement))
-    download_to.path.parent.mkdir(exist_ok=True, parents=True)
-
-    if url.port is not None and f"{url.hostname}:{url.port}" in trusted_hosts:
-        log.debug("Disabling SSL verification, %s:%s is a --trusted-host", url.hostname, url.port)
-        insecure = True
-    elif url.hostname in trusted_hosts:
-        log.debug("Disabling SSL verification, %s is a --trusted-host", url.hostname)
-        insecure = True
-    else:
-        insecure = False
-
-    download_binary_file(requirement.url, download_to.path, insecure=insecure)
-
-    return {
-        "package": requirement.package,
-        "path": download_to.path,
-        "original_url": requirement.url,
-        "checksum": requirement.hashes[0],
-    }
 
 
 def _download_from_requirement_files(

--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -367,6 +367,26 @@ async def _resolve_pypi_distributions(
     return await asyncio.gather(*tasks)
 
 
+def _resolve_and_download_pypi_packages(
+    pypi_reqs: list[PipRequirement],
+    requirements_file: PipRequirementsFile,
+    pip_deps_dir: RootedPath,
+    binary_filters: PipBinaryFilters | None,
+    index_url: str,
+) -> list[PyPIPackage]:
+    """Resolve and download all PyPI packages."""
+    resolve_callback = functools.partial(
+        process_package_distributions,
+        pip_deps_dir=pip_deps_dir,
+        binary_filters=binary_filters,
+        index_url=index_url,
+    )
+    pypi_dpis = asyncio.run(_resolve_pypi_distributions(pypi_reqs, resolve_callback))
+    reqs_dpis_zipped = zip(pypi_reqs, pypi_dpis)
+    pypi_artifacts = [_PyPIArtifact(req, dpi) for req, dpis in reqs_dpis_zipped for dpi in dpis]
+    return _download_pypi_packages(requirements_file, pip_deps_dir, pypi_artifacts)
+
+
 def _download_dependencies(
     output_dir: RootedPath,
     requirements_file: PipRequirementsFile,
@@ -422,18 +442,13 @@ def _download_dependencies(
 
         log.info("-- Finished processing requirement line '%s'", req.download_line)
 
-    pypi_artifacts: list[_PyPIArtifact] = []
     if pypi_reqs:
-        resolve_callback = functools.partial(
-            process_package_distributions,
-            pip_deps_dir=pip_deps_dir,
-            binary_filters=binary_filters,
-            index_url=options["index_url"] or pypi_simple.PYPI_SIMPLE_ENDPOINT,
+        index_url = options["index_url"] or pypi_simple.PYPI_SIMPLE_ENDPOINT
+        processed.extend(
+            _resolve_and_download_pypi_packages(
+                pypi_reqs, requirements_file, pip_deps_dir, binary_filters, index_url
+            )
         )
-        pypi_dpis = asyncio.run(_resolve_pypi_distributions(pypi_reqs, resolve_callback))
-        reqs_dpis_zipped = zip(pypi_reqs, pypi_dpis)
-        pypi_artifacts = [_PyPIArtifact(req, dpi) for req, dpis in reqs_dpis_zipped for dpi in dpis]
-        processed.extend(_download_pypi_packages(requirements_file, pip_deps_dir, pypi_artifacts))
 
     return processed
 

--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -19,7 +19,6 @@ from hermeto.core.constants import Mode
 from hermeto.core.errors import LockfileNotFound, NotAGitRepo, PackageRejected, UnsupportedFeature
 from hermeto.core.models.input import PipBinaryFilters, Request
 from hermeto.core.models.output import EnvironmentVariable, ProjectFile, RequestOutput
-from hermeto.core.models.property_semantics import PropertySet
 from hermeto.core.models.sbom import Component, create_backend_annotation
 from hermeto.core.package_managers.general import (
     async_download_files,
@@ -30,6 +29,13 @@ from hermeto.core.package_managers.general import (
 from hermeto.core.package_managers.pip.package_distributions import (
     DistributionPackageInfo,
     process_package_distributions,
+)
+from hermeto.core.package_managers.pip.packages import (
+    PipPackage,
+    PipPackageInfo,
+    PyPIPackage,
+    URLPackage,
+    VCSPackage,
 )
 from hermeto.core.package_managers.pip.project_files import PyProjectTOML, SetupCFG, SetupPY
 from hermeto.core.package_managers.pip.requirements import (
@@ -79,44 +85,18 @@ def fetch_pip_source(request: Request) -> RequestOutput:
             package.requirements_build_files,
             package.binary,
         )
-        purl = _generate_purl_main_package(info["package"], package_path)
-        components.append(
-            Component(name=info["package"]["name"], version=info["package"]["version"], purl=purl)
-        )
+        purl = _generate_purl_main_package(info, package_path)
+        components.append(Component(name=info.name, version=info.version, purl=purl))
 
-        for dependency in info["dependencies"]:
-            purl = _generate_purl_dependency(dependency)
-            version = dependency["version"] if dependency["kind"] == "pypi" else None
+        for dep in info.requires:
+            components.append(dep.to_component(build_dependency=False))
+        for dep in info.build_requires:
+            components.append(dep.to_component(build_dependency=True))
 
-            missing_hash_in_file: frozenset = frozenset()
-            if dependency["missing_req_file_checksum"]:
-                missing_hash_in_file = frozenset({dependency["requirement_file"]})
-
-            pip_package_binary = False
-            if dependency["package_type"] == "wheel":
-                pip_package_binary = True
-
-            pip_build_dependency = False
-            if dependency["build_dependency"] is True:
-                pip_build_dependency = True
-
-            components.append(
-                Component(
-                    name=dependency["name"],
-                    version=version,
-                    purl=purl,
-                    properties=PropertySet(
-                        missing_hash_in_file=missing_hash_in_file,
-                        pip_package_binary=pip_package_binary,
-                        pip_build_dependency=pip_build_dependency,
-                    ).to_properties(),
-                )
-            )
-
-        replaced_requirements_files = map(_replace_external_requirements, info["requirements"])
+        replaced_requirements_files = map(_replace_external_requirements, info.requirements)
         project_files.extend(filter(None, replaced_requirements_files))
         # each package can have Rust dependencies
-        packages_containing_rust_code += info["packages_containing_rust_code"]
+        packages_containing_rust_code += info.packages_containing_rust_code
 
     annotations = []
     if backend_annotation := create_backend_annotation(components, "pip"):
@@ -132,11 +112,11 @@ def fetch_pip_source(request: Request) -> RequestOutput:
     return pip_packages + cargo_packages
 
 
-def _generate_purl_main_package(package: dict[str, Any], package_path: RootedPath) -> str:
+def _generate_purl_main_package(package: PipPackageInfo, package_path: RootedPath) -> str:
     """Get the purl for this package."""
     type = "pypi"
-    name = package["name"]
-    version = package["version"]
+    name = package.name
+    version = package.version
     try:
         qualifiers = get_vcs_qualifiers(package_path.root)
     except NotAGitRepo:
@@ -156,37 +136,6 @@ def _generate_purl_main_package(package: dict[str, Any], package_path: RootedPat
         version=version,
         qualifiers=qualifiers,
         subpath=subpath,
-    )
-
-    return purl.to_string()
-
-
-def _generate_purl_dependency(package: dict[str, Any]) -> str:
-    """Get the purl for this dependency."""
-    type = "pypi"
-    name = package["name"]
-    dependency_kind = package.get("kind", None)
-    version = None
-    qualifiers: dict[str, str] | None = None
-
-    if dependency_kind == "pypi":
-        version = package["version"]
-        index_url = package["index_url"]
-        if index_url.rstrip("/") != pypi_simple.PYPI_SIMPLE_ENDPOINT.rstrip("/"):
-            qualifiers = {"repository_url": index_url}
-    elif dependency_kind == "vcs":
-        qualifiers = {"vcs_url": package["version"]}
-    elif dependency_kind == "url":
-        qualifiers = {"download_url": package["version"], "checksum": package["checksum"]}
-    else:
-        # Should not happen
-        raise RuntimeError(f"Unexpected requirement kind: {dependency_kind}")
-
-    purl = PackageURL(
-        type=type,
-        name=name,
-        version=version,
-        qualifiers=qualifiers,
     )
 
     return purl.to_string()
@@ -289,13 +238,13 @@ def _download_pypi_packages(
     requirements_file: PipRequirementsFile,
     pip_deps_dir: RootedPath,
     pypi_artifacts: list[_PyPIArtifact],
-) -> list[dict[str, Any]]:
+) -> list[PyPIPackage]:
     files = {dpi.url: dpi.path for _, dpi in pypi_artifacts if not dpi.path.exists()}
     if files:
         log.info("Downloading %d PyPI artifacts", len(files))
         asyncio.run(async_download_files(files, get_config().runtime.concurrency_limit))
 
-    result: list[dict[str, Any]] = []
+    result: list[PyPIPackage] = []
     for req, dpi in pypi_artifacts:
         missing_req_file_checksum = not bool(dpi.req_file_checksums)
         if dpi.checksums_to_match:
@@ -304,22 +253,21 @@ def _download_pypi_packages(
         if dpi.package_type == "sdist":
             _check_metadata_in_sdist(dpi.path)
 
-        download_info: dict[str, Any] = {
-            "package": dpi.name,
-            "path": dpi.path,
-            "kind": "pypi",
-            "requirement_file": str(requirements_file.file_path.subpath_from_root),
-            "missing_req_file_checksum": missing_req_file_checksum,
-            "package_type": dpi.package_type,
-            "version": dpi.version,
-            "index_url": dpi.index_url,
-        }
+        dep = PyPIPackage(
+            name=dpi.name,
+            path=dpi.path,
+            requirement_file=str(requirements_file.file_path.subpath_from_root),
+            missing_req_file_checksum=missing_req_file_checksum,
+            package_type=dpi.package_type,
+            version=dpi.version,
+            index_url=dpi.index_url,
+        )
         log.debug(
             "Successfully processed '%s' in path '%s'",
             req.download_line,
-            download_info["path"].relative_to(pip_deps_dir.root),
+            dep.path.relative_to(pip_deps_dir.root),
         )
-        result.append(download_info)
+        result.append(dep)
     return result
 
 
@@ -327,7 +275,7 @@ def _download_vcs_package(
     req: PipRequirement,
     requirements_file: PipRequirementsFile,
     pip_deps_dir: RootedPath,
-) -> dict[str, Any]:
+) -> VCSPackage:
     """Fetch a Python package from VCS (only git is supported)."""
     git_info = extract_git_info(req.url)
 
@@ -336,21 +284,21 @@ def _download_vcs_package(
 
     clone_as_tarball(git_info["url"], git_info["ref"], to_path=download_to.path)
 
-    download_info: dict[str, Any] = {
-        "package": req.package,
-        "path": download_to.path,
-        "kind": "vcs",
-        "requirement_file": str(requirements_file.file_path.subpath_from_root),
-        "missing_req_file_checksum": True,
-        "package_type": "",
-        **git_info,
-    }
+    dep = VCSPackage(
+        name=req.package,
+        path=download_to.path,
+        requirement_file=str(requirements_file.file_path.subpath_from_root),
+        missing_req_file_checksum=True,
+        package_type="",
+        url=git_info["url"],
+        ref=git_info["ref"],
+    )
     log.debug(
         "Successfully processed '%s' in path '%s'",
         req.download_line,
-        download_info["path"].relative_to(pip_deps_dir.root),
+        dep.path.relative_to(pip_deps_dir.root),
     )
-    return download_info
+    return dep
 
 
 def _download_url_package(
@@ -358,7 +306,7 @@ def _download_url_package(
     requirements_file: PipRequirementsFile,
     pip_deps_dir: RootedPath,
     trusted_hosts: set[str],
-) -> dict[str, Any] | None:
+) -> URLPackage | None:
     """Download a Python package from a URL.
 
     :param trusted_hosts: if host (or host:port) is trusted, do not verify SSL
@@ -392,22 +340,21 @@ def _download_url_package(
         ):
             return None
 
-    download_info: dict[str, Any] = {
-        "package": req.package,
-        "path": download_to.path,
-        "kind": "url",
-        "requirement_file": str(requirements_file.file_path.subpath_from_root),
-        "missing_req_file_checksum": missing_req_file_checksum,
-        "package_type": "wheel" if parsed_url.path.endswith(WHEEL_FILE_EXTENSION) else "",
-        "original_url": req.url,
-        "checksum": req.hashes[0],
-    }
+    dep = URLPackage(
+        name=req.package,
+        path=download_to.path,
+        requirement_file=str(requirements_file.file_path.subpath_from_root),
+        missing_req_file_checksum=missing_req_file_checksum,
+        package_type="wheel" if parsed_url.path.endswith(WHEEL_FILE_EXTENSION) else "",
+        original_url=req.url,
+        checksum=req.hashes[0],
+    )
     log.debug(
         "Successfully processed '%s' in path '%s'",
         req.download_line,
-        download_info["path"].relative_to(pip_deps_dir.root),
+        dep.path.relative_to(pip_deps_dir.root),
     )
-    return download_info
+    return dep
 
 
 async def _resolve_pypi_distributions(
@@ -424,20 +371,18 @@ def _download_dependencies(
     output_dir: RootedPath,
     requirements_file: PipRequirementsFile,
     binary_filters: PipBinaryFilters | None = None,
-) -> list[dict[str, Any]]:
+) -> list[PipPackage]:
     """
     Download artifacts of all dependency packages in a requirements.txt file.
 
     :param output_dir: the root output directory for this request
     :param requirements_file: A requirements.txt file
     :param binary_filters: process wheels?
-    :return: Info about downloaded packages; all items will contain "kind" and "path" keys
-        (and more based on kind, see _download_*_package functions for more details)
-    :rtype: list[dict]
+    :return: list of PipPackage instances for each downloaded package
     """
     options: dict[str, Any] = process_requirements_options(requirements_file.options)
     trusted_hosts = set(options["trusted_hosts"])
-    processed: list[dict[str, Any]] = []
+    processed: list[PipPackage] = []
 
     if options["require_hashes"]:
         log.info("Global --require-hashes option used, will require hashes")
@@ -497,18 +442,17 @@ def _download_from_requirement_files(
     output_dir: RootedPath,
     files: list[RootedPath],
     binary_filters: PipBinaryFilters | None = None,
-) -> list[dict[str, Any]]:
+) -> list[PipPackage]:
     """
     Download dependencies listed in the requirement files.
 
     :param output_dir: the root output directory for this request
     :param files: list of absolute paths to pip requirements files
     :param binary_filters: process wheels?
-    :return: Info about downloaded packages; see download_dependencies return docs for further
-        reference
+    :return: list of PipPackage instances for each downloaded package
     :raises PackageRejected: If requirement file does not exist
     """
-    requirements: list[dict[str, Any]] = []
+    requirements: list[PipPackage] = []
     for req_file in files:
         if not req_file.path.exists():
             raise LockfileNotFound(
@@ -541,23 +485,11 @@ def _resolve_pip(
     requirement_files: list[Path] | None = None,
     build_requirement_files: list[Path] | None = None,
     binary_filters: PipBinaryFilters | None = None,
-) -> dict[str, Any]:
-    """
-    Resolve and fetch pip dependencies for the given pip application.
+) -> PipPackageInfo:
+    """Resolve and fetch pip dependencies for the given pip application.
 
-    :param app_path: the full path to the application source code
-    :param output_dir: the root output directory for this request
-    :param list requirement_files: a list of str representing paths to the Python requirement files
-        to be used to compile a list of dependencies to be fetched
-    :param list build_requirement_files: a list of str representing paths to the Python build
-        requirement files to be used to compile a list of build dependencies to be fetched
-    :param binary_filters: process wheels?
-    :return: a dictionary that has the following keys:
-        ``package`` which is the dict representing the main Package,
-        ``dependencies`` which is a list of dicts representing the package Dependencies
-        ``requirements`` which is a list of absolute paths for the processed requirement files
     :raises PackageRejected | UnsupportedFeature: if the package is not compatible with our
-    requirements/expectations
+        requirements/expectations
     """
     pkg_name, pkg_version = _get_pip_metadata(package_path)
 
@@ -594,48 +526,20 @@ def _resolve_pip(
         output_dir, resolved_build_req_files, binary_filters
     )
 
+    all_deps = requires + build_requires
     if get_config().pip.ignore_dependencies_crates:
         packages_containing_rust_code = []
     else:
-        packages_containing_rust_code = filter_packages_with_rust_code(requires + build_requires)
+        packages_containing_rust_code = filter_packages_with_rust_code(all_deps)
 
-    # Mark all build dependencies as such
-    for dependency in build_requires:
-        dependency["build_dependency"] = True
-
-    def _version(dep: dict[str, Any]) -> str:
-        if dep["kind"] == "pypi":
-            version = dep["version"]
-        elif dep["kind"] == "vcs":
-            # Version is "git+" followed by the URL used to fetch from git
-            version = f"git+{dep['url']}@{dep['ref']}"
-        else:
-            # Version is the original URL for URL dependencies
-            version = dep["original_url"]
-        return version
-
-    dependencies = [
-        {
-            "name": dep["package"],
-            "version": _version(dep),
-            "checksum": dep.get("checksum"),
-            "index_url": dep.get("index_url"),
-            "type": "pip",
-            "build_dependency": dep.get("build_dependency", False),
-            "kind": dep["kind"],
-            "requirement_file": dep["requirement_file"],
-            "missing_req_file_checksum": dep["missing_req_file_checksum"],
-            "package_type": dep["package_type"],
-        }
-        for dep in (requires + build_requires)
-    ]
-
-    return {
-        "package": {"name": pkg_name, "version": pkg_version, "type": "pip"},
-        "dependencies": dependencies,
-        "requirements": [*resolved_req_files, *resolved_build_req_files],
-        "packages_containing_rust_code": packages_containing_rust_code,
-    }
+    return PipPackageInfo(
+        name=pkg_name,
+        version=pkg_version,
+        requires=requires,
+        build_requires=build_requires,
+        requirements=[*resolved_req_files, *resolved_build_req_files],
+        packages_containing_rust_code=packages_containing_rust_code,
+    )
 
 
 def _get_external_requirement_filepath(requirement: PipRequirement) -> Path:

--- a/hermeto/core/package_managers/pip/package_distributions.py
+++ b/hermeto/core/package_managers/pip/package_distributions.py
@@ -7,7 +7,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 from itertools import chain
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Literal, cast
 
 import pypi_simple
 import requests
@@ -84,15 +84,6 @@ class DistributionPackageInfo:
             or len(self.pypi_checksums) == 0
             or len(self.req_file_checksums) == 0
         )
-
-    @property
-    def download_info(self) -> dict[str, Any]:
-        """Only necessary attributes to process download information."""
-        return {
-            "package": self.name,
-            "version": self.version,
-            "path": self.path,
-        }
 
 
 def _sdist_preference(sdist_pkg: DistributionPackageInfo) -> tuple[int, int]:

--- a/hermeto/core/package_managers/pip/packages.py
+++ b/hermeto/core/package_managers/pip/packages.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: GPL-3.0-only
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from pathlib import Path
+
+import pypi_simple
+from packageurl import PackageURL
+
+from hermeto.core.models.input import CargoPackageInput
+from hermeto.core.models.property_semantics import PropertySet
+from hermeto.core.models.sbom import Component
+from hermeto.core.rooted_path import RootedPath
+
+
+@dataclass
+class PipPackage(ABC):
+    """Base class for a fetched pip package."""
+
+    name: str
+    path: Path
+    requirement_file: str
+    missing_req_file_checksum: bool
+    package_type: str
+
+    def to_component(self, build_dependency: bool) -> Component:
+        """Build an SBOM Component from this package."""
+        missing_hash = (
+            frozenset({self.requirement_file}) if self.missing_req_file_checksum else frozenset()
+        )
+        return Component(
+            name=self.name,
+            version=self._sbom_version(),
+            purl=self._make_purl(),
+            properties=PropertySet(
+                missing_hash_in_file=missing_hash,
+                pip_package_binary=(self.package_type == "wheel"),
+                pip_build_dependency=build_dependency,
+            ).to_properties(),
+        )
+
+    @abstractmethod
+    def _make_purl(self) -> str: ...
+
+    @abstractmethod
+    def _sbom_version(self) -> str | None: ...
+
+
+@dataclass
+class PyPIPackage(PipPackage):
+    """A package fetched from a PyPI index."""
+
+    version: str
+    index_url: str
+
+    def _make_purl(self) -> str:
+        qualifiers = None
+        if self.index_url.rstrip("/") != pypi_simple.PYPI_SIMPLE_ENDPOINT.rstrip("/"):
+            qualifiers = {"repository_url": self.index_url}
+        return PackageURL(
+            type="pypi",
+            name=self.name,
+            version=self.version,
+            qualifiers=qualifiers,
+        ).to_string()
+
+    def _sbom_version(self) -> str:
+        return self.version
+
+
+@dataclass
+class VCSPackage(PipPackage):
+    """A package fetched from a VCS repository (git)."""
+
+    url: str
+    ref: str
+
+    def _make_purl(self) -> str:
+        return PackageURL(
+            type="pypi",
+            name=self.name,
+            qualifiers={"vcs_url": f"git+{self.url}@{self.ref}"},
+        ).to_string()
+
+    def _sbom_version(self) -> str | None:
+        return None
+
+
+@dataclass
+class URLPackage(PipPackage):
+    """A package fetched from a direct URL."""
+
+    original_url: str
+    checksum: str
+
+    def _make_purl(self) -> str:
+        return PackageURL(
+            type="pypi",
+            name=self.name,
+            qualifiers={"download_url": self.original_url, "checksum": self.checksum},
+        ).to_string()
+
+    def _sbom_version(self) -> str | None:
+        return None
+
+
+@dataclass
+class PipPackageInfo:
+    """Resolved pip package with all its dependencies."""
+
+    name: str
+    version: str | None
+    requires: list[PipPackage]
+    build_requires: list[PipPackage]
+    requirements: list[RootedPath]
+    packages_containing_rust_code: list[CargoPackageInput]

--- a/hermeto/core/package_managers/pip/rust.py
+++ b/hermeto/core/package_managers/pip/rust.py
@@ -5,13 +5,13 @@ import logging
 import shutil
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any
 
 import tomlkit
 
 from hermeto.core.models.input import CargoPackageInput, Request
 from hermeto.core.models.output import EnvironmentVariable, ProjectFile, RequestOutput
 from hermeto.core.package_managers.cargo import fetch_cargo_source
+from hermeto.core.package_managers.pip.packages import PipPackage
 from hermeto.core.package_managers.pip.project_files import PyProjectTOML, SetupCFG, SetupPY
 from hermeto.core.package_managers.pip.requirements import WHEEL_FILE_EXTENSION
 from hermeto.core.rooted_path import RootedPath
@@ -67,25 +67,24 @@ def _get_rust_root_dir(source_dir: Path) -> Path | None:
     return None
 
 
-def filter_packages_with_rust_code(packages: list[dict[str, Any]]) -> list[CargoPackageInput]:
+def filter_packages_with_rust_code(packages: list[PipPackage]) -> list[CargoPackageInput]:
     """Filter packages that contain Rust code from a list of pip packages."""
     packages_containing_rust_code = []
 
     for p in packages:
         # File name and package name may differ e.g. when there is a hyphen in
         # package name it might be replaced by an underscore in a file name.
-        package_path: Path | None = p.get("path")
-        if package_path is None or package_path.suffix == WHEEL_FILE_EXTENSION:
+        if p.path.suffix == WHEEL_FILE_EXTENSION:
             continue
 
-        filename = Path(package_path.name)
+        filename = Path(p.path.name)
         extract_filter = "data" if filename.suffix != ".zip" else None
         while filename.suffix in (".zip", ".tar", ".gz", ".tgz"):
             filename = filename.with_suffix("")
 
-        pip_deps_dir = package_path.parent
+        pip_deps_dir = p.path.parent
         extract_dir = pip_deps_dir / filename
-        shutil.unpack_archive(package_path, extract_dir=extract_dir, filter=extract_filter)  # type: ignore[arg-type]
+        shutil.unpack_archive(p.path, extract_dir=extract_dir, filter=extract_filter)  # type: ignore[arg-type]
 
         # The unpacked URL/VCS package may have an arbitrary directory name that we cannot control.
         # Therefore, it is inside a predictable directory derived from the package name.

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -27,6 +27,7 @@ from hermeto.core.errors import (
 from hermeto.core.models.input import CargoPackageInput, Request
 from hermeto.core.package_managers.cargo.main import PackageWithCorruptLockfileRejected
 from hermeto.core.package_managers.pip import main as pip
+from hermeto.core.package_managers.pip.packages import PipPackageInfo, URLPackage, VCSPackage
 from hermeto.core.rooted_path import RootedPath
 from tests.common_utils import GIT_REF
 
@@ -229,24 +230,21 @@ class TestDownload:
         req = mock_requirement("eggs", "vcs", url=vcs_url, download_line=f"eggs @ {vcs_url}")
         req_file = mock_requirements_file(requirements=[req])
 
-        download_info = pip._download_vcs_package(req, req_file, rooted_tmp_path)
+        result = pip._download_vcs_package(req, req_file, rooted_tmp_path)
 
-        assert download_info == {
-            "package": "eggs",
-            "path": rooted_tmp_path.join_within_root(f"eggs-gitcommit-{GIT_REF}.tar.gz").path,
-            "kind": "vcs",
-            "requirement_file": str(req_file.file_path.subpath_from_root),
-            "missing_req_file_checksum": True,
-            "package_type": "",
-            "url": "https://github.com/spam/eggs",
-            "ref": GIT_REF,
-            "namespace": "spam",
-            "repo": "eggs",
-            "host": "github.com",
-        }
+        assert isinstance(result, VCSPackage)
+        assert result.name == "eggs"
+        assert (
+            result.path == rooted_tmp_path.join_within_root(f"eggs-gitcommit-{GIT_REF}.tar.gz").path
+        )
+        assert result.requirement_file == str(req_file.file_path.subpath_from_root)
+        assert result.missing_req_file_checksum is True
+        assert result.package_type == ""
+        assert result.url == "https://github.com/spam/eggs"
+        assert result.ref == GIT_REF
 
         mock_clone_as_tarball.assert_called_once_with(
-            "https://github.com/spam/eggs", GIT_REF, to_path=download_info["path"]
+            "https://github.com/spam/eggs", GIT_REF, to_path=result.path
         )
 
     @pytest.mark.parametrize(
@@ -287,26 +285,24 @@ class TestDownload:
         )
         req_file = mock_requirements_file(requirements=[req])
 
-        download_info = pip._download_url_package(
+        result = pip._download_url_package(
             req,
             req_file,
             rooted_tmp_path,
             set(trusted_hosts),
         )
 
-        assert download_info == {
-            "package": "foo",
-            "path": rooted_tmp_path.join_within_root("foo-abcdef.tar.gz").path,
-            "kind": "url",
-            "requirement_file": str(req_file.file_path.subpath_from_root),
-            "missing_req_file_checksum": False,
-            "package_type": "",
-            "original_url": original_url,
-            "checksum": "sha256:abcdef",
-        }
+        assert isinstance(result, URLPackage)
+        assert result.name == "foo"
+        assert result.path == rooted_tmp_path.join_within_root("foo-abcdef.tar.gz").path
+        assert result.requirement_file == str(req_file.file_path.subpath_from_root)
+        assert result.missing_req_file_checksum is False
+        assert result.package_type == ""
+        assert result.original_url == original_url
+        assert result.checksum == "sha256:abcdef"
 
         mock_download_file.assert_called_once_with(
-            original_url, download_info["path"], insecure=host_is_trusted
+            original_url, result.path, insecure=host_is_trusted
         )
 
     @pytest.mark.parametrize(
@@ -342,8 +338,8 @@ class TestDownload:
 
         result = pip._download_url_package(req, req_file, rooted_tmp_path, set())
 
-        assert result is not None
-        assert result["package_type"] == expected_type
+        assert isinstance(result, URLPackage)
+        assert result.package_type == expected_type
 
     def test_ignored_and_rejected_options(self, caplog: pytest.LogCaptureFixture) -> None:
         """
@@ -764,80 +760,6 @@ def test_replace_external_requirements(
 
 
 @pytest.mark.parametrize(
-    "dependency, expected_purl",
-    [
-        (
-            {
-                "name": "pypi_package",
-                "version": "1.0.0",
-                "type": "pip",
-                "dev": False,
-                "kind": "pypi",
-                "index_url": pypi_simple.PYPI_SIMPLE_ENDPOINT,
-            },
-            "pkg:pypi/pypi-package@1.0.0",
-        ),
-        (
-            {
-                "name": "mypypi_package",
-                "version": "2.0.0",
-                "type": "pip",
-                "dev": False,
-                "kind": "pypi",
-                "index_url": CUSTOM_PYPI_ENDPOINT,
-            },
-            f"pkg:pypi/mypypi-package@2.0.0?repository_url={CUSTOM_PYPI_ENDPOINT}",
-        ),
-        (
-            {
-                "name": "git_dependency",
-                "version": f"git+https://github.com/my-org/git_dependency@{'a' * 40}",
-                "type": "pip",
-                "dev": False,
-                "kind": "vcs",
-            },
-            f"pkg:pypi/git-dependency?vcs_url=git%2Bhttps://github.com/my-org/git_dependency%40{'a' * 40}",
-        ),
-        (
-            {
-                "name": "Git_dependency",
-                "version": f"git+file:///github.com/my-org/git_dependency@{'a' * 40}",
-                "type": "pip",
-                "dev": False,
-                "kind": "vcs",
-            },
-            f"pkg:pypi/git-dependency?vcs_url=git%2Bfile:///github.com/my-org/git_dependency%40{'a' * 40}",
-        ),
-        (
-            {
-                "name": "git_dependency",
-                "version": f"git+ssh://git@github.com/my-org/git_dependency@{'a' * 40}",
-                "type": "pip",
-                "dev": False,
-                "kind": "vcs",
-            },
-            f"pkg:pypi/git-dependency?vcs_url=git%2Bssh://git%40github.com/my-org/git_dependency%40{'a' * 40}",
-        ),
-        (
-            {
-                "name": "https_dependency",
-                "version": f"https://github.com/my-org/https_dependency/{'a' * 40}/file.tar.gz",
-                "type": "pip",
-                "dev": False,
-                "kind": "url",
-                "checksum": "sha256:de526c1",
-            },
-            f"pkg:pypi/https-dependency?checksum=sha256:de526c1&download_url=https://github.com/my-org/https_dependency/{'a' * 40}/file.tar.gz",
-        ),
-    ],
-)
-def test_generate_purl_dependencies(dependency: dict[str, Any], expected_purl: str) -> None:
-    purl = pip._generate_purl_dependency(dependency)
-
-    assert purl == expected_purl
-
-
-@pytest.mark.parametrize(
     "subpath, expected_purl",
     [
         (
@@ -854,7 +776,14 @@ def test_generate_purl_dependencies(dependency: dict[str, Any], expected_purl: s
 def test_generate_purl_main_package(
     mock_git_repo: Any, subpath: Path, expected_purl: str, rooted_tmp_path: RootedPath
 ) -> None:
-    package = {"name": "foo", "version": "1.0.0", "type": "pip"}
+    package = PipPackageInfo(
+        name="foo",
+        version="1.0.0",
+        requires=[],
+        build_requires=[],
+        requirements=[],
+        packages_containing_rust_code=[],
+    )
 
     mocked_repo = mock.Mock()
     mocked_repo.remote.return_value.url = "ssh://git@github.com/my-org/my-repo"
@@ -890,7 +819,14 @@ def test_generate_purl_main_package_permissive_mode_without_vcs_url(
 ) -> None:
     mock_handle_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
     mock_get_config.return_value.mode = Mode.PERMISSIVE
-    package = {"name": "foo", "version": "1.0.0", "type": "pip"}
+    package = PipPackageInfo(
+        name="foo",
+        version="1.0.0",
+        requires=[],
+        build_requires=[],
+        requirements=[],
+        packages_containing_rust_code=[],
+    )
 
     purl = pip._generate_purl_main_package(package, rooted_tmp_path.join_within_root(subpath))
 
@@ -906,7 +842,14 @@ def test_generate_purl_main_package_strict_mode_raises_without_git_repo(
 ) -> None:
     mock_get_repo_id.side_effect = NotAGitRepo("Not a git repo", solution="N/A")
     mock_get_config.return_value.mode = Mode.STRICT
-    package = {"name": "foo", "version": "1.0.0", "type": "pip"}
+    package = PipPackageInfo(
+        name="foo",
+        version="1.0.0",
+        requires=[],
+        build_requires=[],
+        requirements=[],
+        packages_containing_rust_code=[],
+    )
 
     with pytest.raises(NotAGitRepo):
         pip._generate_purl_main_package(package, rooted_tmp_path.join_within_root("."))
@@ -942,7 +885,14 @@ def test_generate_purl_main_package_permissive_mode_with_vcs_url(
     mock_git_repo.return_value = mocked_repo
 
     mock_get_config.return_value.mode = Mode.PERMISSIVE
-    package = {"name": "foo", "version": "1.0.0", "type": "pip"}
+    package = PipPackageInfo(
+        name="foo",
+        version="1.0.0",
+        requires=[],
+        build_requires=[],
+        requirements=[],
+        packages_containing_rust_code=[],
+    )
 
     purl = pip._generate_purl_main_package(package, rooted_tmp_path.join_within_root(subpath))
 
@@ -991,12 +941,14 @@ def test_fetch_pip_source_correctly_reraises_when_there_is_a_dependency_cargo_lo
     )
     mock_verify_lockfile_present.return_value = None
 
-    resolved = {
-        "package": {"name": "foo", "version": "1.0", "type": "pip"},
-        "dependencies": [],
-        "packages_containing_rust_code": [CargoPackageInput(type="cargo", path=".")],
-        "requirements": [],
-    }
+    resolved = PipPackageInfo(
+        name="foo",
+        version="1.0",
+        requires=[],
+        build_requires=[],
+        requirements=[],
+        packages_containing_rust_code=[CargoPackageInput(type="cargo", path=".")],
+    )
 
     mock_resolve_pip.return_value = resolved
 

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -227,12 +227,17 @@ class TestDownload:
         vcs_url = f"git+https://github.com/spam/eggs@{GIT_REF}"
 
         req = mock_requirement("eggs", "vcs", url=vcs_url, download_line=f"eggs @ {vcs_url}")
+        req_file = mock_requirements_file(requirements=[req])
 
-        download_info = pip._download_vcs_package(req, rooted_tmp_path)
+        download_info = pip._download_vcs_package(req, req_file, rooted_tmp_path)
 
         assert download_info == {
             "package": "eggs",
             "path": rooted_tmp_path.join_within_root(f"eggs-gitcommit-{GIT_REF}.tar.gz").path,
+            "kind": "vcs",
+            "requirement_file": str(req_file.file_path.subpath_from_root),
+            "missing_req_file_checksum": True,
+            "package_type": "",
             "url": "https://github.com/spam/eggs",
             "ref": GIT_REF,
             "namespace": "spam",
@@ -240,10 +245,8 @@ class TestDownload:
             "host": "github.com",
         }
 
-        download_path = download_info["path"]
-
         mock_clone_as_tarball.assert_called_once_with(
-            "https://github.com/spam/eggs", GIT_REF, to_path=download_path
+            "https://github.com/spam/eggs", GIT_REF, to_path=download_info["path"]
         )
 
     @pytest.mark.parametrize(
@@ -258,10 +261,15 @@ class TestDownload:
             ("example.org:443", ["example.org"], True),
         ],
     )
+    @mock.patch(
+        "hermeto.core.package_managers.pip.main._checksum_must_match_or_path_unlink",
+        return_value=True,
+    )
     @mock.patch("hermeto.core.package_managers.pip.main.download_binary_file")
     def test_download_url_package(
         self,
         mock_download_file: Any,
+        mock_checksum: Any,
         host_in_url: bool,
         trusted_hosts: list[str],
         host_is_trusted: bool,
@@ -277,9 +285,11 @@ class TestDownload:
             download_line=f"foo @ {original_url}",
             hashes=["sha256:abcdef"],
         )
+        req_file = mock_requirements_file(requirements=[req])
 
         download_info = pip._download_url_package(
             req,
+            req_file,
             rooted_tmp_path,
             set(trusted_hosts),
         )
@@ -287,14 +297,53 @@ class TestDownload:
         assert download_info == {
             "package": "foo",
             "path": rooted_tmp_path.join_within_root("foo-abcdef.tar.gz").path,
+            "kind": "url",
+            "requirement_file": str(req_file.file_path.subpath_from_root),
+            "missing_req_file_checksum": False,
+            "package_type": "",
             "original_url": original_url,
             "checksum": "sha256:abcdef",
         }
 
-        download_path = download_info["path"]
         mock_download_file.assert_called_once_with(
-            original_url, download_path, insecure=host_is_trusted
+            original_url, download_info["path"], insecure=host_is_trusted
         )
+
+    @pytest.mark.parametrize(
+        "url_path, expected_type",
+        [
+            pytest.param("/pkg-1.0-py3-none-any.whl", "wheel", id="wheel"),
+            pytest.param("/pkg-1.0-py3-none-any.whl#sha256=abc", "wheel", id="wheel_with_fragment"),
+            pytest.param(
+                "/pkg-1.0-py3-none-any.whl?v=1#sha256=abc", "wheel", id="wheel_with_query"
+            ),
+            pytest.param("/pkg-1.0.tar.gz", "", id="sdist"),
+        ],
+    )
+    @mock.patch(
+        "hermeto.core.package_managers.pip.main._checksum_must_match_or_path_unlink",
+        return_value=True,
+    )
+    @mock.patch("hermeto.core.package_managers.pip.main.download_binary_file")
+    def test_download_url_package_identifies_wheel_from_url(
+        self,
+        mock_download_file: Any,
+        mock_checksum: Any,
+        url_path: str,
+        expected_type: str,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        """Wheel detection works even when the URL contains fragments or query strings."""
+        url = f"https://example.org{url_path}"
+        req = mock_requirement(
+            "foo", "url", url=url, download_line=f"foo @ {url}", hashes=["sha256:abcdef"]
+        )
+        req_file = mock_requirements_file(requirements=[req])
+
+        result = pip._download_url_package(req, req_file, rooted_tmp_path, set())
+
+        assert result is not None
+        assert result["package_type"] == expected_type
 
     def test_ignored_and_rejected_options(self, caplog: pytest.LogCaptureFixture) -> None:
         """
@@ -958,30 +1007,3 @@ def test_fetch_pip_source_correctly_reraises_when_there_is_a_dependency_cargo_lo
 
     with pytest.raises(PackageWithCorruptLockfileRejected):
         pip.fetch_pip_source(request)
-
-
-@pytest.mark.parametrize(
-    ("test_url", "expected_type"),
-    [
-        ("https://example.com/pkg-1.0-py3-none-any.whl", "wheel"),
-        ("https://example.com/pkg-1.0-py3-none-any.whl#sha256=08695f5ad7", "wheel"),
-        ("https://example.com/pkg-1.0-py3-none-any.whl?v=1.0#sha256=08695f5ad7", "wheel"),
-        ("https://example.com/pkg-1.0.tar.gz", ""),
-        ("https://example.com/pkg-1.0.tar.gz#sha256=08695f5ad7", ""),
-        ("https://example.com/pkg-1.0.tar.gz?v=1.0#sha256=08695f5ad7", ""),
-    ],
-)
-@mock.patch("hermeto.core.package_managers.pip.main._download_url_package")
-@mock.patch("hermeto.core.package_managers.pip.main._process_req")
-def test_process_url_req(
-    mock_process_req: mock.Mock,
-    mock_download_url_package: mock.Mock,
-    test_url: str,
-    expected_type: str,
-) -> None:
-    """Ensure wheel packages are correctly identified even with URL fragments."""
-    req = mock_requirement("pkg", "url", url=test_url)
-    mock_process_req.return_value = {"package_type": ""}
-    result = pip._process_url_req(req, pip_deps_dir=mock.Mock(), trusted_hosts=set())
-    assert result is not None
-    assert result.get("package_type") == expected_type

--- a/tests/unit/package_managers/pip/test_packages.py
+++ b/tests/unit/package_managers/pip/test_packages.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: GPL-3.0-only
+from pathlib import Path
+
+import pypi_simple
+import pytest
+
+from hermeto.core.models.property_semantics import PropertySet
+from hermeto.core.package_managers.pip.packages import (
+    PyPIPackage,
+    URLPackage,
+    VCSPackage,
+)
+
+CUSTOM_PYPI_ENDPOINT = "https://my-pypi.org/simple/"
+GIT_REF = "a" * 40
+
+_PATH = Path("/deps/pip/pkg.tar.gz")
+_REQ_FILE = "requirements.txt"
+
+
+@pytest.mark.parametrize(
+    "dep, expected_purl",
+    [
+        pytest.param(
+            PyPIPackage(
+                name="pypi_package",
+                path=_PATH,
+                requirement_file=_REQ_FILE,
+                missing_req_file_checksum=False,
+                package_type="sdist",
+                version="1.0.0",
+                index_url=pypi_simple.PYPI_SIMPLE_ENDPOINT,
+            ),
+            "pkg:pypi/pypi-package@1.0.0",
+            id="pypi-default-index",
+        ),
+        pytest.param(
+            PyPIPackage(
+                name="mypypi_package",
+                path=_PATH,
+                requirement_file=_REQ_FILE,
+                missing_req_file_checksum=False,
+                package_type="sdist",
+                version="2.0.0",
+                index_url=CUSTOM_PYPI_ENDPOINT,
+            ),
+            f"pkg:pypi/mypypi-package@2.0.0?repository_url={CUSTOM_PYPI_ENDPOINT}",
+            id="pypi-custom-index",
+        ),
+        pytest.param(
+            VCSPackage(
+                name="git_dependency",
+                path=_PATH,
+                requirement_file=_REQ_FILE,
+                missing_req_file_checksum=False,
+                package_type="sdist",
+                url="https://github.com/my-org/git_dependency",
+                ref=GIT_REF,
+            ),
+            f"pkg:pypi/git-dependency?vcs_url=git%2Bhttps://github.com/my-org/git_dependency%40{GIT_REF}",
+            id="vcs-https",
+        ),
+        pytest.param(
+            VCSPackage(
+                name="Git_dependency",
+                path=_PATH,
+                requirement_file=_REQ_FILE,
+                missing_req_file_checksum=False,
+                package_type="sdist",
+                url="file:///github.com/my-org/git_dependency",
+                ref=GIT_REF,
+            ),
+            f"pkg:pypi/git-dependency?vcs_url=git%2Bfile:///github.com/my-org/git_dependency%40{GIT_REF}",
+            id="vcs-file",
+        ),
+        pytest.param(
+            VCSPackage(
+                name="git_dependency",
+                path=_PATH,
+                requirement_file=_REQ_FILE,
+                missing_req_file_checksum=False,
+                package_type="sdist",
+                url="ssh://git@github.com/my-org/git_dependency",
+                ref=GIT_REF,
+            ),
+            f"pkg:pypi/git-dependency?vcs_url=git%2Bssh://git%40github.com/my-org/git_dependency%40{GIT_REF}",
+            id="vcs-ssh",
+        ),
+        pytest.param(
+            URLPackage(
+                name="https_dependency",
+                path=_PATH,
+                requirement_file=_REQ_FILE,
+                missing_req_file_checksum=False,
+                package_type="sdist",
+                original_url=f"https://github.com/my-org/https_dependency/{GIT_REF}/file.tar.gz",
+                checksum="sha256:de526c1",
+            ),
+            f"pkg:pypi/https-dependency?checksum=sha256:de526c1&download_url=https://github.com/my-org/https_dependency/{GIT_REF}/file.tar.gz",
+            id="url",
+        ),
+    ],
+)
+def test_make_purl(dep: PyPIPackage | VCSPackage | URLPackage, expected_purl: str) -> None:
+    assert dep._make_purl() == expected_purl
+
+
+def test_to_component_missing_checksum_populates_missing_hash_property() -> None:
+    """When the requirements file has no checksum, the component records which file is missing it."""
+    pkg = PyPIPackage(
+        name="foo",
+        path=_PATH,
+        requirement_file=_REQ_FILE,
+        missing_req_file_checksum=True,
+        package_type="sdist",
+        version="1.0",
+        index_url=pypi_simple.PYPI_SIMPLE_ENDPOINT,
+    )
+
+    component = pkg.to_component(build_dependency=False)
+    props = PropertySet.from_properties(component.properties)
+
+    assert props.missing_hash_in_file == frozenset({_REQ_FILE})
+
+
+def test_to_component_with_checksum_has_empty_missing_hash_property() -> None:
+    """When the requirements file provides a checksum, missing_hash_in_file is empty."""
+    pkg = PyPIPackage(
+        name="foo",
+        path=_PATH,
+        requirement_file=_REQ_FILE,
+        missing_req_file_checksum=False,
+        package_type="sdist",
+        version="1.0",
+        index_url=pypi_simple.PYPI_SIMPLE_ENDPOINT,
+    )
+
+    component = pkg.to_component(build_dependency=False)
+    props = PropertySet.from_properties(component.properties)
+
+    assert props.missing_hash_in_file == frozenset()
+
+
+def test_to_component_pypi_package_has_version() -> None:
+    """PyPI packages carry their resolved version into the SBOM component."""
+    pkg = PyPIPackage(
+        name="foo",
+        path=_PATH,
+        requirement_file=_REQ_FILE,
+        missing_req_file_checksum=False,
+        package_type="sdist",
+        version="2.5.0",
+        index_url=pypi_simple.PYPI_SIMPLE_ENDPOINT,
+    )
+
+    component = pkg.to_component(build_dependency=False)
+
+    assert component.version == "2.5.0"
+
+
+@pytest.mark.parametrize(
+    "dep",
+    [
+        pytest.param(
+            VCSPackage(
+                name="bar",
+                path=_PATH,
+                requirement_file=_REQ_FILE,
+                missing_req_file_checksum=False,
+                package_type="",
+                url="https://github.com/org/bar",
+                ref=GIT_REF,
+            ),
+            id="vcs",
+        ),
+        pytest.param(
+            URLPackage(
+                name="baz",
+                path=_PATH,
+                requirement_file=_REQ_FILE,
+                missing_req_file_checksum=False,
+                package_type="sdist",
+                original_url="https://example.com/baz-1.0.tar.gz",
+                checksum="sha256:abc123",
+            ),
+            id="url",
+        ),
+    ],
+)
+def test_to_component_non_pypi_package_has_no_version(dep: VCSPackage | URLPackage) -> None:
+    """VCS and URL packages have no meaningful version for the SBOM component."""
+    component = dep.to_component(build_dependency=False)
+
+    assert component.version is None


### PR DESCRIPTION
Replace the untyped dicts threaded through the pip backend with typed dataclasses. Each class owns its PURL generation and SBOM component construction. This also consolidates the scattered per-kind download/process helpers into a cleaner resolution flow, making the pip backend easier to extend with proxy support in a follow-up PR.