### PR TITLE
pnpm: build an offline store instead of rewriting lockfile resolutions

### DIFF
--- a/hermeto/core/package_managers/javascript/pnpm/main.py
+++ b/hermeto/core/package_managers/javascript/pnpm/main.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
 import asyncio
+import base64
 import copy
+import hashlib
+import json
+import tarfile
 from pathlib import Path
 
 import aiohttp
@@ -9,7 +13,13 @@ import yaml
 from hermeto.core.checksum import ChecksumInfo, must_match_any_checksum
 from hermeto.core.config import get_config
 from hermeto.core.models.input import Request
-from hermeto.core.models.output import Annotation, Component, ProjectFile, RequestOutput
+from hermeto.core.models.output import (
+    Annotation,
+    Component,
+    EnvironmentVariable,
+    ProjectFile,
+    RequestOutput,
+)
 from hermeto.core.models.sbom import create_backend_annotation
 from hermeto.core.package_managers.javascript.npm import (
     NPM_REGISTRY_URL,
@@ -23,6 +33,11 @@ from hermeto.core.package_managers.javascript.pnpm.project import (
 )
 from hermeto.core.package_managers.javascript.pnpm.resolver import generate_sbom_components
 
+# pnpm keys each package's store index file by the first 32 bytes (64 hex chars) of
+# the SHA-512 digest carried in the package integrity SRI: the first 2 hex chars name
+# the subdirectory, the remaining 62 form the filename prefix.
+_PNPM_STORE_INDEX_HEX_LEN = 64
+
 
 def fetch_pnpm_source(request: Request) -> RequestOutput:
     """Process all pnpm source directories in the given request."""
@@ -33,10 +48,16 @@ def fetch_pnpm_source(request: Request) -> RequestOutput:
     deps_dir = request.output_dir.path.joinpath("deps", "pnpm")
     deps_dir.mkdir(parents=True, exist_ok=True)
 
+    # A content-addressable store lets pnpm resolve packages offline by their integrity
+    # hash, so the lockfile keeps its registry-style resolutions untouched. pnpm
+    # >=10.34.2 rejects a registry dependency whose resolution was rewritten to a local
+    # "tarball: file://" (ERR_PNPM_RESOLUTION_SHAPE_MISMATCH); the store sidesteps that.
+    store_dir = request.output_dir.path.joinpath("pnpm-store")
+
     for package in request.pnpm_packages:
         project_dir = request.source_dir.join_within_root(package.path)
         lockfile = PnpmLock.from_dir(project_dir.path)
-        packages, updated_lockfile = _resolve_pnpm_project(deps_dir, lockfile)
+        packages, updated_lockfile = _resolve_pnpm_project(deps_dir, store_dir, lockfile)
         project_files.append(updated_lockfile)
         components.extend(generate_sbom_components(project_dir, packages, lockfile))
 
@@ -46,18 +67,44 @@ def fetch_pnpm_source(request: Request) -> RequestOutput:
     return RequestOutput.from_obj_list(
         components=components,
         project_files=project_files,
+        environment_variables=[
+            # pnpm reads the store location from the npm-style NPM_CONFIG_STORE_DIR;
+            # with "pnpm install --offline" it then resolves from the store with no
+            # network access and no lockfile edits.
+            EnvironmentVariable(name="NPM_CONFIG_STORE_DIR", value="${output_dir}/pnpm-store"),
+        ],
         annotations=annotations,
     )
 
 
 def _resolve_pnpm_project(
-    deps_dir: Path, lockfile: PnpmLock
+    deps_dir: Path, store_dir: Path, lockfile: PnpmLock
 ) -> tuple[list[PnpmPackage], ProjectFile]:
     """Resolve a pnpm project."""
     packages = parse_packages(lockfile)
     non_local = [p for p in packages if not p.url.startswith("file:")]
     _download_resolved_packages(non_local, deps_dir)
-    return packages, _prepare_lockfile_for_hermetic_build(lockfile, non_local)
+
+    # pnpm >=10.34.2 rejects only a *registry-shaped* lockfile key (name@<semver>) whose
+    # resolution was rewritten to a local "tarball: file://"
+    # (ERR_PNPM_RESOLUTION_SHAPE_MISMATCH), so those are served from the content-addressable
+    # store with their resolution left untouched. Non-registry keys (git/URL deps) are exempt
+    # from that check and have no integrity-addressed store slot to populate, so they keep the
+    # file:// resolution rewrite that has always worked for them.
+    store_packages = [p for p in non_local if p.registry_shaped]
+    rewritten_packages = [p for p in non_local if not p.registry_shaped]
+
+    for package in store_packages:
+        if package.integrity is not None:
+            _add_tarball_to_pnpm_store(
+                tarball_path=deps_dir / package.tarball_filename,
+                store_dir=store_dir,
+                name=package.name,
+                scope=package.scope,
+                version=package.version,
+                pkg_integrity=package.integrity,
+            )
+    return packages, _prepare_lockfile_for_hermetic_build(lockfile, rewritten_packages)
 
 
 def _download_resolved_packages(packages: list[PnpmPackage], deps_dir: Path) -> None:
@@ -100,9 +147,159 @@ def _download_resolved_packages(packages: list[PnpmPackage], deps_dir: Path) -> 
             )
 
 
