### PR TITLE
fix(pip): Make custom indices override proxy setting

### DIFF
--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -386,10 +386,15 @@ def _resolve_and_download_pypi_packages(
     """Resolve and download all PyPI packages."""
     config = get_config()
     proxy_url = str(config.pip.proxy_url) if config.pip.proxy_url is not None else None
-    query_url = proxy_url if proxy_url is not None else index_url
+    # A proxy must be used only if an index is the standard one, custom indices must
+    # be preserved. A custom index would always override proxy.
+    is_standard = lambda index_url: index_url and index_url == pypi_simple.PYPI_SIMPLE_ENDPOINT
+    query_url = proxy_url if (proxy_url is not None and is_standard(index_url)) else index_url
     requests_auth = None
     aiohttp_auth = None
-    if config.pip.proxy_login and config.pip.proxy_password:
+    # No attempt should be made at logging into custom indices, if query URL ends up pointing
+    # to a custom index then authorization must be skipped.
+    if config.pip.proxy_login and config.pip.proxy_password and (query_url == proxy_url):
         requests_auth = requests.auth.HTTPBasicAuth(
             config.pip.proxy_login, config.pip.proxy_password
         )
@@ -405,12 +410,15 @@ def _resolve_and_download_pypi_packages(
     pypi_dpis = asyncio.run(_resolve_pypi_distributions(pypi_reqs, resolve_callback))
     reqs_dpis_zipped = zip(pypi_reqs, pypi_dpis)
     pypi_artifacts = [_PyPIArtifact(req, dpi) for req, dpis in reqs_dpis_zipped for dpi in dpis]
+    # If a standard PyPI index is used with proxy URL then proxy URL must be reported,
+    # if a custom index is used then proxy URL must not be reported even if set.
+    proxy_to_report = proxy_url if (proxy_url is not None and (proxy_url != index_url)) else None
     return _download_pypi_packages(
         requirements_file,
         pip_deps_dir,
         pypi_artifacts,
         index_url=index_url,
-        proxy_url=proxy_url,
+        proxy_url=proxy_to_report,
         auth=aiohttp_auth,
     )
 


### PR DESCRIPTION
Prior to this change a proxy URL would override all sources for pip including custom indices which is not correct -- if a custom index is present it must be used since a proxy is not guaranteed to mirror it (unlike the standard source). This change implements this rule and also ensures that proxy authentication headers will be added only to requests issued to proxies and not to custom indices.

The change is tested with `pip/custom_index` scenario.