### PR TITLE
.github: gating: Enable Nexus proxying in integration tests

### DIFF
--- a/.github/workflows/gating.yaml
+++ b/.github/workflows/gating.yaml
@@ -180,6 +180,7 @@ jobs:
         env:
           HERMETO_TEST_IMAGE: localhost/hermeto:${{ github.sha }}
           HERMETO_TEST_LOCAL_NEXUS: "1"
+          HERMETO_TEST_LOCAL_NEXUS_PROXY: "1"
         run: |
           git config --global --add safe.directory "*"
           /var/tmp/venv/bin/nox -s integration-tests -- -n auto


### PR DESCRIPTION
PR https://github.com/hermetoproject/hermeto/pull/1525 has shown us that not testing the proxy code path can open us up for nasty regressions. We now have parallel executions of test so since the Nexus server is already running in the CI, we might as well want to use it.

Note this change is a "hot-fix" and so a naive one. We had a regression inside the proxy code path which shouldn't happen again with this change. However, we'll now have the inverse problem - what if the native upstream dependency fetch code path introduces a regression that isn't exhibited through the proxy code path? Right now this is somewhat unlikely to happen, but if it does, we need to adopt a proper fix preceded by an investigation on whether we're better of running a subset of scenarios twice (prolonging the time it takes to run CI) OR try Github's CI action artifact uploading (needs hermeto image export and compression) to run fully parallelized.

References: https://github.com/hermetoproject/hermeto/pull/1644