### PR TITLE
models: output: Make EnvironmentVariable a frozen model

### DIFF
--- a/hermeto/core/models/output.py
+++ b/hermeto/core/models/output.py
@@ -14,7 +14,7 @@ from hermeto.core.models.validators import unique_sorted
 log = logging.getLogger(__name__)
 
 
-class EnvironmentVariable(pydantic.BaseModel):
+class EnvironmentVariable(pydantic.BaseModel, frozen=True):
     """An environment variable high-level representation.
 
     An environment variable is represented as a string template that is evaluated (i.e.


### PR DESCRIPTION
EnvironmentVariable instances are never mutated after construction. resolve_value() is a pure function returning a new string. Making the model frozen enforces this invariant and enables hashing, which allows using EnvironmentVariable in sets and as dict keys.

Reference: https://github.com/hermetoproject/hermeto/pull/1629#discussion_r3490476061