+def _sri_to_pnpm_store_key(sri: str) -> tuple[str, str]:
+    """Convert a SHA-512 integrity SRI to the (subdir, filename-prefix) of its store index file.
+
+    >>> _sri_to_pnpm_store_key("sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZR/iIBfbufAb6wWgzA==")
+    ('bf', '690311ee7b95e713ba568322e3533f2dd1cb880b189e99d4edef13592b8176')
+    """
+    raw = base64.b64decode(sri.removeprefix("sha512-"))
+    hex_val = raw.hex()
+    return hex_val[0:2], hex_val[2:_PNPM_STORE_INDEX_HEX_LEN]
+
+
+def _sha512_hexdigest(path: Path) -> str:
+    """Return the hex SHA-512 digest of a file, read in chunks to bound memory."""
+    hasher = hashlib.sha512()
+    with path.open("rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _add_tarball_to_pnpm_store(
+    tarball_path: Path,
+    store_dir: Path,
+    name: str,
+    scope: str,
+    version: str,
+    pkg_integrity: str,
+) -> None:
+    """Unpack a downloaded npm tarball into pnpm's content-addressable store ("v10").
+
+    The store lets ``pnpm install --offline`` materialise the package from its integrity
+    hash without any ``tarball`` URL in the lockfile. The on-disk layout mirrors what
+    pnpm itself writes, since pnpm hardlinks the stored files into ``node_modules`` and
+    reads its own index, so any deviation makes pnpm treat the package as missing:
+
+    - ``files/<sha512_hex[0:2]>/<sha512_hex[2:]>`` holds each file's raw content;
+      executable files (any ``x`` mode bit) get a ``-exec`` suffix and are stored as
+      ``0o750`` so the hardlinked copy stays executable, the rest as ``0o640`` -- pnpm
+      does not re-apply the index ``mode`` to the hardlink, so the stored file's mode
+      is what the installed file gets.
+    - ``index/<int_hex[0:2]>/<int_hex[2:64]>-<pkg>@<ver>.json`` holds per-package
+      metadata keyed by the package integrity. ``requiresBuild`` must reflect whether
+      the package has an install script or a node-gyp config, otherwise pnpm skips the
+      build of allow-listed native dependencies.
+    """
+    files_dir = store_dir / "v10" / "files"
+    index_dir = store_dir / "v10" / "index"
+
+    files_index: dict[str, dict[str, object]] = {}
+    # pnpm records when it last verified each file; a fixed value keeps the prefetch output
+    # reproducible (pnpm re-verifies against the stored integrity on install regardless).
+    checked_at = 0
+    requires_build = False
+    package_manifest: dict[str, object] = {}
+
+    with tarfile.open(tarball_path, "r:gz") as tf:
+        for member in tf.getmembers():
+            # npm publishes regular files only; directories, and the symlinks/hardlinks a
+            # tarball may contain, are skipped -- pnpm's store holds only file content keyed
+            # by hash, with no slot to materialise a link.
+            if not member.isfile():
+                continue
+
+            # npm tarballs wrap everything in a top-level "package/" directory.
+            rel_path = member.name
+            if rel_path.startswith("package/"):
+                rel_path = rel_path[len("package/") :]
+
+            if rel_path.endswith(".gyp"):
+                requires_build = True
+
+            file_obj = tf.extractfile(member)
+            if file_obj is None:
+                continue
+            data = file_obj.read()
+
+            if rel_path == "package.json":
+                try:
+                    parsed_manifest = json.loads(data)
+                except (ValueError, UnicodeDecodeError):
+                    parsed_manifest = None
+                # A malformed or non-object package.json must not abort the prefetch;
+                # only a JSON object can carry the "scripts" read further down.
+                if isinstance(parsed_manifest, dict):
+                    package_manifest = parsed_manifest
+
+            file_digest = hashlib.sha512(data).digest()
+            file_hex = file_digest.hex()
+            file_sri = "sha512-" + base64.b64encode(file_digest).decode()
+
+            is_exec = bool(member.mode & 0o111)
+            cas_path = files_dir / file_hex[0:2] / (file_hex[2:] + ("-exec" if is_exec else ""))
+            cas_path.parent.mkdir(parents=True, exist_ok=True)
+            if not cas_path.exists():
+                # Write to a temp file and atomically rename it in, so an interrupted
+                # prefetch never leaves a truncated file that a later run would trust
+                # (the existence check above skips rewriting).
+                tmp_path = cas_path.with_name(cas_path.name + ".tmp")
+                tmp_path.write_bytes(data)
+                tmp_path.chmod(0o750 if is_exec else 0o640)
+                tmp_path.replace(cas_path)
+
+            files_index[rel_path] = {
+                "checkedAt": checked_at,
+                "integrity": file_sri,
+                "mode": member.mode & 0o7777,
+                "size": len(data),
+            }
+
+    if scope:
+        full_name = f"@{scope}/{name}"
+        pkg_index_suffix = f"@{scope}+{name}@{version}.json"
+    else:
+        full_name = name
+        pkg_index_suffix = f"{name}@{version}.json"
+
+    # pnpm addresses the store index by the SHA-512 of the tarball. A registry tarball's
+    # SHA-512 integrity SRI already is that digest, so reuse it; otherwise (e.g. a legacy
+    # sha1 integrity) hash the tarball, since the store is SHA-512-addressed regardless.
+    if pkg_integrity.startswith("sha512-"):
+        prefix, hex_key = _sri_to_pnpm_store_key(pkg_integrity)
+    else:
+        tarball_hex = _sha512_hexdigest(tarball_path)
+        prefix, hex_key = tarball_hex[0:2], tarball_hex[2:_PNPM_STORE_INDEX_HEX_LEN]
+    index_path = index_dir / prefix / f"{hex_key}-{pkg_index_suffix}"
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+
+    scripts = package_manifest.get("scripts") or {}
+    if isinstance(scripts, dict) and any(
+        scripts.get(hook) for hook in ("preinstall", "install", "postinstall")
+    ):
+        requires_build = True
+
+    index_data = {
+        "name": full_name,
+        "version": version,
+        "requiresBuild": requires_build,
+        "files": files_index,
+    }
+    index_path.write_text(json.dumps(index_data, separators=(",", ":")))
+
+
 def _prepare_lockfile_for_hermetic_build(
     lockfile: PnpmLock, packages: list[PnpmPackage]
 ) -> ProjectFile:
