### PR TITLE
Changed bundler package manager backend to async download HTTP gems

### DIFF
--- a/hermeto/core/package_managers/bundler/gem_models.py
+++ b/hermeto/core/package_managers/bundler/gem_models.py
@@ -12,7 +12,7 @@ from typing_extensions import Self
 from hermeto.core.config import get_config
 from hermeto.core.constants import Mode
 from hermeto.core.errors import NotAGitRepo
-from hermeto.core.package_managers.general import download_binary_file, get_vcs_qualifiers
+from hermeto.core.package_managers.general import get_vcs_qualifiers
 from hermeto.core.rooted_path import PathOutsideRoot, RootedPath
 from hermeto.core.scm import GitRepo
 
@@ -41,10 +41,6 @@ class _GemMetadata(pydantic.BaseModel):
     name: str
     version: str
 
-    def download_to(self, deps_dir: RootedPath) -> None:  # noqa: ARG002
-        """Download gem to the specified directory."""
-        return None
-
 
 class GemDependency(_GemMetadata):
     """
@@ -69,11 +65,9 @@ class GemDependency(_GemMetadata):
         """Return remote location to download this gem from."""
         return urljoin(self.source, f"downloads/{self.name}-{self.version}.gem")
 
-    def download_to(self, deps_dir: RootedPath) -> None:
-        """Download represented gem to specified file system location."""
-        fs_location = deps_dir.join_within_root(Path(f"{self.name}-{self.version}.gem"))
-        log.info("Downloading gem %s", self.name)
-        download_binary_file(self.remote_location, fs_location)
+    def download_location(self, deps_dir: RootedPath) -> RootedPath:
+        """Get the file system location of the gem."""
+        return deps_dir.join_within_root(Path(f"{self.name}-{self.version}.gem"))
 
 
 class GemPlatformSpecificDependency(GemDependency):
@@ -89,21 +83,15 @@ class GemPlatformSpecificDependency(GemDependency):
     @property
     def remote_location(self) -> str:
         """Return remote location to download this gem from."""
-        return urljoin(self.source, f"downloads/{self.name}-{self.version}-{self.platform}.gem")
-
-    def download_to(self, deps_dir: RootedPath) -> None:
-        """Download represented gem to specified file system location."""
-        fs_location = deps_dir.join_within_root(
-            Path(f"{self.name}-{self.version}-{self.platform}.gem")
-        )
-        log.info(
-            "Downloading platform-specific gem %s-%s-%s", self.name, self.version, self.platform
-        )
         # A combination of Ruby v.3.0.7 and some Bundler dependencies results in
         # -gnu suffix being dropped from some platforms. This was observed on
         # sqlite3-aarch-linux-gnu. We discourage using outdated platforms
         # for building dependencies and cnsider this to be a limitation of Ruby.
-        download_binary_file(self.remote_location, fs_location)
+        return urljoin(self.source, f"downloads/{self.name}-{self.version}-{self.platform}.gem")
+
+    def download_location(self, deps_dir: RootedPath) -> RootedPath:
+        """Get the file system location of the gem."""
+        return deps_dir.join_within_root(Path(f"{self.name}-{self.version}-{self.platform}.gem"))
 
 
 class GitDependency(_GemMetadata):

--- a/hermeto/core/package_managers/bundler/main.py
+++ b/hermeto/core/package_managers/bundler/main.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: GPL-3.0-only
+import asyncio
 import logging
 import os
 from pathlib import Path
@@ -12,16 +13,17 @@ from hermeto.core.constants import Mode
 from hermeto.core.errors import NotAGitRepo, PackageRejected, UnsupportedFeature
 from hermeto.core.models.input import BundlerBinaryFilters, Request
 from hermeto.core.models.output import EnvironmentVariable, ProjectFile, RequestOutput
-from hermeto.core.models.property_semantics import PropertySet
+from hermeto.core.models.property_semantics import Property, PropertySet
 from hermeto.core.models.sbom import Component, create_backend_annotation
 from hermeto.core.package_managers.bundler.parser import (
+    GemDependency,
     GemPlatformSpecificDependency,
     GitDependency,
     ParseResult,
     PathDependency,
     parse_lockfile,
 )
-from hermeto.core.package_managers.general import get_vcs_qualifiers
+from hermeto.core.package_managers.general import async_download_files, get_vcs_qualifiers
 from hermeto.core.rooted_path import RootedPath
 from hermeto.core.scm import get_repo_id
 
@@ -97,18 +99,29 @@ def _resolve_bundler_package(
 
     components = [Component(name=name, version=version, purl=main_package_purl.to_string())]
     git_paths = []
+    files_to_download: dict[str, RootedPath] = {}
     for dep in dependencies:
-        dep.download_to(deps_dir)
-        if isinstance(dep, GemPlatformSpecificDependency):
-            properties = PropertySet(bundler_package_binary=True).to_properties()
-        else:
-            properties = []
-        if isinstance(dep, GitDependency):
-            git_paths.append((dep.name, dep.repo_name + "-" + dep.ref[:12]))
+        properties: list[Property] = []
+        match dep:
+            case GemPlatformSpecificDependency():
+                files_to_download[dep.remote_location] = dep.download_location(deps_dir)
+                properties = PropertySet(bundler_package_binary=True).to_properties()
+            case GemDependency():
+                files_to_download[dep.remote_location] = dep.download_location(deps_dir)
+            case GitDependency():
+                dep.download_to(deps_dir)
+                git_paths.append((dep.name, dep.repo_name + "-" + dep.ref[:12]))
 
         c = Component(name=dep.name, version=dep.version, purl=dep.purl, properties=properties)
         components.append(c)
 
+    if files_to_download:
+        asyncio.run(
+            async_download_files(
+                files_to_download=files_to_download,
+                concurrency_limit=get_config().runtime.concurrency_limit,
+            )
+        )
     return components, git_paths
 
 

--- a/tests/unit/package_managers/bundler/test_parser.py
+++ b/tests/unit/package_managers/bundler/test_parser.py
@@ -195,53 +195,6 @@ def test_parse_gemlock_empty(
     assert result == []
 
 
-@pytest.mark.parametrize(
-    "source",
-    [
-        "https://rubygems.org",
-        "https://dedicatedprivategemrepo.com",
-    ],
-)
-@mock.patch("hermeto.core.package_managers.bundler.gem_models.download_binary_file")
-def test_source_gem_dependencies_could_be_downloaded(
-    mock_downloader: mock.MagicMock,
-    rooted_tmp_path: RootedPath,
-    caplog: pytest.LogCaptureFixture,
-    source: str,
-) -> None:
-    dependency = GemDependency(name="foo", version="0.0.2", source=source)
-    expected_source_url = f"{source}/downloads/foo-0.0.2.gem"
-    expected_destination = rooted_tmp_path.join_within_root("foo-0.0.2.gem")
-
-    dependency.download_to(rooted_tmp_path)
-
-    assert f"Downloading gem {dependency.name}" in caplog.messages
-    mock_downloader.assert_called_once_with(expected_source_url, expected_destination)
-
-
-@mock.patch("hermeto.core.package_managers.bundler.gem_models.download_binary_file")
-def test_binary_gem_dependencies_could_be_downloaded(
-    mock_downloader: mock.MagicMock,
-    rooted_tmp_path: RootedPath,
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    source = "https://rubygems.org/"
-    platform = "m6502_wm"
-    dependency = GemPlatformSpecificDependency(
-        name="foo",
-        version="0.0.2",
-        source=source,
-        platform=platform,
-    )
-    expected_source_url = f"{source}downloads/foo-0.0.2-{platform}.gem"
-    expected_destination = rooted_tmp_path.join_within_root(f"foo-0.0.2-{platform}.gem")
-
-    dependency.download_to(rooted_tmp_path)
-
-    assert some_message_contains_substring("Downloading platform-specific gem", caplog.messages)
-    mock_downloader.assert_called_once_with(expected_source_url, expected_destination)
-
-
 @mock.patch("hermeto.core.package_managers.bundler.gem_models.GitRepo.clone_from")
 def test_download_git_dependency_works(
     mock_git_clone: mock.Mock,


### PR DESCRIPTION
### Summery
Bundler now downloads all HTTP dependencies with async instead of sync, similar with the other package managers. Updated the unit tests to test the new changes instead.

### Details
1. Changed the download_to() methods to return the file system location of the gem instead of calling download_binary_file() method; also renamed the method to download_location()
2. Changed _resolve_bundler_package() to download all HTTP gems asynchronously
3. Removed the unit tests that were testing the download_to() method as it's not needed anymore.

Signed-off-by: Mohamed Bouchtout <mbouchto@redhat.com>
