### PR TITLE
fix(pip): reject VCS deps in hash-locked requirements with clear error

### DIFF
--- a/hermeto/core/package_managers/pip/requirements.py
+++ b/hermeto/core/package_managers/pip/requirements.py
@@ -658,24 +658,35 @@ def validate_requirements_hashes(requirements: list[PipRequirement], require_has
 
     :param list[PipRequirement] requirements: All requirements from a file
     :param bool require_hashes: True if hashes are required for all requirements
+    :raise UnsupportedFeature: If any VCS requirement is used in a hash-locked requirements file
     :raise MissingChecksum: If any hashes are missing
     :raise InvalidChecksum: If hashes have invalid format
     """
     for req in requirements:
         hashes = req.hashes
 
-        if require_hashes and not hashes:
-            # We shouldn't get here, but it's a definite error if we do.
+        if require_hashes:
             # VCS reqs *cannot* be hashed, so we'll always hit
             # this for any VCS req in a 'requirements.txt' which has *any* hash.
             # For URL requirements, having a hash is required to pass *basic* validation.
-            raise MissingChecksum(
-                None,
-                solution=(
-                    f"Hash is required, dependency does not specify any: {req.download_line}.\n"
-                    "Please specify the expected hashes for all dependencies"
-                ),
-            )
+            if req.kind == "vcs":
+                raise UnsupportedFeature(
+                    f"VCS requirements are not supported in hash-locked requirements files: {req.download_line}",
+                    solution=(
+                        "VCS requirements do not support pip's --hash option.\n"
+                        "Consider using a hashable URL instead, for example:\n"
+                        "  <name> @ https://github.com/.../1.0.0.tar.gz \\\n"
+                        "    --hash=sha256:..."
+                    ),
+                )
+            elif not hashes:
+                raise MissingChecksum(
+                    None,
+                    solution=(
+                        f"Hash is required, dependency does not specify any: {req.download_line}.\n"
+                        "Please specify the expected hashes for all dependencies"
+                    ),
+                )
 
         for hash_spec in hashes:
             _, _, digest = hash_spec.partition(":")

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -509,8 +509,8 @@ class TestDownload:
                     ("bar", "vcs", {}),
                 ],
                 [],
-                MissingChecksum,
-                id="vcs_local_hash_triggers_missing",
+                UnsupportedFeature,
+                id="vcs_local_hash_triggers_unsupported",
             ),
             pytest.param(
                 [
@@ -527,7 +527,7 @@ class TestDownload:
                     ("bar", "vcs", {}),
                 ],
                 ["--require-hashes"],
-                MissingChecksum,
+                UnsupportedFeature,
                 id="vcs_global_require_hashes",
             ),
             pytest.param(
@@ -545,7 +545,7 @@ class TestDownload:
                     ("bar", "vcs", {}),
                 ],
                 ["--require-hashes"],
-                MissingChecksum,
+                UnsupportedFeature,
                 id="vcs_both_global_and_local_hash",
             ),
             pytest.param(
@@ -557,8 +557,8 @@ class TestDownload:
             pytest.param(
                 [("foo", "vcs", {"hashes": ["malformed"]})],
                 [],
-                InvalidChecksum,
-                id="vcs_malformed_hash",
+                UnsupportedFeature,
+                id="vcs_malformed_hash_triggers_unsupported",
             ),
             pytest.param(
                 [("foo", "url", {"hashes": ["malformed"]})],


### PR DESCRIPTION
Hashed requirements.txt files trigger mandatory checksum validation for every line. Git and other VCS dependencies cannot carry pip --hash entries, so users who mix the two hit MissingChecksum with advice to add hashes they can never satisfy. That sends people down the wrong fix path instead of switching to a hashable archive URL.

Fixes https://github.com/hermetoproject/hermeto/issues/1427