### PR TITLE
fix(pip): Make artifact registry proxy auth work again

### DIFF
--- a/hermeto/core/package_managers/general.py
+++ b/hermeto/core/package_managers/general.py
@@ -98,6 +98,7 @@ async def _async_download_binary_file(
     headers: dict[str, str] | None = None,
     ssl_context: ssl.SSLContext | None = None,
     chunk_size: int = 8192,
+    auth: str | None = None,
 ) -> None:
     """
     Download a binary file (such as a TAR archive) from a URL using asyncio.
@@ -116,6 +117,7 @@ async def _async_download_binary_file(
             f"aiohttp.ClientSession.get(url: {url}, timeout: {timeout}, raise_for_status: True)"
         )
 
+        headers = {"Authorization": auth} if auth is not None else headers
         async with session.get(
             url,
             timeout=timeout,
@@ -145,6 +147,7 @@ async def async_download_files(
     concurrency_limit: int,
     ssl_context: ssl.SSLContext | None = None,
     headers: Mapping[str, dict[str, str]] | None = None,
+    auth: str | None = None,
 ) -> None:
     """Asynchronous function to download files.
 
@@ -201,6 +204,7 @@ async def async_download_files(
                         download_path,
                         ssl_context=ssl_context,
                         headers=headers.get(url) if headers else None,
+                        auth=auth,
                     )
                 )
             )

--- a/hermeto/core/package_managers/pip/main.py
+++ b/hermeto/core/package_managers/pip/main.py
@@ -246,12 +246,15 @@ def _download_pypi_packages(
     index_url: str,
     proxy_url: str | None = None,
     headers: Mapping[str, dict[str, str]] | None = None,
+    auth: str | None = None,
 ) -> list[PyPIPackage]:
     files = {dpi.url: dpi.path for _, dpi in pypi_artifacts if not dpi.path.exists()}
     if files:
         log.info("Downloading %d PyPI artifacts", len(files))
         asyncio.run(
-            async_download_files(files, get_config().runtime.concurrency_limit, headers=headers)
+            async_download_files(
+                files, get_config().runtime.concurrency_limit, headers=headers, auth=auth
+            )
         )
 
     result: list[PyPIPackage] = []
@@ -415,17 +418,13 @@ def _resolve_and_download_pypi_packages(
     # If a standard PyPI index is used with proxy URL then proxy URL must be reported,
     # if a custom index is used then proxy URL must not be reported even if set.
     proxy_to_report = proxy_url if (proxy_url is not None and (proxy_url != index_url)) else None
-    headers = None
-    if aiohttp_auth is not None:
-        value = {"Authorization": str(aiohttp_auth)}
-        headers = {req.url: value for req in pypi_reqs}
     return _download_pypi_packages(
         requirements_file,
         pip_deps_dir,
         pypi_artifacts,
         index_url=index_url,
         proxy_url=proxy_to_report,
-        headers=headers,
+        auth=aiohttp_auth,
     )
 
 


### PR DESCRIPTION
Problem:

```
$ git status
On branch main
Your branch is up to date with 'origin/main'.

nothing to commit, working tree clean
$ git log -n10 --pretty=oneline
b791600244db536e04ada68b68943e667b6146d9 (HEAD -> fix_nexus_auth_30062026, origin/main, origin/HEAD, main) docs(generic): add authentication section to generic fetcher docs
325191eadb283fc9572f64efdc0cb01b702b878b test(generic): add unit and integration tests for auth support
72d12225e024629f9979fd5774b13b723c2678ce test(nexus): add a new nginx server with bearer auth
b3a6c0512d7ead4c6384842cf4ded0ba8e24efd9 feat(generic): add authentication support for artifact downloads
6a357698419b7d5af67e0ee7655ab6e3d4ee4f8b docs: Update notes and warnings formatting across all markdown files
f153a136ec3768474727e98b7d70123594f7a272 fix(pip): Make custom indices override proxy setting
7c31ea419dfead368ad335a644debb0893138c48 bundler: Download HTTP gems asynchronously
adfc307daf22f16df34070949a18014913d26483 pnpm: Add user documentation
2f91fbd06990bc2e40177c473ca3d3f1e1564040 pnpm: Drop experimental prefix
a3d5ab739752d18d55635a158192fcabc36fd842 pnpm: Add new properties to the package class
$
$ nox -s all-integration-tests -- -k pip
...
============================== 12 failed, 4 passed in 49.80s ==============================
nox > Command pytest --log-cli-level=WARNING -W ignore::DeprecationWarning tests/integration -k pip failed with exit code 1
nox > Session all-integration-tests failed.
```

This happens when Nexus server is enabled locally, I observed this with the default noxfile.

The failure:

```
E         ValueError: Cannot extract URL from pypi requirement
```

happens [here](https://github.com/hermetoproject/hermeto/blob/b791600244db536e04ada68b68943e667b6146d9/hermeto/core/package_managers/pip/main.py#L421):

```
E         │   419 │   if aiohttp_auth is not None:
E         │   420 │   │   value = {"Authorization": str(aiohttp_auth)}
E         │ ❱ 421 │   │   headers = {req.url: value for req in pypi_reqs}
```

because pypi requirements do not have urls accosiated with them (see [source]( https://github.com/hermetoproject/hermeto/blob/b791600244db536e04ada68b68943e667b6146d9/hermeto/core/package_managers/pip/requirements.py#L265)).

After the change is applied:

```
...
============================= 16 passed in 274.95s (0:04:34) ==============================                                                                                                                        
nox > Session all-integration-tests was successful in 5 minutes.
```

This change is a crude fix for the the problem, a better solution is welcome.
