### PR TITLE
feat(pip): support index_url in prefetch-input JSON

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -39,6 +39,9 @@ where 'JSON input' is
   // path to the package (relative to the --source directory)
   // defaults to "."
   "path": ".",
+  // default PyPI index URL for requirements files that don't specify --index-url
+  // defaults to https://pypi.org/simple/
+  "index_url": "https://my-index.example.com/simple/",
   // specify requirements files (relative to the package path)
   // defaults to ["requirements.txt"] or [] if the file does not exist
   "requirements_files": ["requirements.txt", "requirements-extra.txt"],
@@ -313,6 +316,30 @@ Make Hermeto download packages from the specified Python Package Index server.
 > index server (`https://pypi.org/simple`).
 
 :warning: **Do not include credentials in the index url.** If needed, provide
+authentication via
+[a **.netrc** file](https://pip.pypa.io/en/stable/topics/authentication/#netrc-support).
+
+##### JSON-level `index_url`
+
+Instead of embedding `--index-url` in your requirements files, you can specify a
+default index URL in the JSON input:
+
+```json
+{"type": "pip", "index_url": "https://my-index.example.com/simple/"}
+```
+
+This is useful in CI/CD pipelines where the index URL may change between
+environments (e.g., staging vs. production) without requiring modifications to
+the requirements files themselves.
+
+**Precedence:** `requirements.txt --index-url` > JSON `index_url` > PyPI default
+(`https://pypi.org/simple/`).
+
+The JSON `index_url` acts as a **default** — it only applies to requirements
+files that don't already specify `--index-url`. Files that have their own
+`--index-url` are not affected, so existing multi-index setups are preserved.
+
+:warning: **Do not include credentials in the index URL.** If needed, provide
 authentication via
 [a **.netrc** file](https://pip.pypa.io/en/stable/topics/authentication/#netrc-support).
 

--- a/docs/pip.md
+++ b/docs/pip.md
@@ -321,8 +321,8 @@ authentication via
 
 ##### JSON-level `index_url`
 
-Instead of embedding `--index-url` in your requirements files, you can specify a
-default index URL in the JSON input:
+Specify a default index URL in the JSON input instead of embedding `--index-url`
+in your requirements files:
 
 ```json
 {"type": "pip", "index_url": "https://my-index.example.com/simple/"}

--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -4,6 +4,7 @@ import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeVar, Union
+from urllib.parse import urlparse
 
 import pydantic
 from typing_extensions import Self
@@ -315,6 +316,28 @@ class PipPackageInput(_PackageInputBase):
     requirements_build_files: list[Path] | None = None
     allow_binary: bool = False
     binary: PipBinaryFilters | None = None
+    index_url: str | None = None
+
+    @pydantic.field_validator("index_url")
+    @classmethod
+    def _validate_index_url(cls, url: str | None) -> str | None:
+        if url is None:
+            return url
+        if not url:
+            raise ValueError("index_url must not be empty")
+        parsed = urlparse(url)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError(
+                f"index_url must use http or https scheme, got: {parsed.scheme or 'none'}"
+            )
+        if not parsed.netloc:
+            raise ValueError("index_url must include a host")
+        if parsed.username or parsed.password:
+            raise ValueError(
+                "index_url must not contain embedded credentials; "
+                "use a .netrc file for authentication"
+            )
+        return url
 
     @pydantic.field_validator("requirements_files", "requirements_build_files")
     @classmethod

--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -89,6 +89,7 @@ def fetch_pip_source(request: Request) -> RequestOutput:
             package.requirements_files,
             package.requirements_build_files,
             package.binary,
+            package.index_url,
         )
         purl = _generate_purl_main_package(info, package_path)
         components.append(Component(name=info.name, version=info.version, purl=purl))
@@ -419,6 +420,7 @@ def _download_dependencies(
     output_dir: RootedPath,
     requirements_file: PipRequirementsFile,
     binary_filters: PipBinaryFilters | None = None,
+    default_index_url: str | None = None,
 ) -> list[PipPackage]:
     """
     Download artifacts of all dependency packages in a requirements.txt file.
@@ -471,7 +473,16 @@ def _download_dependencies(
         log.info("-- Finished processing requirement line '%s'", req.download_line)
 
     if pypi_reqs:
-        index_url = options["index_url"] or pypi_simple.PYPI_SIMPLE_ENDPOINT
+        if options["index_url"]:
+            index_url = options["index_url"]
+        elif default_index_url:
+            index_url = default_index_url
+            log.info(
+                "Using JSON default index_url '%s' (no --index-url in requirements file)",
+                default_index_url,
+            )
+        else:
+            index_url = pypi_simple.PYPI_SIMPLE_ENDPOINT
         processed.extend(
             _resolve_and_download_pypi_packages(
                 pypi_reqs, requirements_file, pip_deps_dir, binary_filters, index_url
@@ -485,6 +496,7 @@ def _download_from_requirement_files(
     output_dir: RootedPath,
     files: list[RootedPath],
     binary_filters: PipBinaryFilters | None = None,
+    default_index_url: str | None = None,
 ) -> list[PipPackage]:
     """
     Download dependencies listed in the requirement files.
@@ -492,6 +504,8 @@ def _download_from_requirement_files(
     :param output_dir: the root output directory for this request
     :param files: list of absolute paths to pip requirements files
     :param binary_filters: process wheels?
+    :param default_index_url: fallback index URL from JSON input, used when the
+        requirements file does not specify --index-url
     :return: list of PipPackage instances for each downloaded package
     :raises PackageRejected: If requirement file does not exist
     """
@@ -503,7 +517,9 @@ def _download_from_requirement_files(
                 solution="Please check that you have specified correct requirements file paths",
             )
         requirements.extend(
-            _download_dependencies(output_dir, PipRequirementsFile(req_file), binary_filters)
+            _download_dependencies(
+                output_dir, PipRequirementsFile(req_file), binary_filters, default_index_url
+            )
         )
 
     return requirements
@@ -528,6 +544,7 @@ def _resolve_pip(
     requirement_files: list[Path] | None = None,
     build_requirement_files: list[Path] | None = None,
     binary_filters: PipBinaryFilters | None = None,
+    default_index_url: str | None = None,
 ) -> PipPackageInfo:
     """Resolve and fetch pip dependencies for the given pip application.
 
@@ -564,9 +581,11 @@ def _resolve_pip(
             ", ".join(str(f.subpath_from_root) for f in resolved_build_req_files),
         )
 
-    requires = _download_from_requirement_files(output_dir, resolved_req_files, binary_filters)
+    requires = _download_from_requirement_files(
+        output_dir, resolved_req_files, binary_filters, default_index_url
+    )
     build_requires = _download_from_requirement_files(
-        output_dir, resolved_build_req_files, binary_filters
+        output_dir, resolved_build_req_files, binary_filters, default_index_url
     )
 
     all_deps = requires + build_requires

--- a/tests/unit/models/test_input.py
+++ b/tests/unit/models/test_input.py
@@ -53,6 +53,7 @@ class TestPackageInput:
                     "requirements_build_files": None,
                     "allow_binary": False,
                     "binary": None,
+                    "index_url": None,
                 },
             ),
             (
@@ -77,6 +78,7 @@ class TestPackageInput:
                         "platform": None,
                         "packages": BINARY_FILTER_ALL,
                     },
+                    "index_url": None,
                 },
             ),
             (
@@ -192,8 +194,51 @@ class TestPackageInput:
                         "platform": None,
                         "packages": "numpy,pandas",
                     },
+                    "index_url": None,
                 },
                 id="pip_with_binary_filters",
+            ),
+            pytest.param(
+                {"type": "pip", "index_url": "https://my-index.example.com/simple/"},
+                {
+                    "type": "pip",
+                    "path": Path("."),
+                    "requirements_files": None,
+                    "requirements_build_files": None,
+                    "allow_binary": False,
+                    "binary": None,
+                    "index_url": "https://my-index.example.com/simple/",
+                },
+                id="pip_with_index_url",
+            ),
+            pytest.param(
+                {"type": "pip", "index_url": "http://internal-pypi.corp.example.com/simple/"},
+                {
+                    "type": "pip",
+                    "path": Path("."),
+                    "requirements_files": None,
+                    "requirements_build_files": None,
+                    "allow_binary": False,
+                    "binary": None,
+                    "index_url": "http://internal-pypi.corp.example.com/simple/",
+                },
+                id="pip_with_http_index_url",
+            ),
+            pytest.param(
+                {
+                    "type": "pip",
+                    "index_url": "https://my-index.example.com/custom/simple/",
+                },
+                {
+                    "type": "pip",
+                    "path": Path("."),
+                    "requirements_files": None,
+                    "requirements_build_files": None,
+                    "allow_binary": False,
+                    "binary": None,
+                    "index_url": "https://my-index.example.com/custom/simple/",
+                },
+                id="pip_with_index_url_path",
             ),
             pytest.param(
                 {
@@ -297,6 +342,31 @@ class TestPackageInput:
                 {"type": "rpm", "options": {"dnf": {"repo": "bad_type"}}},
                 r"Unexpected data type for 'options.dnf.repo.bad_type' in input JSON",
                 id="rpm_bad_type_for_dnf_options",
+            ),
+            pytest.param(
+                {"type": "pip", "index_url": "ftp://my-index.example.com/simple/"},
+                r"index_url must use http or https scheme, got: ftp",
+                id="pip_index_url_bad_scheme",
+            ),
+            pytest.param(
+                {"type": "pip", "index_url": "not-a-url"},
+                r"index_url must use http or https scheme, got: none",
+                id="pip_index_url_no_scheme",
+            ),
+            pytest.param(
+                {"type": "pip", "index_url": "https://"},
+                r"index_url must include a host",
+                id="pip_index_url_no_host",
+            ),
+            pytest.param(
+                {"type": "pip", "index_url": "https://user:pass@my-index.example.com/simple/"},
+                r"index_url must not contain embedded credentials",
+                id="pip_index_url_with_credentials",
+            ),
+            pytest.param(
+                {"type": "pip", "index_url": ""},
+                r"index_url must not be empty",
+                id="pip_index_url_empty_string",
             ),
             pytest.param(
                 {"type": "pip", "binary": "invalid_string"},
@@ -413,6 +483,7 @@ class TestRequest:
                     "requirements_build_files": [],
                     "allow_binary": False,
                     "binary": None,
+                    "index_url": None,
                 },
             ],
             "flags": frozenset(),

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -964,87 +964,58 @@ class TestDefaultIndexUrl:
     Precedence: requirements.txt --index-url > JSON default_index_url > PyPI default.
     """
 
+    @pytest.mark.parametrize(
+        "options, default_index_url, expected_index_url",
+        [
+            pytest.param(
+                [],
+                CUSTOM_PYPI_ENDPOINT,
+                CUSTOM_PYPI_ENDPOINT,
+                id="json_default_used_when_no_req_file_index",
+            ),
+            pytest.param(
+                ["-i", "https://req-file-index.example.com/simple/"],
+                CUSTOM_PYPI_ENDPOINT,
+                "https://req-file-index.example.com/simple/",
+                id="req_file_index_wins_over_json_default",
+            ),
+            pytest.param(
+                ["-i", "https://req-file-index.example.com/simple/"],
+                None,
+                "https://req-file-index.example.com/simple/",
+                id="req_file_index_used_when_no_json_default",
+            ),
+            pytest.param(
+                [],
+                None,
+                None,
+                id="pypi_default_used_when_no_index_provided",
+            ),
+        ],
+    )
     @mock.patch("hermeto.core.package_managers.pip.main._resolve_and_download_pypi_packages")
-    def test_json_default_used_when_no_req_file_index(
+    def test_index_url_precedence(
         self,
         mock_resolve: mock.Mock,
+        options: list[str],
+        default_index_url: str | None,
+        expected_index_url: str | None,
         rooted_tmp_path: RootedPath,
     ) -> None:
-        """JSON default_index_url is used when requirements file has no --index-url."""
-        mock_resolve.return_value = []
-        req = mock_requirement("foo", "pypi")
-        req_file = mock_requirements_file(requirements=[req], options=[])
-
-        pip._download_dependencies(
-            rooted_tmp_path, req_file, default_index_url=CUSTOM_PYPI_ENDPOINT
-        )
-
-        mock_resolve.assert_called_once()
-        call_args = mock_resolve.call_args
-        assert call_args[0][4] == CUSTOM_PYPI_ENDPOINT
-
-    @mock.patch("hermeto.core.package_managers.pip.main._resolve_and_download_pypi_packages")
-    def test_req_file_index_wins_over_json_default(
-        self,
-        mock_resolve: mock.Mock,
-        rooted_tmp_path: RootedPath,
-    ) -> None:
-        """Requirements file --index-url wins over JSON default_index_url."""
-        mock_resolve.return_value = []
-        req = mock_requirement("foo", "pypi")
-        req_file_index = "https://req-file-index.example.com/simple/"
-        req_file = mock_requirements_file(
-            requirements=[req],
-            options=["-i", req_file_index],
-        )
-
-        pip._download_dependencies(
-            rooted_tmp_path, req_file, default_index_url=CUSTOM_PYPI_ENDPOINT
-        )
-
-        mock_resolve.assert_called_once()
-        call_args = mock_resolve.call_args
-        assert call_args[0][4] == req_file_index
-
-    @mock.patch("hermeto.core.package_managers.pip.main._resolve_and_download_pypi_packages")
-    def test_req_file_index_used_when_no_json_default(
-        self,
-        mock_resolve: mock.Mock,
-        rooted_tmp_path: RootedPath,
-    ) -> None:
-        """Requirements file --index-url is used when JSON default_index_url is None."""
-        mock_resolve.return_value = []
-        req = mock_requirement("foo", "pypi")
-        req_file_index = "https://req-file-index.example.com/simple/"
-        req_file = mock_requirements_file(
-            requirements=[req],
-            options=["-i", req_file_index],
-        )
-
-        pip._download_dependencies(rooted_tmp_path, req_file)
-
-        mock_resolve.assert_called_once()
-        call_args = mock_resolve.call_args
-        assert call_args[0][4] == req_file_index
-
-    @mock.patch("hermeto.core.package_managers.pip.main._resolve_and_download_pypi_packages")
-    def test_pypi_default_used_when_no_index_provided(
-        self,
-        mock_resolve: mock.Mock,
-        rooted_tmp_path: RootedPath,
-    ) -> None:
-        """PyPI default is used when neither JSON nor requirements file provides an index."""
+        """Test index_url precedence: req file --index-url > JSON default > PyPI default."""
         import pypi_simple
 
+        if expected_index_url is None:
+            expected_index_url = pypi_simple.PYPI_SIMPLE_ENDPOINT
+
         mock_resolve.return_value = []
         req = mock_requirement("foo", "pypi")
-        req_file = mock_requirements_file(requirements=[req], options=[])
+        req_file = mock_requirements_file(requirements=[req], options=options)
 
-        pip._download_dependencies(rooted_tmp_path, req_file)
+        pip._download_dependencies(rooted_tmp_path, req_file, default_index_url=default_index_url)
 
         mock_resolve.assert_called_once()
-        call_args = mock_resolve.call_args
-        assert call_args[0][4] == pypi_simple.PYPI_SIMPLE_ENDPOINT
+        assert mock_resolve.call_args[0][4] == expected_index_url
 
     @mock.patch("hermeto.core.package_managers.pip.main._resolve_and_download_pypi_packages")
     def test_json_default_logged_when_applied(

--- a/tests/unit/package_managers/pip/test_main.py
+++ b/tests/unit/package_managers/pip/test_main.py
@@ -956,3 +956,179 @@ def test_fetch_pip_source_correctly_reraises_when_there_is_a_dependency_cargo_lo
 
     with pytest.raises(PackageWithCorruptLockfileRejected):
         pip.fetch_pip_source(request)
+
+
+class TestDefaultIndexUrl:
+    """Test the default_index_url parameter precedence logic.
+
+    Precedence: requirements.txt --index-url > JSON default_index_url > PyPI default.
+    """
+
+    @mock.patch("hermeto.core.package_managers.pip.main._resolve_and_download_pypi_packages")
+    def test_json_default_used_when_no_req_file_index(
+        self,
+        mock_resolve: mock.Mock,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        """JSON default_index_url is used when requirements file has no --index-url."""
+        mock_resolve.return_value = []
+        req = mock_requirement("foo", "pypi")
+        req_file = mock_requirements_file(requirements=[req], options=[])
+
+        pip._download_dependencies(
+            rooted_tmp_path, req_file, default_index_url=CUSTOM_PYPI_ENDPOINT
+        )
+
+        mock_resolve.assert_called_once()
+        call_args = mock_resolve.call_args
+        assert call_args[0][4] == CUSTOM_PYPI_ENDPOINT
+
+    @mock.patch("hermeto.core.package_managers.pip.main._resolve_and_download_pypi_packages")
+    def test_req_file_index_wins_over_json_default(
+        self,
+        mock_resolve: mock.Mock,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        """Requirements file --index-url wins over JSON default_index_url."""
+        mock_resolve.return_value = []
+        req = mock_requirement("foo", "pypi")
+        req_file_index = "https://req-file-index.example.com/simple/"
+        req_file = mock_requirements_file(
+            requirements=[req],
+            options=["-i", req_file_index],
+        )
+
+        pip._download_dependencies(
+            rooted_tmp_path, req_file, default_index_url=CUSTOM_PYPI_ENDPOINT
+        )
+
+        mock_resolve.assert_called_once()
+        call_args = mock_resolve.call_args
+        assert call_args[0][4] == req_file_index
+
+    @mock.patch("hermeto.core.package_managers.pip.main._resolve_and_download_pypi_packages")
+    def test_req_file_index_used_when_no_json_default(
+        self,
+        mock_resolve: mock.Mock,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        """Requirements file --index-url is used when JSON default_index_url is None."""
+        mock_resolve.return_value = []
+        req = mock_requirement("foo", "pypi")
+        req_file_index = "https://req-file-index.example.com/simple/"
+        req_file = mock_requirements_file(
+            requirements=[req],
+            options=["-i", req_file_index],
+        )
+
+        pip._download_dependencies(rooted_tmp_path, req_file)
+
+        mock_resolve.assert_called_once()
+        call_args = mock_resolve.call_args
+        assert call_args[0][4] == req_file_index
+
+    @mock.patch("hermeto.core.package_managers.pip.main._resolve_and_download_pypi_packages")
+    def test_pypi_default_used_when_no_index_provided(
+        self,
+        mock_resolve: mock.Mock,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        """PyPI default is used when neither JSON nor requirements file provides an index."""
+        import pypi_simple
+
+        mock_resolve.return_value = []
+        req = mock_requirement("foo", "pypi")
+        req_file = mock_requirements_file(requirements=[req], options=[])
+
+        pip._download_dependencies(rooted_tmp_path, req_file)
+
+        mock_resolve.assert_called_once()
+        call_args = mock_resolve.call_args
+        assert call_args[0][4] == pypi_simple.PYPI_SIMPLE_ENDPOINT
+
+    @mock.patch("hermeto.core.package_managers.pip.main._resolve_and_download_pypi_packages")
+    def test_json_default_logged_when_applied(
+        self,
+        mock_resolve: mock.Mock,
+        rooted_tmp_path: RootedPath,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """INFO log emitted when JSON default_index_url is applied."""
+        mock_resolve.return_value = []
+        req = mock_requirement("foo", "pypi")
+        req_file = mock_requirements_file(requirements=[req], options=[])
+
+        pip._download_dependencies(
+            rooted_tmp_path, req_file, default_index_url=CUSTOM_PYPI_ENDPOINT
+        )
+
+        assert f"Using JSON default index_url '{CUSTOM_PYPI_ENDPOINT}'" in caplog.text
+
+    @mock.patch("hermeto.core.package_managers.pip.main._resolve_and_download_pypi_packages")
+    def test_no_log_when_req_file_index_wins(
+        self,
+        mock_resolve: mock.Mock,
+        rooted_tmp_path: RootedPath,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """No JSON default log when requirements file --index-url wins."""
+        mock_resolve.return_value = []
+        req = mock_requirement("foo", "pypi")
+        req_file = mock_requirements_file(
+            requirements=[req],
+            options=["-i", "https://req-file-index.example.com/simple/"],
+        )
+
+        pip._download_dependencies(
+            rooted_tmp_path, req_file, default_index_url=CUSTOM_PYPI_ENDPOINT
+        )
+
+        assert "Using JSON default index_url" not in caplog.text
+
+    @mock.patch("hermeto.core.package_managers.pip.main._download_dependencies")
+    @mock.patch("hermeto.core.package_managers.pip.main.PipRequirementsFile")
+    def test_default_index_url_threads_to_download_dependencies(
+        self,
+        mock_req_file_cls: mock.Mock,
+        mock_download: mock.Mock,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        """default_index_url is forwarded from _download_from_requirement_files."""
+        mock_download.return_value = []
+        req_path = rooted_tmp_path.join_within_root("requirements.txt")
+        req_path.path.touch()
+
+        pip._download_from_requirement_files(
+            rooted_tmp_path,
+            [req_path],
+            binary_filters=None,
+            default_index_url=CUSTOM_PYPI_ENDPOINT,
+        )
+
+        mock_download.assert_called_once()
+        assert mock_download.call_args[0][3] == CUSTOM_PYPI_ENDPOINT
+
+    @mock.patch("hermeto.core.package_managers.pip.main._download_from_requirement_files")
+    @mock.patch("hermeto.core.package_managers.pip.main._get_pip_metadata")
+    def test_default_index_url_threads_to_both_req_file_types(
+        self,
+        mock_metadata: mock.Mock,
+        mock_download_from_files: mock.Mock,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        """default_index_url is forwarded to both requires and build_requires paths."""
+        mock_metadata.return_value = ("foo", "1.0")
+        mock_download_from_files.return_value = []
+
+        pip._resolve_pip(
+            rooted_tmp_path,
+            rooted_tmp_path,
+            requirement_files=[],
+            build_requirement_files=[],
+            binary_filters=None,
+            default_index_url=CUSTOM_PYPI_ENDPOINT,
+        )
+
+        assert mock_download_from_files.call_count == 2
+        for call in mock_download_from_files.call_args_list:
+            assert call[0][3] == CUSTOM_PYPI_ENDPOINT


### PR DESCRIPTION
Embedding --index-url inside every requirements.txt couples build
infrastructure config (which index to use) with dependency declarations
(which packages to install). When the index URL changes — e.g. on a
release version bump — every requirements file must be touched, even
though the packages and versions stay the same.

Add an `index_url` field to PipPackageInput so CI/CD pipelines can
provide a default PyPI index URL externally:

  {"type": "pip", "index_url": "https://my-index.example.com/simple/"}

The field acts as a fallback default, not an override:

  requirements.txt --index-url  >  JSON index_url  >  PyPI default

Files that specify their own --index-url keep working exactly as today,
preserving multi-index setups where different requirements files point
to different private indexes.

https://github.com/hermetoproject/hermeto/issues/1634