+    """Point the given packages' resolutions at their downloaded tarballs.
+
+    Registry dependencies resolve offline from the pre-populated pnpm store (see
+    ``_add_tarball_to_pnpm_store``) and are not passed here, so their resolutions stay
+    registry-style -- pnpm >=10.34.2 rejects a registry-style key paired with a local
+    ``tarball: file://`` resolution. Only non-registry dependencies (git/URL), which pnpm
+    exempts from that check and cannot serve from the store, get the ``file://`` rewrite.
+    """
     lockfile_copy = copy.deepcopy(lockfile)
 
     for package in packages:

--- a/hermeto/core/package_managers/javascript/pnpm/project.py
+++ b/hermeto/core/package_managers/javascript/pnpm/project.py
@@ -96,6 +96,16 @@ class PnpmPackage:
 
         return f"{self.name}-{self.version}.tgz"
 
+    @property
+    def registry_shaped(self) -> bool:
+        """Return whether the lockfile key is registry-shaped (``name@<semver>``).
+
+        pnpm enforces a registry-style ``resolution`` -- and so rejects a local
+        ``tarball: file://`` rewrite as a shape mismatch -- only for keys whose version
+        component is a semver. Keys carrying a URL (git or remote-tarball deps) are exempt.
+        """
+        return Version.is_valid(_parse_pnpm_package(self.id).version)
+
 
 def _ensure_lockfile_version_is_supported(lockfile: PnpmLock) -> None:
     """Ensure Hermeto supports the lockfile version in the pnpm-lock.yaml file."""

--- a/tests/unit/package_managers/javascript/pnpm/test_main.py
+++ b/tests/unit/package_managers/javascript/pnpm/test_main.py
@@ -1,4 +1,10 @@
 # SPDX-License-Identifier: GPL-3.0-only
+import base64
+import hashlib
+import io
+import json
+import stat
+import tarfile
 from pathlib import Path
 from unittest import mock
 
