### PR TITLE
Revert PR 1612 & drop legacy 'kind=literal|path' field handling

### DIFF
--- a/hermeto/core/extras/envfile.py
+++ b/hermeto/core/extras/envfile.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: GPL-3.0-only
 import json
 import shlex
-from copy import deepcopy
 from enum import Enum
 from pathlib import Path
 
@@ -55,7 +54,13 @@ def generate_envfile(build_config: BuildConfig, fmt: EnvFormat, relative_to_path
     - env: export GOCACHE=/path/to/output-dir/deps/gomod
            export ...
     """
-    env_vars = _resolve_env_vars(build_config, relative_to_path)
+    # pass all variables as placeholder mappings to env var template value resolution
+    mappings = {var.name: var.value for var in build_config.environment_variables}
+    mappings["output_dir"] = relative_to_path.as_posix()
+    env_vars = [
+        (env_var.name, env_var.resolve_value(mappings))
+        for env_var in build_config.environment_variables
+    ]
     if fmt == EnvFormat.json:
         content = json.dumps([{"name": name, "value": value} for name, value in env_vars])
     else:
@@ -63,22 +68,3 @@ def generate_envfile(build_config: BuildConfig, fmt: EnvFormat, relative_to_path
             f"export {shlex.quote(name)}={shlex.quote(value)}" for name, value in env_vars
         )
     return content
-
-
-def _resolve_env_vars(build_config: BuildConfig, relative_to_path: Path) -> list[tuple[str, str]]:
-    """Resolve the environment variables for the given build config and path."""
-    # pass all variables as placeholder mappings to env var template value resolution
-    mappings = {var.name: var.value for var in build_config.environment_variables}
-    mappings["output_dir"] = relative_to_path.as_posix()
-
-    # Legacy kind="path" variables must be resolved into mappings before dependents
-    # (e.g. GOPROXY's file://${GOMODCACHE}/...) are expanded; otherwise substitution
-    # uses the unresolved relative path from the initial mappings dict.
-    for env_var in build_config.environment_variables:
-        if env_var.kind == "path":
-            mappings[env_var.name] = deepcopy(env_var).resolve_value(mappings)
-
-    return [
-        (env_var.name, env_var.resolve_value(mappings))
-        for env_var in build_config.environment_variables
-    ]

--- a/hermeto/core/models/output.py
+++ b/hermeto/core/models/output.py
@@ -3,7 +3,7 @@ import logging
 import string
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any
 
 import pydantic
 
@@ -22,19 +22,10 @@ class EnvironmentVariable(pydantic.BaseModel):
     variable to the output.
     Templating as the base solution for this representation is useful in cases where the exact
     value of a given environment variable can't be determined at the time of instantiation.
-
-    Note that legacy implementation of this model differentiated between 2 kinds of variables:
-    'path' & 'literal' with the following behaviour:
-        - for "literal" variables, the resolved value is simply the value it was created with
-        - for "path" variables, the value is joined to the specified path.
-
-    The new implementation is backwards compatible with the legacy handling in terms of input
-    parsing, but the produced output is not.
     """
 
     name: str
     value: str
-    kind: Literal["literal", "path"] | None = pydantic.Field(default=None, exclude=True)
 
     def resolve_value(self, mappings: dict[str, str]) -> str:
         """Return the resolved value of this templated environment variable.
@@ -43,7 +34,7 @@ class EnvironmentVariable(pydantic.BaseModel):
 
         The environment variable value will be converted to a string template which will then
         substitute all placeholders defined; if no placeholders are contained within the value
-        string, substitution is a NOOP (e.g. legacy "literal" variables)
+        string, substitution is a NOOP
         """
 
         def get_placeholders(t: string.Template) -> set[str]:
@@ -63,11 +54,6 @@ class EnvironmentVariable(pydantic.BaseModel):
                     placeholders.add(placeholder)
 
             return placeholders
-
-        # legacy path variable handling, need to prepend the base path placeholder
-        if self.kind == "path" and "output_dir" in mappings:
-            log.debug(f"Adjusting a legacy path variable value '{self.name}={self.value}'")
-            self.value = "${output_dir}/" + self.value
 
         # "Recursively" resolve potentially nested variables up to len(mappings) tries
         log.debug(f"Resolving environment variable '{self.name}={self.value}'")

--- a/tests/unit/extras/test_envfile.py
+++ b/tests/unit/extras/test_envfile.py
@@ -47,8 +47,8 @@ def test_cannot_determine_format(filename: str, expect_reason: str) -> None:
 
 def test_generate_env_as_json() -> None:
     env_vars = [
-        {"name": "GOCACHE", "value": "deps/gomod", "kind": "path"},
-        {"name": "GOSUMDB", "value": "off", "kind": "literal"},
+        {"name": "GOCACHE", "value": "${output_dir}/deps/gomod"},
+        {"name": "GOSUMDB", "value": "off"},
     ]
     build_config = BuildConfig(environment_variables=env_vars, project_files=[])
 
@@ -62,9 +62,9 @@ def test_generate_env_as_json() -> None:
 
 def test_generate_env_as_env() -> None:
     env_vars = [
-        {"name": "GOCACHE", "value": "deps/gomod", "kind": "path"},
-        {"name": "GOSUMDB", "value": "off", "kind": "literal"},
-        {"name": "SNEAKY", "value": "foo; echo hello there", "kind": "literal"},
+        {"name": "GOCACHE", "value": "${output_dir}/deps/gomod"},
+        {"name": "GOSUMDB", "value": "off"},
+        {"name": "SNEAKY", "value": "foo; echo hello there"},
     ]
     build_config = BuildConfig(environment_variables=env_vars, project_files=[])
 

--- a/tests/unit/extras/test_envfile.py
+++ b/tests/unit/extras/test_envfile.py
@@ -6,7 +6,7 @@ import pytest
 
 from hermeto import APP_NAME
 from hermeto.core.errors import UnsupportedFeature
-from hermeto.core.extras.envfile import EnvFormat, _resolve_env_vars, generate_envfile
+from hermeto.core.extras.envfile import EnvFormat, generate_envfile
 from hermeto.core.models.output import BuildConfig
 
 
@@ -78,17 +78,3 @@ def test_generate_env_as_env() -> None:
 
     content = generate_envfile(build_config, EnvFormat.env, relative_to_path=Path("/output/dir"))
     assert content == expect_content
-
-
-def test_resolve_env_vars_dependent_path_var() -> None:
-    build_config = BuildConfig(
-        environment_variables=[
-            {"name": "GOMODCACHE", "value": "deps/gomod/pkg/mod", "kind": "path"},
-            {"name": "GOPROXY", "value": "file://${GOMODCACHE}/cache/download"},
-        ],
-        project_files=[],
-    )
-    assert _resolve_env_vars(build_config, Path("/tmp/output")) == [
-        ("GOMODCACHE", "/tmp/output/deps/gomod/pkg/mod"),
-        ("GOPROXY", "file:///tmp/output/deps/gomod/pkg/mod/cache/download"),
-    ]

--- a/tests/unit/extras/test_envfile.py
+++ b/tests/unit/extras/test_envfile.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-only
+import json
 from pathlib import Path
 from textwrap import dedent
 
@@ -78,3 +79,23 @@ def test_generate_env_as_env() -> None:
 
     content = generate_envfile(build_config, EnvFormat.env, relative_to_path=Path("/output/dir"))
     assert content == expect_content
+
+
+def test_generate_env_dependent_var() -> None:
+    build_config = BuildConfig(
+        environment_variables=[
+            {"name": "GOMODCACHE", "value": "${output_dir}/deps/gomod/pkg/mod"},
+            {"name": "GOPROXY", "value": "file://${GOMODCACHE}/cache/download"},
+        ],
+        project_files=[],
+    )
+
+    content = generate_envfile(build_config, EnvFormat.json, relative_to_path=Path("/tmp/output"))
+
+    expected = json.dumps(
+        [
+            {"name": "GOMODCACHE", "value": "/tmp/output/deps/gomod/pkg/mod"},
+            {"name": "GOPROXY", "value": "file:///tmp/output/deps/gomod/pkg/mod/cache/download"},
+        ]
+    )
+    assert content == expected

--- a/tests/unit/models/test_output.py
+++ b/tests/unit/models/test_output.py
@@ -37,9 +37,7 @@ class TestProjectFile:
 class TestBuildConfig:
     def test_conflicting_env_vars(self) -> None:
         expect_error = (
-            "conflict by GOSUMDB: "
-            "name='GOSUMDB' value='on' kind=None "
-            "X name='GOSUMDB' value='sum.golang.org' kind=None"
+            "conflict by GOSUMDB: name='GOSUMDB' value='on' X name='GOSUMDB' value='sum.golang.org'"
         )
         with pytest.raises(pydantic.ValidationError, match=expect_error):
             BuildConfig(
@@ -130,8 +128,6 @@ ENVVAR_TEMPLATE_MAPPINGS = {
     "BAR": "and",
     "BARR": "the_${BAZ}",
     "FOO": "python_${BAR}_${BARR}",
-    "LEGACY_LITERAL": "foobar",
-    "LEGACY_PATH": "relative/path",
     "SIMPLE": "${deadbeef}",
 }
 
@@ -139,28 +135,13 @@ ENVVAR_TEMPLATE_MAPPINGS = {
 class TestEnvironmentVariable:
     @pytest.fixture(scope="class")
     def env_variables(self) -> dict[str, EnvironmentVariable]:
-        ret = {k: EnvironmentVariable(name=k, value=v) for k, v in ENVVAR_TEMPLATE_MAPPINGS.items()}
-
-        # need to inject 'kind' for legacy variable templates
-        ret["LEGACY_LITERAL"].kind = "literal"
-        ret["LEGACY_PATH"].kind = "path"
-        return ret
+        return {
+            k: EnvironmentVariable(name=k, value=v) for k, v in ENVVAR_TEMPLATE_MAPPINGS.items()
+        }
 
     @pytest.mark.parametrize(
         "var, expected, mappings",
         [
-            pytest.param(
-                "LEGACY_LITERAL",
-                "foobar",
-                {"output_dir": "/absolute/path"},
-                id="compatibility_test_legacy_literal",
-            ),
-            pytest.param(
-                "LEGACY_PATH",
-                "/absolute/path/relative/path",
-                {"output_dir": "/absolute/path"},
-                id="compatibility_test_legacy_path",
-            ),
             pytest.param(
                 "SIMPLE", "badf00d", {"deadbeef": "badf00d"}, id="simple_template_variable"
             ),
@@ -180,7 +161,6 @@ class TestEnvironmentVariable:
         mappings: dict[str, str],
     ) -> None:
         assert env_variables[var].resolve_value(mappings) == expected
-        assert "kind" not in env_variables[var].model_dump()
 
     @pytest.mark.parametrize(
         "envs",

--- a/tests/unit/test_resolver.py
+++ b/tests/unit/test_resolver.py
@@ -20,7 +20,7 @@ GOMOD_OUTPUT = RequestOutput.from_obj_list(
         )
     ],
     environment_variables=[
-        EnvironmentVariable(name="GOMODCACHE", value="deps/gomod/pkg/mod", kind="path"),
+        EnvironmentVariable(name="GOMODCACHE", value="${output_dir}/deps/gomod/pkg/mod"),
     ],
     project_files=[
         ProjectFile(abspath="/your/project/go.mod", template="Hello gomod my old friend.")
@@ -32,7 +32,7 @@ PIP_OUTPUT = RequestOutput.from_obj_list(
         Component(type="library", name="spam", version="1.0.0", purl="pkg:pypi/spam@1.0.0")
     ],
     environment_variables=[
-        EnvironmentVariable(name="PIP_INDEX_URL", value="file:///some/path", kind="literal"),
+        EnvironmentVariable(name="PIP_INDEX_URL", value="file:///some/path"),
     ],
     project_files=[
         ProjectFile(
@@ -44,7 +44,7 @@ PIP_OUTPUT = RequestOutput.from_obj_list(
 NPM_OUTPUT = RequestOutput.from_obj_list(
     components=[Component(type="library", name="eggs", version="1.0.0", purl="pkg:npm/eggs@1.0.0")],
     environment_variables=[
-        EnvironmentVariable(name="CHROMEDRIVER_SKIP_DOWNLOAD", value="true", kind="literal"),
+        EnvironmentVariable(name="CHROMEDRIVER_SKIP_DOWNLOAD", value="true"),
     ],
     project_files=[
         ProjectFile(


### PR DESCRIPTION
Quite unsurprisingly, issue https://github.com/hermetoproject/hermeto/issues/1424 was entirely an agentic fabulation that looked correct on paper, could manually exercise a valid code path and yield the reported incorrect results except that the code path was no longer exercised in our current production code. That fact was revealed upon a deeper code inspection that led me to commit fd609346 which migrated our whole code base to a more robust solution in 2024.
That commit itself was quite conservative in that it introduced a legacy compatibility path for some reason which then the AI agent used in #1424 and hallucinated on top of it. 

Since build config YAML isn't public API and it's fully generated by us, we can now safely remove that legacy code path after 2 years as I don't expect any old build-configs to be lurking anywhere. Even if that were the case, removing the file -> rerun hermeto is the supposed operation in that case.

Closes https://github.com/hermetoproject/hermeto/issues/1424