### PR TITLE
pnpm: add support for pnpmv11

### DIFF
--- a/docs/design/pnpm.md
+++ b/docs/design/pnpm.md
@@ -296,10 +296,11 @@ file.
 
 ```yaml
 patchedDependencies:
-  lodash@4.17.23:
-    hash: 5877a18891ec19fc2a2e4eaf39284abc77fe7f8a910708f424aac3434b0813aa
-    path: patches/lodash-4.17.23.patch
+  lodash@4.17.23: 5877a18891ec19fc2a2e4eaf39284abc77fe7f8a910708f424aac3434b0813aa
 ```
+pnpm v11 simplified `patchedDependencies` to a hash mapping.
+Patch file paths are no longer stored in the lockfile;
+they are resolved from `pnpm-workspace.yaml` instead.
 
 CycloneDX specification defines patches for a component as a list of `patch` objects.
 This approach is already used for the yarn berry backend. See [cyclonedx.org/docs](https://cyclonedx.org/docs/1.6/json/#metadata_tools_oneOf_i0_components_items_pedigree_patches).

--- a/hermeto/core/package_managers/javascript/pnpm/project.py
+++ b/hermeto/core/package_managers/javascript/pnpm/project.py
@@ -30,7 +30,20 @@ class PnpmLock(UserDict):
 
         try:
             with path.open() as f:
-                data = yaml.safe_load(f)
+                content = f.read()
+                if content.startswith("---\n") or content.startswith(
+                    "---\r\n"
+                ):  # pnpm v11 lockfile format
+                    documents = list(yaml.safe_load_all(content))
+                    if len(documents) < 2:
+                        raise InvalidLockfileFormat(
+                            path,
+                            err_details="Expected at least two YAML documents in pnpm v11 lockfile format.",
+                            solution="Ensure the pnpm-lock.yaml file is not corrupted.",
+                        )
+                    data = documents[1]
+                else:  # pnpm v10 lockfile format
+                    data = yaml.safe_load(content)
         except yaml.YAMLError as e:
             raise InvalidLockfileFormat(
                 path,


### PR DESCRIPTION
Fixes #1607

## Summary

The pnpm v11 keeps the same lockfileVersion field but introduces several lockfile and behavior changes that affect lockfile parsing.

## Changes

### 1. Handle multi-document lockfile format. 
pnpm v11 prepends a YAML document containing env/config metadata (`packageManager`, config dependencies) to the lockfile, separated by `---`. Both v10 and v11 use `lockfileVersion: '9.0'`, the presence of a leading `---\n` is used to branch, which is consistent with pnpm's own internal parser.

### 2. Update `patchedDependencies` schema in design doc
pnpm v11 [#10911](https://github.com/pnpm/pnpm/pull/10911) flattened `patchedDependencies` from an object with `hash` and
`path` fields to a plain `hash` mapping. Patch file paths no longer live in the lockfile; they are resolved from `pnpm-workspace.yaml`.