@@ -8,9 +14,11 @@ import yaml
 from hermeto.core.checksum import ChecksumInfo
 from hermeto.core.package_managers.javascript.npm import NPM_REGISTRY_URL
 from hermeto.core.package_managers.javascript.pnpm.main import (
+    _add_tarball_to_pnpm_store,
     _download_resolved_packages,
     _prepare_lockfile_for_hermetic_build,
     _resolve_pnpm_project,
+    _sri_to_pnpm_store_key,
 )
 from hermeto.core.package_managers.javascript.pnpm.project import PnpmLock, PnpmPackage
 from tests.unit.test_checksum import SHA512_SRI
@@ -18,24 +26,126 @@ from tests.unit.test_checksum import SHA512_SRI
 FAKE_PROXY_URL = "http://proxy.com/npm/registry"
 
 
+def _make_npm_tarball(path: Path, members: list[tuple[str, bytes, int]]) -> None:
+    """Write a minimal npm-style ``.tgz`` (every entry under a top-level ``package/``)."""
+    with tarfile.open(path, "w:gz") as tf:
+        for name, data, mode in members:
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            info.mode = mode
+            tf.addfile(info, io.BytesIO(data))
+
+
 @mock.patch(
     "hermeto.core.package_managers.javascript.pnpm.main._prepare_lockfile_for_hermetic_build"
 )
+@mock.patch("hermeto.core.package_managers.javascript.pnpm.main._add_tarball_to_pnpm_store")
 @mock.patch("hermeto.core.package_managers.javascript.pnpm.main._download_resolved_packages")
 @mock.patch("hermeto.core.package_managers.javascript.pnpm.main.parse_packages")
 def test_resolve_pnpm_project_skips_local_packages(
     mock_parse_packages: mock.Mock,
     mock_download_resolved_packages: mock.Mock,
+    mock_add_tarball_to_pnpm_store: mock.Mock,
     mock_prepare_lockfile_for_hermetic_build: mock.Mock,
     tmp_path: Path,
 ) -> None:
+    deps_dir = tmp_path / "deps"
+    store_dir = tmp_path / "store"
     remote = PnpmPackage("a@1.0.0", "", "a", "1.0.0", f"{NPM_REGISTRY_URL}/a/-/a-1.0.0.tgz")
     local = PnpmPackage("b@1.0.0", "", "b", "1.0.0", "file:packages/b.tgz")
     mock_parse_packages.return_value = [remote, local]
+    lockfile = mock.Mock()
 
