### PR TITLE
Pip index url env

### DIFF
--- a/docs/pip.md
+++ b/docs/pip.md
@@ -306,8 +306,16 @@ Make Hermeto download packages from the specified Python Package Index server.
 
 Applies to all the packages (and only the packages) from the file which
 contains the `--index-url` option. If file A contains `--index-url` and file B
-does not, Hermeto will download the packages declared in B from the default
-index server (`https://pypi.org/simple`).
+does not, Hermeto will download the packages declared in B from the
+`PIP_INDEX_URL` environment variable (if set) or the default index server
+(`https://pypi.org/simple`).
+
+The precedence follows
+[pip's own configuration precedence](https://pip.pypa.io/en/stable/topics/configuration/#environment-variables):
+
+```text
+requirements.txt --index-url  >  PIP_INDEX_URL env var  >  PyPI default
+```
 
 > [!WARNING]
 > Do not include credentials in the index url. If needed, provide authentication

--- a/hermeto/core/package_managers/python/pip/main.py
+++ b/hermeto/core/package_managers/python/pip/main.py
@@ -18,7 +18,13 @@ from packaging.utils import canonicalize_name
 from hermeto.core.checksum import ChecksumInfo, must_match_any_checksum
 from hermeto.core.config import get_config
 from hermeto.core.constants import Mode
-from hermeto.core.errors import LockfileNotFound, NotAGitRepo, PackageRejected, UnsupportedFeature
+from hermeto.core.errors import (
+    InvalidInput,
+    LockfileNotFound,
+    NotAGitRepo,
+    PackageRejected,
+    UnsupportedFeature,
+)
 from hermeto.core.models.input import PipBinaryFilters, Request
 from hermeto.core.models.output import EnvironmentVariable, ProjectFile, RequestOutput
 from hermeto.core.models.sbom import (
@@ -64,6 +70,32 @@ log = logging.getLogger(__name__)
 
 DEFAULT_BUILD_REQUIREMENTS_FILE = "requirements-build.txt"
 DEFAULT_REQUIREMENTS_FILE = "requirements.txt"
+
+
+def _validate_index_url(url: str, source: str) -> None:
+    """Validate a PyPI index URL regardless of where it was configured.
+
+    :param url: the index URL to validate
+    :param source: human-readable origin for error messages (e.g. "--index-url", "PIP_INDEX_URL")
+    :raises PackageRejected: if the URL is invalid
+    """
+    parsed = urlparse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise InvalidInput(
+            f"{source} must use http or https scheme, got: {parsed.scheme or 'none'}",
+            solution=f"Set {source} to a valid HTTP(S) URL (e.g., https://pypi.org/simple/)",
+        )
+    if not parsed.netloc:
+        raise InvalidInput(
+            f"{source} must include a host",
+            solution=f"Set {source} to a valid HTTP(S) URL (e.g., https://pypi.org/simple/)",
+        )
+    if parsed.username or parsed.password:
+        raise InvalidInput(
+            f"{source} must not contain embedded credentials",
+            solution="Use a .netrc file for authentication instead of embedding "
+            "credentials in the URL",
+        )
 
 
 class _PyPIArtifact(NamedTuple):
@@ -484,7 +516,11 @@ def _download_dependencies(
         log.info("-- Finished processing requirement line '%s'", req.download_line)
 
     if pypi_reqs:
-        index_url = options["index_url"] or pypi_simple.PYPI_SIMPLE_ENDPOINT
+        if options["index_url"]:
+            _validate_index_url(options["index_url"], "--index-url")
+            index_url = options["index_url"]
+        else:
+            index_url = pypi_simple.PYPI_SIMPLE_ENDPOINT
         processed.extend(
             _resolve_and_download_pypi_packages(
                 pypi_reqs, requirements_file, pip_deps_dir, binary_filters, index_url

--- a/hermeto/core/package_managers/python/pip/main.py
+++ b/hermeto/core/package_managers/python/pip/main.py
@@ -2,6 +2,7 @@
 import asyncio
 import functools
 import logging
+import os
 import tarfile
 import zipfile
 from collections.abc import Callable, Iterable, Iterator
@@ -519,6 +520,13 @@ def _download_dependencies(
         if options["index_url"]:
             _validate_index_url(options["index_url"], "--index-url")
             index_url = options["index_url"]
+        elif pip_index_url := os.environ.get("PIP_INDEX_URL", "").strip():
+            _validate_index_url(pip_index_url, "PIP_INDEX_URL")
+            index_url = pip_index_url
+            log.info(
+                "Using PIP_INDEX_URL='%s' (no --index-url in requirements file)",
+                pip_index_url,
+            )
         else:
             index_url = pypi_simple.PYPI_SIMPLE_ENDPOINT
         processed.extend(

--- a/tests/unit/package_managers/python/pip/test_main.py
+++ b/tests/unit/package_managers/python/pip/test_main.py
@@ -998,3 +998,68 @@ class TestValidateIndexUrl:
         )
         with pytest.raises(InvalidInput):
             pip._download_dependencies(rooted_tmp_path, req_file)
+
+
+class TestPipIndexUrlEnv:
+    """Tests for PIP_INDEX_URL environment variable support."""
+
+    @pytest.mark.parametrize(
+        "env_url, file_options, expected_url",
+        [
+            pytest.param(
+                "https://env-index.example.com/simple/",
+                ["-i", "https://file-index.example.com/simple/"],
+                "https://file-index.example.com/simple/",
+                id="file_wins_over_env",
+            ),
+            pytest.param(
+                "https://env-index.example.com/simple/",
+                [],
+                "https://env-index.example.com/simple/",
+                id="env_used_when_no_file_index",
+            ),
+            pytest.param(
+                None,
+                [],
+                "https://pypi.org/simple/",
+                id="pypi_default_when_neither_set",
+            ),
+        ],
+    )
+    @mock.patch("hermeto.core.package_managers.python.pip.main._resolve_and_download_pypi_packages")
+    def test_precedence(
+        self,
+        mock_resolve: Any,
+        env_url: str | None,
+        file_options: list[str],
+        expected_url: str,
+        monkeypatch: pytest.MonkeyPatch,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        """Test precedence of index URL configuration sources."""
+        if env_url is not None:
+            monkeypatch.setenv("PIP_INDEX_URL", env_url)
+        else:
+            monkeypatch.delenv("PIP_INDEX_URL", raising=False)
+
+        mock_resolve.return_value = []
+        req = mock_requirement("foo", "pypi", version_specs=[("==", "1.0")])
+        req_file = mock_requirements_file(requirements=[req], options=file_options)
+
+        pip._download_dependencies(rooted_tmp_path, req_file)
+
+        call_args = mock_resolve.call_args
+        assert call_args[0][4] == expected_url
+
+    def test_invalid_env_url_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        rooted_tmp_path: RootedPath,
+    ) -> None:
+        """An invalid PIP_INDEX_URL is rejected when no --index-url is in the file."""
+        monkeypatch.setenv("PIP_INDEX_URL", "ftp://bad.example.com/simple/")
+        req = mock_requirement("foo", "pypi", version_specs=[("==", "1.0")])
+        req_file = mock_requirements_file(requirements=[req])
+
+        with pytest.raises(InvalidInput):
+            pip._download_dependencies(rooted_tmp_path, req_file)

--- a/tests/unit/package_managers/python/pip/test_main.py
+++ b/tests/unit/package_managers/python/pip/test_main.py
@@ -14,6 +14,7 @@ from hermeto.core.checksum import ChecksumInfo
 from hermeto.core.constants import Mode
 from hermeto.core.errors import (
     InvalidChecksum,
+    InvalidInput,
     InvalidVCSReference,
     LockfileNotFound,
     MissingChecksum,
@@ -956,3 +957,44 @@ def test_fetch_pip_source_correctly_reraises_when_there_is_a_dependency_cargo_lo
 
     with pytest.raises(PackageWithCorruptLockfileRejected):
         pip.fetch_pip_source(request)
+
+
+class TestValidateIndexUrl:
+    """Tests for index URL validation shared by --index-url and PIP_INDEX_URL."""
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            pytest.param(CUSTOM_PYPI_ENDPOINT, id="https"),
+            pytest.param("http://internal.example.com/simple/", id="http"),
+        ],
+    )
+    def test_validate_index_url_accepts_valid(self, url: str) -> None:
+        """Accept valid HTTP(S) index URLs."""
+        pip._validate_index_url(url, "--index-url")
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            pytest.param("ftp://example.com/simple/", id="ftp_scheme"),
+            pytest.param("https://", id="no_host"),
+            pytest.param("https://user:pass@example.com/simple/", id="user_pass"),
+            pytest.param("https://user@example.com/simple/", id="user_only"),
+        ],
+    )
+    def test_validate_index_url_rejects_invalid(self, url: str) -> None:
+        """Reject index URLs with bad scheme, missing host, or embedded credentials."""
+        with pytest.raises(InvalidInput):
+            pip._validate_index_url(url, "--index-url")
+
+    def test_download_dependencies_rejects_invalid_file_index_url(
+        self, rooted_tmp_path: RootedPath
+    ) -> None:
+        """--index-url from a requirements file is validated before use."""
+        req = mock_requirement("foo", "pypi", version_specs=[("==", "1.0")])
+        req_file = mock_requirements_file(
+            requirements=[req],
+            options=["-i", "ftp://bad.example.com/simple/"],
+        )
+        with pytest.raises(InvalidInput):
+            pip._download_dependencies(rooted_tmp_path, req_file)


### PR DESCRIPTION
 Hermeto now reads PIP_INDEX_URL as a fallback when a requirements file does not specify --index-url, matching pip's own documented precedence:
    requirements.txt --index-url > PIP_INDEX_URL > PyPI default.
    
This lets CI/CD pipelines parameterize the index URL without embedding it in every requirements file.
    
Closes https://github.com/hermetoproject/hermeto/issues/1656