### PR TITLE
fix(generate-env): resolve path vars before dependent expansion

### DIFF
--- a/hermeto/core/extras/envfile.py
+++ b/hermeto/core/extras/envfile.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-3.0-only
 import json
 import shlex
+from copy import deepcopy
 from enum import Enum
 from pathlib import Path
 
@@ -54,13 +55,7 @@ def generate_envfile(build_config: BuildConfig, fmt: EnvFormat, relative_to_path
     - env: export GOCACHE=/path/to/output-dir/deps/gomod
            export ...
     """
-    # pass all variables as placeholder mappings to env var template value resolution
-    mappings = {var.name: var.value for var in build_config.environment_variables}
-    mappings["output_dir"] = relative_to_path.as_posix()
-    env_vars = [
-        (env_var.name, env_var.resolve_value(mappings))
-        for env_var in build_config.environment_variables
-    ]
+    env_vars = _resolve_env_vars(build_config, relative_to_path)
     if fmt == EnvFormat.json:
         content = json.dumps([{"name": name, "value": value} for name, value in env_vars])
     else:
@@ -68,3 +63,22 @@ def generate_envfile(build_config: BuildConfig, fmt: EnvFormat, relative_to_path
             f"export {shlex.quote(name)}={shlex.quote(value)}" for name, value in env_vars
         )
     return content
+
+
+def _resolve_env_vars(build_config: BuildConfig, relative_to_path: Path) -> list[tuple[str, str]]:
+    """Resolve the environment variables for the given build config and path."""
+    # pass all variables as placeholder mappings to env var template value resolution
+    mappings = {var.name: var.value for var in build_config.environment_variables}
+    mappings["output_dir"] = relative_to_path.as_posix()
+
+    # Legacy kind="path" variables must be resolved into mappings before dependents
+    # (e.g. GOPROXY's file://${GOMODCACHE}/...) are expanded; otherwise substitution
+    # uses the unresolved relative path from the initial mappings dict.
+    for env_var in build_config.environment_variables:
+        if env_var.kind == "path":
+            mappings[env_var.name] = deepcopy(env_var).resolve_value(mappings)
+
+    return [
+        (env_var.name, env_var.resolve_value(mappings))
+        for env_var in build_config.environment_variables
+    ]

--- a/tests/unit/extras/test_envfile.py
+++ b/tests/unit/extras/test_envfile.py
@@ -6,7 +6,7 @@ import pytest
 
 from hermeto import APP_NAME
 from hermeto.core.errors import UnsupportedFeature
-from hermeto.core.extras.envfile import EnvFormat, generate_envfile
+from hermeto.core.extras.envfile import EnvFormat, _resolve_env_vars, generate_envfile
 from hermeto.core.models.output import BuildConfig
 
 
@@ -78,3 +78,17 @@ def test_generate_env_as_env() -> None:
 
     content = generate_envfile(build_config, EnvFormat.env, relative_to_path=Path("/output/dir"))
     assert content == expect_content
+
+
+def test_resolve_env_vars_dependent_path_var() -> None:
+    build_config = BuildConfig(
+        environment_variables=[
+            {"name": "GOMODCACHE", "value": "deps/gomod/pkg/mod", "kind": "path"},
+            {"name": "GOPROXY", "value": "file://${GOMODCACHE}/cache/download"},
+        ],
+        project_files=[],
+    )
+    assert _resolve_env_vars(build_config, Path("/tmp/output")) == [
+        ("GOMODCACHE", "/tmp/output/deps/gomod/pkg/mod"),
+        ("GOPROXY", "file:///tmp/output/deps/gomod/pkg/mod/cache/download"),
+    ]


### PR DESCRIPTION
Dependent variables like GOPROXY referenced stale relative paths when kind="path" targets were expanded after mappings were built, producing invalid file:// URLs at build time.

Pre-resolve legacy path variables into the substitution mappings before expanding dependents.

Fixes https://github.com/hermetoproject/hermeto/issues/1424