-    _resolve_pnpm_project(tmp_path, mock.Mock())
-    mock_download_resolved_packages.assert_called_once_with([remote], tmp_path)
-    mock_prepare_lockfile_for_hermetic_build.assert_called_once_with(mock.ANY, [remote])
+    _resolve_pnpm_project(deps_dir, store_dir, lockfile)
+
+    mock_download_resolved_packages.assert_called_once_with([remote], deps_dir)
+    # The local "file:" package is never downloaded nor added to the store; the remote
+    # one carries no integrity in this fixture, so it is not added to the store either.
+    mock_add_tarball_to_pnpm_store.assert_not_called()
+    # The remote package is registry-shaped, so it is served from the store rather than
+    # rewritten: nothing is left for the file:// rewrite.
+    mock_prepare_lockfile_for_hermetic_build.assert_called_once_with(lockfile, [])
+
+
+@mock.patch(
+    "hermeto.core.package_managers.javascript.pnpm.main._prepare_lockfile_for_hermetic_build"
+)
+@mock.patch("hermeto.core.package_managers.javascript.pnpm.main._add_tarball_to_pnpm_store")
+@mock.patch("hermeto.core.package_managers.javascript.pnpm.main._download_resolved_packages")
+@mock.patch("hermeto.core.package_managers.javascript.pnpm.main.parse_packages")
+def test_resolve_pnpm_project_adds_remote_packages_to_store(
+    mock_parse_packages: mock.Mock,
+    mock_download_resolved_packages: mock.Mock,
+    mock_add_tarball_to_pnpm_store: mock.Mock,
+    mock_prepare_lockfile_for_hermetic_build: mock.Mock,
+    tmp_path: Path,
+) -> None:
+    deps_dir = tmp_path / "deps"
+    store_dir = tmp_path / "store"
+    remote = PnpmPackage(
+        "a@1.0.0", "", "a", "1.0.0", f"{NPM_REGISTRY_URL}/a/-/a-1.0.0.tgz", SHA512_SRI
+    )
+    mock_parse_packages.return_value = [remote]
+
+    _resolve_pnpm_project(deps_dir, store_dir, mock.Mock())
+
+    # A registry package with an integrity is unpacked into the offline store keyed by
+    # that integrity, so "pnpm install --offline" can resolve it without a tarball URL.
+    mock_add_tarball_to_pnpm_store.assert_called_once_with(
+        tarball_path=deps_dir / remote.tarball_filename,
+        store_dir=store_dir,
+        name="a",
+        scope="",
+        version="1.0.0",
+        pkg_integrity=SHA512_SRI,
+    )
+
+
+@mock.patch(
+    "hermeto.core.package_managers.javascript.pnpm.main._prepare_lockfile_for_hermetic_build"
+)
+@mock.patch("hermeto.core.package_managers.javascript.pnpm.main._add_tarball_to_pnpm_store")
+@mock.patch("hermeto.core.package_managers.javascript.pnpm.main._download_resolved_packages")
+@mock.patch("hermeto.core.package_managers.javascript.pnpm.main.parse_packages")
+def test_resolve_pnpm_project_rewrites_non_registry_packages(
+    mock_parse_packages: mock.Mock,
+    mock_download_resolved_packages: mock.Mock,
+    mock_add_tarball_to_pnpm_store: mock.Mock,
+    mock_prepare_lockfile_for_hermetic_build: mock.Mock,
+    tmp_path: Path,
+) -> None:
+    deps_dir = tmp_path / "deps"
+    store_dir = tmp_path / "store"
+    registry = PnpmPackage(
+        "a@1.0.0", "", "a", "1.0.0", f"{NPM_REGISTRY_URL}/a/-/a-1.0.0.tgz", SHA512_SRI
+    )
+    # A git/URL dependency: its lockfile key carries a URL, so pnpm treats it as
+    # non-registry-shaped and it has no integrity field.
+    git = PnpmPackage(
+        "repo@https://codeload.github.com/org/repo/tar.gz/abc123",
+        "",
+        "repo",
+        "1.0.0",
+        "https://codeload.github.com/org/repo/tar.gz/abc123",
+    )
+    mock_parse_packages.return_value = [registry, git]
+    lockfile = mock.Mock()
+
+    _resolve_pnpm_project(deps_dir, store_dir, lockfile)
+
+    # Only the registry package goes to the integrity-addressed store; the git/URL package
+    # cannot be served from it and must not be added.
+    mock_add_tarball_to_pnpm_store.assert_called_once_with(
+        tarball_path=deps_dir / registry.tarball_filename,
+        store_dir=store_dir,
+        name="a",
+        scope="",
+        version="1.0.0",
+        pkg_integrity=SHA512_SRI,
+    )
+    # The git/URL package keeps a file:// resolution rewrite (pnpm accepts that for
+    # non-registry keys); the registry package, served from the store, is not rewritten.
+    mock_prepare_lockfile_for_hermetic_build.assert_called_once_with(lockfile, [git])
 
 
 def _mock_pnpm_config(url: str | None, login: str | None, password: str | None) -> mock.Mock:
@@ -127,58 +237,211 @@ def test_download_resolved_packages_without_proxy(
     )
 
 
