### PR TITLE
feat(sbom): flag experimental backend usage in SBOM output

### DIFF
--- a/hermeto/core/models/output.py
+++ b/hermeto/core/models/output.py
@@ -8,7 +8,14 @@ from typing import Any
 import pydantic
 
 from hermeto.core.errors import BaseError
-from hermeto.core.models.sbom import Annotation, Component, Sbom, merge_component_properties
+from hermeto.core.models.property_semantics import Property, PropertyEnum
+from hermeto.core.models.sbom import (
+    BACKEND_ANNOTATION_PREFIX,
+    Annotation,
+    Component,
+    Sbom,
+    merge_component_properties,
+)
 from hermeto.core.models.validators import unique_sorted
 
 log = logging.getLogger(__name__)
@@ -143,14 +150,34 @@ class RequestOutput(pydantic.BaseModel):
     build_config: BuildConfig
 
     def generate_sbom(self) -> Sbom:
-        """Generate the SBOM for this RequestOutput.
+        """
+        Generate the SBOM for RequestOutput.
 
         Note that RequestOutput may contain duplicated components, we de-duplicate them here
-        while merging their `properties`.
+        while merging their `properties`. If any experimental backends were used, the SBOM
+        metadata and the affected components are tagged with the experimental property.
         """
-        return Sbom(
+        sbom = Sbom(
             annotations=self.annotations, components=merge_component_properties(self.components)
         )
+
+        experimental_annotations = [
+            a
+            for a in self.annotations
+            if a.text.startswith(f"{BACKEND_ANNOTATION_PREFIX}experimental:")
+        ]
+        if not experimental_annotations:
+            return sbom
+
+        experimental = Property(name=PropertyEnum.PROP_EXPERIMENTAL, value="true")
+        sbom.metadata.properties.append(experimental)
+
+        experimental_subjects = {s for a in experimental_annotations for s in a.subjects}
+        for comp in sbom.components:
+            if comp.bom_ref in experimental_subjects:
+                comp.properties.append(experimental)
+
+        return sbom
 
     def __add__(self, other: "RequestOutput") -> "RequestOutput":
         if not isinstance(other, self.__class__):

--- a/hermeto/core/models/property_semantics.py
+++ b/hermeto/core/models/property_semantics.py
@@ -18,6 +18,7 @@ class PropertyEnum(str, Enum):
     PROP_BUNDLER_PACKAGE_BINARY = f"{APP_NAME}:bundler:package:binary"
     PROP_CDX_NPM_PACKAGE_BUNDLED = "cdx:npm:package:bundled"
     PROP_CDX_NPM_PACKAGE_DEVELOPMENT = "cdx:npm:package:development"
+    PROP_EXPERIMENTAL = f"{APP_NAME}:experimental"
     PROP_FOUND_BY = f"{APP_NAME}:found_by"
     PROP_MISSING_HASH_IN_FILE = f"{APP_NAME}:missing_hash:in_file"
     PROP_PIP_PACKAGE_BINARY = f"{APP_NAME}:pip:package:binary"
@@ -41,6 +42,7 @@ class PropertySet:
     """Represents the semantic meaning of the set of Properties of a single Component."""
 
     bundler_package_binary: bool = False
+    experimental: bool = False
     found_by: str | None = None
     missing_hash_in_file: frozenset[str] = field(default_factory=frozenset)
     npm_bundled: bool = False
@@ -54,6 +56,7 @@ class PropertySet:
     def from_properties(cls, props: Iterable[Property]) -> "Self":
         """Convert a list of SBOM component properties to a PropertySet."""
         bundler_package_binary = False
+        experimental = False
         found_by = None
         missing_hash_in_file = []
         npm_bundled = False
@@ -66,6 +69,8 @@ class PropertySet:
         for prop in props:
             if prop.name == PropertyEnum.PROP_BUNDLER_PACKAGE_BINARY:
                 bundler_package_binary = True
+            elif prop.name == PropertyEnum.PROP_EXPERIMENTAL:
+                experimental = True
             elif prop.name == PropertyEnum.PROP_CDX_NPM_PACKAGE_BUNDLED:
                 npm_bundled = True
             elif prop.name == PropertyEnum.PROP_CDX_NPM_PACKAGE_DEVELOPMENT:
@@ -87,6 +92,7 @@ class PropertySet:
 
         return cls(
             bundler_package_binary,
+            experimental,
             found_by,
             frozenset(missing_hash_in_file),
             npm_bundled,
@@ -102,6 +108,8 @@ class PropertySet:
         props = []
         if self.bundler_package_binary:
             props.append(Property(name=PropertyEnum.PROP_BUNDLER_PACKAGE_BINARY, value="true"))
+        if self.experimental:
+            props.append(Property(name=PropertyEnum.PROP_EXPERIMENTAL, value="true"))
         if self.found_by:
             props.append(Property(name=PropertyEnum.PROP_FOUND_BY, value=self.found_by))
         props.extend(
@@ -134,6 +142,7 @@ class PropertySet:
         cls = type(self)
         return cls(
             bundler_package_binary=self.bundler_package_binary or other.bundler_package_binary,
+            experimental=self.experimental or other.experimental,
             found_by=self.found_by or other.found_by,
             missing_hash_in_file=self.missing_hash_in_file | other.missing_hash_in_file,
             npm_bundled=self.npm_bundled and other.npm_bundled,

--- a/hermeto/core/models/sbom.py
+++ b/hermeto/core/models/sbom.py
@@ -227,6 +227,17 @@ class Metadata(pydantic.BaseModel):
     """Metadata field in a SBOM."""
 
     tools: list[Tool] = [Tool(vendor="red hat", name=f"{APP_NAME}")]
+    properties: list[Property] = pydantic.Field(default_factory=list)
+
+    @pydantic.model_serializer(mode="wrap")
+    def serialize_model(self, handler: pydantic.SerializerFunctionWrapHandler) -> dict[str, object]:
+        """
+        Custom serializer that removes the `properties` field if it is empty.
+        """
+        serialized = handler(self)
+        if not self.properties:
+            serialized.pop("properties")
+        return serialized
 
 
 def spdx_now() -> datetime:
@@ -303,6 +314,11 @@ class Sbom(pydantic.BaseModel):
 
     def __add__(self, other: Union["Sbom", "SPDXSbom"]) -> "Sbom":
         if isinstance(other, self.__class__):
+            merged_metadata_props = (
+                PropertySet.from_properties(self.metadata.properties)
+                .merge(PropertySet.from_properties(other.metadata.properties))
+                .to_properties()
+            )
             return Sbom(
                 # NOTE: We might consider deduplicating annotations based on the annotation text
                 # in the future. It is a very rare corner case, though, and it only matters when
@@ -313,6 +329,7 @@ class Sbom(pydantic.BaseModel):
                 components=merge_component_properties(
                     chain.from_iterable(s.components for s in [self, other])
                 ),
+                metadata=Metadata(tools=self.metadata.tools, properties=merged_metadata_props),
             )
         else:
             return self + other.to_cyclonedx()
@@ -338,7 +355,24 @@ class Sbom(pydantic.BaseModel):
         """
 
         def create_document_root() -> SPDXPackage:
-            return SPDXPackage(name="", versionInfo="", SPDXID="SPDXRef-DocumentRoot-File-")
+            # Metadata properties are encoded as annotations on the DocumentRoot
+            # package to enable round-tripping metadata through SPDX format.
+            now = spdx_now()
+            annotations = [
+                SPDXPackageAnnotation(
+                    annotator=f"Tool: {ANNOTATOR_JSON}",
+                    annotationDate=now,
+                    annotationType="OTHER",
+                    comment=json.dumps({"name": prop.name, "value": prop.value}),
+                )
+                for prop in self.metadata.properties
+            ]
+            return SPDXPackage(
+                name="",
+                versionInfo="",
+                SPDXID="SPDXRef-DocumentRoot-File-",
+                annotations=annotations,
+            )
 
         def create_root_relationship() -> SPDXRelation:
             return SPDXRelation(
@@ -836,11 +870,20 @@ class SPDXSbom(pydantic.BaseModel):
 
         tools = convert_creators_to_tools(self.creationInfo.creators)
         annotations = _PerBackendAccumulator.to_annotations(backend_accumulators)
+        properties = []
+        root_package = next((p for p in self.packages if p.SPDXID == self.root_id), None)
+        if root_package:
+            properties = [
+                prop
+                for an in root_package.annotations
+                if an.annotator.endswith(ANNOTATOR_JSON)
+                and isinstance(prop := convert_annotation_to_property(an), Property)
+            ]
 
         return Sbom(
             annotations=annotations,
             components=components,
-            metadata=Metadata(tools=tools),
+            metadata=Metadata(tools=tools, properties=properties),
         )
 
 

--- a/tests/unit/models/test_output.py
+++ b/tests/unit/models/test_output.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-only
+from datetime import datetime, timezone
 from pathlib import Path
 from textwrap import dedent
 from typing import Any
@@ -6,8 +7,11 @@ from typing import Any
 import pydantic
 import pytest
 
+from hermeto import APP_NAME
 from hermeto.core.errors import BaseError
 from hermeto.core.models.output import BuildConfig, EnvironmentVariable, ProjectFile, RequestOutput
+from hermeto.core.models.property_semantics import PropertyEnum
+from hermeto.core.models.sbom import Annotation, Component
 
 
 class TestProjectFile:
@@ -185,3 +189,46 @@ class TestEnvironmentVariable:
         err_msg = f"Detected a cycle in environment variable expansion of '{envs[0].name}'"
         with pytest.raises(BaseError, match=err_msg):
             envs[0].resolve_value(mappings)
+
+
+class TestRequestOutputExperimental:
+    @pytest.mark.parametrize(
+        ("annotation_text_template", "expect_flag"),
+        [
+            ("{app_name}:backend:experimental:x-foo", True),
+            ("{app_name}:backend:pip", False),
+        ],
+    )
+    def test_generate_sbom_experimental_flag(
+        self, annotation_text_template: str, expect_flag: bool
+    ) -> None:
+        comp_experimental = Component(name="exp-pkg", purl="pkg:generic/exp-pkg")
+        comp_normal = Component(name="normal-pkg", purl="pkg:generic/normal-pkg")
+
+        anno = Annotation(
+            subjects={comp_experimental.bom_ref},
+            annotator={"organization": {"name": "red hat"}},
+            timestamp=datetime.now(timezone.utc),
+            text=annotation_text_template.format(app_name=APP_NAME),
+        )
+        ro = RequestOutput(
+            annotations=[anno],
+            components=[comp_experimental, comp_normal],
+            build_config=BuildConfig(),
+        )
+        sbom = ro.generate_sbom()
+        has_flag = any(
+            p.name == PropertyEnum.PROP_EXPERIMENTAL and p.value == "true"
+            for p in sbom.metadata.properties
+        )
+        assert has_flag is expect_flag
+
+        for comp in sbom.components:
+            has_comp_flag = any(
+                p.name == PropertyEnum.PROP_EXPERIMENTAL and p.value == "true"
+                for p in comp.properties
+            )
+            if comp.bom_ref == comp_experimental.bom_ref:
+                assert has_comp_flag is expect_flag
+            else:
+                assert not has_comp_flag


### PR DESCRIPTION
Resolves #614

## Description
Rework on #1422
This PR addresses the remaining requirement from #614  (reopened) to definitively state when experimental features were used during generation, and exactly which components were produced by them.

## Changes

- `property_semantics.py`: add `PROP_EXPERIMENTAL`  to `PropertyEnum` and pass it through `PropertySet` 
- `sbom.py`: add `properties` field to `Metadata`; fix `Sbom.__add__` to merge metadata properties via `PropertySet.merge`; encode metadata properties onto the SPDX DocumentRoot package for sbom conversions.
- `output.py`: update `generate_sbom` to detect experimental backend annotations and tag both `sbom.metadata.properties` and the affected individual components.
- `test_output.py`: add `TestRequestOutputExperimental`, covering experimental and non-experimental annotation text.