+def test_sri_to_pnpm_store_key() -> None:
+    # pnpm derives the index location from the first 32 bytes of the SHA-512 digest:
+    # 2 hex chars name the subdir, the next 62 form the filename prefix.
+    raw = bytes(range(64))
+    sri = "sha512-" + base64.b64encode(raw).decode()
+
+    assert _sri_to_pnpm_store_key(sri) == (
+        "00",
+        "0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+    )
+
+
+def test_add_tarball_to_pnpm_store(tmp_path: Path) -> None:
+    store_dir = tmp_path / "store"
+    tarball = tmp_path / "foo-1.0.0.tgz"
+    manifest = b'{"name":"foo","version":"1.0.0","scripts":{"postinstall":"node-gyp rebuild"}}'
+    cli = b"#!/usr/bin/env node\nconsole.log('hi');\n"
+    index_js = b"module.exports = 1;\n"
+    _make_npm_tarball(
+        tarball,
+        [
+            ("package/package.json", manifest, 0o644),
+            ("package/bin/cli.js", cli, 0o755),
+            ("package/index.js", index_js, 0o644),
+        ],
+    )
+    integrity = "sha512-" + base64.b64encode(bytes(range(64))).decode()
+
+    _add_tarball_to_pnpm_store(
+        tarball_path=tarball,
+        store_dir=store_dir,
+        name="foo",
+        scope="",
+        version="1.0.0",
+        pkg_integrity=integrity,
+    )
+
+    files_dir = store_dir / "v10" / "files"
+
+    # An executable file is stored under a "-exec" suffix at 0o750 on disk: pnpm
+    # hardlinks the CAS file into node_modules, so the stored mode is what is run.
+    cli_hex = hashlib.sha512(cli).hexdigest()
+    cli_cas = files_dir / cli_hex[0:2] / (cli_hex[2:] + "-exec")
+    assert cli_cas.read_bytes() == cli
+    assert stat.S_IMODE(cli_cas.stat().st_mode) == 0o750
+
+    # A plain file uses the bare hash at 0o640.
+    index_hex = hashlib.sha512(index_js).hexdigest()
+    index_cas = files_dir / index_hex[0:2] / index_hex[2:]
+    assert index_cas.read_bytes() == index_js
+    assert stat.S_IMODE(index_cas.stat().st_mode) == 0o640
+
+    prefix, key = _sri_to_pnpm_store_key(integrity)
+    index = json.loads((store_dir / "v10" / "index" / prefix / f"{key}-foo@1.0.0.json").read_text())
+
+    assert index["name"] == "foo"
+    assert index["version"] == "1.0.0"
+    # A postinstall script means pnpm must build the package, so the index says so.
+    assert index["requiresBuild"] is True
+    assert set(index["files"]) == {"package.json", "bin/cli.js", "index.js"}
+    assert index["files"]["bin/cli.js"]["mode"] == 0o755
+    assert index["files"]["index.js"]["size"] == len(index_js)
+    assert (
+        index["files"]["bin/cli.js"]["integrity"]
+        == "sha512-" + base64.b64encode(bytes.fromhex(cli_hex)).decode()
+    )
+
+
+def test_add_tarball_to_pnpm_store_scoped_package(tmp_path: Path) -> None:
+    store_dir = tmp_path / "store"
+    tarball = tmp_path / "scope-b-2.0.0.tgz"
+    _make_npm_tarball(
+        tarball,
+        [("package/package.json", b'{"name":"@scope/b","version":"2.0.0"}', 0o644)],
+    )
+    integrity = "sha512-" + base64.b64encode(bytes(range(64))).decode()
+
+    _add_tarball_to_pnpm_store(
+        tarball_path=tarball,
+        store_dir=store_dir,
+        name="b",
+        scope="scope",
+        version="2.0.0",
+        pkg_integrity=integrity,
+    )
+
+    prefix, key = _sri_to_pnpm_store_key(integrity)
+    index = json.loads(
+        (store_dir / "v10" / "index" / prefix / f"{key}-@scope+b@2.0.0.json").read_text()
+    )
+    assert index["name"] == "@scope/b"
+    # No install scripts and no node-gyp config: pnpm need not build this package.
+    assert index["requiresBuild"] is False
+
+
+def test_add_tarball_to_pnpm_store_requires_build_from_gyp(tmp_path: Path) -> None:
+    store_dir = tmp_path / "store"
+    tarball = tmp_path / "native-1.0.0.tgz"
+    _make_npm_tarball(
+        tarball,
+        [
+            ("package/package.json", b'{"name":"native","version":"1.0.0"}', 0o644),
+            ("package/binding.gyp", b"{}", 0o644),
+        ],
+    )
+    integrity = "sha512-" + base64.b64encode(bytes(range(64))).decode()
+
+    _add_tarball_to_pnpm_store(
+        tarball_path=tarball,
+        store_dir=store_dir,
+        name="native",
+        scope="",
+        version="1.0.0",
+        pkg_integrity=integrity,
+    )
+
+    prefix, key = _sri_to_pnpm_store_key(integrity)
+    index = json.loads(
+        (store_dir / "v10" / "index" / prefix / f"{key}-native@1.0.0.json").read_text()
+    )
+    # A node-gyp config means the package builds a native addon at install time.
+    assert index["requiresBuild"] is True
+
+
+def test_add_tarball_to_pnpm_store_non_sha512_integrity(tmp_path: Path) -> None:
+    store_dir = tmp_path / "store"
+    tarball = tmp_path / "legacy-1.0.0.tgz"
+    _make_npm_tarball(
+        tarball,
+        [("package/package.json", b'{"name":"legacy","version":"1.0.0"}', 0o644)],
+    )
+
+    # A non-sha512 integrity must not crash; pnpm keys the store by the sha512 of the
+    # tarball, so the index lands under that digest rather than the integrity hash.
+    _add_tarball_to_pnpm_store(
+        tarball_path=tarball,
+        store_dir=store_dir,
+        name="legacy",
+        scope="",
+        version="1.0.0",
+        pkg_integrity="sha1-" + base64.b64encode(bytes(20)).decode(),
+    )
+
+    tarball_hex = hashlib.sha512(tarball.read_bytes()).hexdigest()
+    index_path = (
+        store_dir / "v10" / "index" / tarball_hex[0:2] / f"{tarball_hex[2:64]}-legacy@1.0.0.json"
+    )
+    assert index_path.is_file()
+
+
+def test_add_tarball_to_pnpm_store_non_object_manifest(tmp_path: Path) -> None:
+    store_dir = tmp_path / "store"
+    tarball = tmp_path / "weird-1.0.0.tgz"
+    # A package.json whose JSON root is not an object must not abort the prefetch.
+    _make_npm_tarball(tarball, [("package/package.json", b'["not", "an", "object"]', 0o644)])
+    integrity = "sha512-" + base64.b64encode(bytes(range(64))).decode()
+
+    _add_tarball_to_pnpm_store(
+        tarball_path=tarball,
+        store_dir=store_dir,
+        name="weird",
+        scope="",
+        version="1.0.0",
+        pkg_integrity=integrity,
+    )
+
+    prefix, key = _sri_to_pnpm_store_key(integrity)
+    index = json.loads(
+        (store_dir / "v10" / "index" / prefix / f"{key}-weird@1.0.0.json").read_text()
+    )
+    assert index["requiresBuild"] is False
+
+
 def test_prepare_lockfile_for_hermetic_build(tmp_path: Path) -> None:
+    git_id = "repo@https://codeload.github.com/org/repo/tar.gz/abc123"
     data = {
         "lockfileVersion": "9.0",
         "packages": {
             "a@1.0.0": {"resolution": {"integrity": "sha512-abc"}},
-            "@scope/b@2.0.0": {"resolution": {"integrity": "sha512-def"}},
+            git_id: {
+                "resolution": {"tarball": "https://codeload.github.com/org/repo/tar.gz/abc123"}
+            },
         },
     }
     lockfile = PnpmLock(path=tmp_path / "pnpm-lock.yaml", data=data)
-    packages = [
-        PnpmPackage(
-            "a@1.0.0",
-            "",
-            "a",
-            "1.0.0",
-            f"{NPM_REGISTRY_URL}/a/-/a-1.0.0.tgz",
-            "sha512-abc",
-        ),
-        PnpmPackage(
-            "@scope/b@2.0.0",
-            "scope",
-            "b",
-            "2.0.0",
-            f"{NPM_REGISTRY_URL}/@scope/b/-/b-2.0.0.tgz",
-            "sha512-def",
-        ),
-    ]
+    git = PnpmPackage(
+        git_id, "", "repo", "1.0.0", "https://codeload.github.com/org/repo/tar.gz/abc123"
+    )
 
-    project_file = _prepare_lockfile_for_hermetic_build(lockfile, packages)
+    project_file = _prepare_lockfile_for_hermetic_build(lockfile, [git])
 
     assert project_file.abspath == lockfile.path
+    # Only the non-registry (git/URL) package is rewritten to its downloaded tarball. The
+    # registry package is served from the offline store and keeps its registry-style
+    # resolution, which pnpm >=10.34.2 requires (a "tarball: file://" on it is rejected as
+    # a resolution-shape mismatch).
     assert project_file.template == yaml.safe_dump(
         {
             "lockfileVersion": "9.0",
             "packages": {
-                "a@1.0.0": {
-                    "resolution": {
-                        "integrity": "sha512-abc",
-                        "tarball": "file://${output_dir}/deps/pnpm/a-1.0.0.tgz",
-                    }
-                },
-                "@scope/b@2.0.0": {
-                    "resolution": {
-                        "integrity": "sha512-def",
-                        "tarball": "file://${output_dir}/deps/pnpm/scope-b-2.0.0.tgz",
-                    }
+                "a@1.0.0": {"resolution": {"integrity": "sha512-abc"}},
+                git_id: {
+                    "resolution": {"tarball": "file://${output_dir}/deps/pnpm/repo-1.0.0.tgz"}
                 },
             },
         },
         sort_keys=False,
     )
-
-    # Verify that the original URLs are preserved.
-    assert packages[0].url == f"{NPM_REGISTRY_URL}/a/-/a-1.0.0.tgz"
-    assert packages[1].url == f"{NPM_REGISTRY_URL}/@scope/b/-/b-2.0.0.tgz"

--- a/tests/unit/package_managers/javascript/pnpm/test_project.py
+++ b/tests/unit/package_managers/javascript/pnpm/test_project.py
@@ -5,7 +5,11 @@ from typing import Any
 import pytest
 
 from hermeto.core.errors import InvalidLockfileFormat, LockfileNotFound, UnsupportedFeature
-from hermeto.core.package_managers.javascript.pnpm.project import PnpmLock, parse_packages
+from hermeto.core.package_managers.javascript.pnpm.project import (
+    PnpmLock,
+    PnpmPackage,
+    parse_packages,
+)
 
 
 class TestPnpmLock:
@@ -55,3 +59,19 @@ class TestPnpmLock:
         packages = parse_packages(lockfile)
         assert packages[0].version == "1.0.0"
         assert packages[0].url == "https://codeload.github.com/org/repo/tar.gz/abc123"
+
+    @pytest.mark.parametrize(
+        "id, expected",
+        [
+            ("foo@1.0.0", True),
+            ("@scope/bar@2.3.4", True),
+            ("@jsr/foo@1.0.0", True),
+            ("foo@1.0.0-rc.1+build.5", True),
+            ("repo@https://codeload.github.com/org/repo/tar.gz/abc123", False),
+            ("foo@git+ssh://git@github.com/org/repo.git#abc123", False),
+        ],
+    )
+    def test_pnpm_package_registry_shaped(self, id: str, expected: bool) -> None:
+        # registry_shaped reads only the key, so the other fields are irrelevant here.
+        package = PnpmPackage(id, "", "x", "1.0.0", "https://example.com/x.tgz")
+        assert package.registry_shaped is expected


### PR DESCRIPTION
## Problem

pnpm 10.34.2 tightened resolution-shape validation: a registry-style lockfile key (`name@version`) may no longer carry a non-registry `resolution.tarball: file://...`. The hermeto pnpm backend rewrote **every** registry dependency that way in `_prepare_lockfile_for_hermetic_build`, so any hermetic build that pins pnpm >= 10.34.2 (via `packageManager` / corepack, or a Renovate bump of the pinned version) now fails at install time with:

```
ERR_PNPM_RESOLUTION_SHAPE_MISMATCH  Lockfile resolution for <pkg>@<ver> is broken
```

Tracked in https://github.com/hermetoproject/hermeto/issues/1619.

## Fix

Stop rewriting the lockfile. Instead, pre-populate a pnpm content-addressable store ("v10") from the downloaded tarballs and point pnpm at it via `NPM_CONFIG_STORE_DIR`, so `pnpm install --offline` resolves every dependency by its `integrity` hash:

- `store/v10/files/<fileSha512hex[0:2]>/<fileSha512hex[2:]>` — raw file content (CAS)
- `store/v10/index/<intHex[0:2]>/<intHex[2:64]>-<pkg>@<ver>.json` — per-package metadata, keyed by the package integrity SRI

The lockfile keeps its registry-style resolutions untouched, so it stays valid for any pnpm version, and the build remains fully offline.

### Store layout subtleties

Matching what `pnpm install --store-dir` writes is load-bearing — pnpm hardlinks the stored files into `node_modules` and reads its own index, so each deviation is a distinct offline failure we hit while validating:

- **Executable files** (`mode & 0o111`) use a `-exec` CAS suffix and are stored `0o750`; plain files use the bare hash at `0o640`. pnpm does not re-apply the index `mode` to the hardlink, so the stored file's mode is the installed file's mode. Wrong suffix → package treated as absent (`ERR_PNPM_NO_OFFLINE_TARBALL`); wrong mode → `spawn ... EACCES` for binaries (e.g. esbuild).
- **`requiresBuild`** is derived from `preinstall`/`install`/`postinstall` scripts or a `*.gyp` file, otherwise pnpm skips building allow-listed native dependencies (e.g. re2).

## Verification

- `pytest --doctest-modules hermeto tests/unit` (1444 passed) and the lint suite (`ruff check`, `ruff format --check`, `mypy` — 171 files, no issues) pass.
- Validated end-to-end in a hermetic build (1453-package project, `--network=none`): `pnpm install --offline` → `reused 1453, downloaded 0`, native modules (re2, better-sqlite3) built from source, full `pnpm build` succeeds.
- Negative control (same lockfile with `tarball: file://`) reproduces `ERR_PNPM_RESOLUTION_SHAPE_MISMATCH`.

The commit is DCO signed-off and carries the `Assisted-by: Claude` trailer.
