### PR TITLE
[tests] Allow resource restrictions for cargo build jobs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,20 +230,6 @@ nox -s python-3.10 -- tests/unit/extras/test_envfile.py::test_cannot_determine_f
 
 In short, nox passes all arguments to the right of `--` directly to pytest.
 
-#### Generating new test data
-
-To generate new data (output, dependencies checksums, vendor checksums) and run integration tests with them:
-
-```shell
-nox -s generate-test-data
-```
-
-Generate data for test cases matching a pytest pattern:
-
-```shell
-nox -s generate-test-data -- -k test_e2e_gomod
-```
-
 ### Running integration tests
 
 See [tests/integration/README.md](tests/integration/README.md) for full details

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -246,50 +246,8 @@ nox -s generate-test-data -- -k test_e2e_gomod
 
 ### Running integration tests
 
-Build Hermeto image (localhost/hermeto:latest) and run most integration tests:
-
-```shell
-nox -s integration-tests
-```
-
-Build Hermeto image (localhost/hermeto:latest) and run **all** integration tests:
-
-```shell
-nox -s all-integration-tests
-```
-
-> [!NOTE]
-> While developing, you can run the Nexus server with `tests/nexusserver/run.sh`.
-
-To run integration-tests with custom image, specify the HERMETO\_TEST\_IMAGE environment variable or use the --hermeto-image option. Examples:
-
-```shell
-HERMETO_TEST_IMAGE=ghcr.io/hermetoproject/hermeto:{tag} nox -s integration-tests
-HERMETO_TEST_IMAGE=localhost/hermeto:latest nox -s integration-tests
-
-nox -s integration-tests -- --hermeto-image=ghcr.io/hermetoproject/hermeto:{tag}
-nox -s integration-tests -- --hermeto-image=localhost/hermeto:latest
-```
-
-Another way to run integration tests is directly via `pytest`. This approach can be helpful for debugging and gives you more control over which tests are run and how they are executed. Examples:
-
-```shell
-HERMETO_TEST_IMAGE=localhost/hermeto:latest pytest [path/to/integration/test]
-
-pytest --hermeto-image=localhost/hermeto:latest [path/to/integration/test]
-```
-
-All hermeto integration test CLI options as well as the corresponding environment variables can be listed with `pytest --help`.
-
-To run integration tests in parallel, use the `-n` option + the number of workers. To utilize all CPU cores, use `auto` as the number of workers. Examples:
-
-```shell
-nox -s integration-tests -- -n 4
-nox -s integration-tests -- -n auto
-
-pytest [path/to/test] -n 4
-pytest [path/to/test] -n auto
-```
+See [tests/integration/README.md](tests/integration/README.md) for full details
+on running integration tests, available environment variables, and more.
 
 ### Adding new dependencies to the project
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -60,3 +60,19 @@ Generate data for test cases matching a pytest pattern:
 ```shell
 nox -s generate-test-data -- -k test_e2e_gomod
 ```
+
+## Resource tuning
+
+Some end-to-end tests build Rust code inside containers. With many parallel
+workers, concurrent `cargo build` processes can saturate the machine. The
+following environment variables can help limit resource usage for your own local
+use:
+
+* `PYTEST_XDIST_AUTO_NUM_WORKERS` - caps the number of pytest-xdist workers
+  when using `-n auto` (defaults to the number of logical CPUs).
+* `CARGO_BUILD_JOBS` - limits the number of parallel `rustc` processes cargo
+  spawns inside each container build (defaults to all available CPUs).
+
+Integration tests also define several `HERMETO_TEST_*` variables for controlling
+the test image, container engine, and other options. Run `pytest --help` inside
+the integration test directory for a full list.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,46 @@
+# Integration Tests
+
+Build Hermeto image (localhost/hermeto:latest) and run most integration tests:
+
+```shell
+nox -s integration-tests
+```
+
+Build Hermeto image (localhost/hermeto:latest) and run **all** integration tests:
+
+```shell
+nox -s all-integration-tests
+```
+
+> [!NOTE]
+> While developing, you can run the Nexus server with `tests/nexusserver/run.sh`.
+
+To run integration-tests with custom image, specify the HERMETO\_TEST\_IMAGE environment variable or use the --hermeto-image option. Examples:
+
+```shell
+HERMETO_TEST_IMAGE=ghcr.io/hermetoproject/hermeto:{tag} nox -s integration-tests
+HERMETO_TEST_IMAGE=localhost/hermeto:latest nox -s integration-tests
+
+nox -s integration-tests -- --hermeto-image=ghcr.io/hermetoproject/hermeto:{tag}
+nox -s integration-tests -- --hermeto-image=localhost/hermeto:latest
+```
+
+Another way to run integration tests is directly via `pytest`. This approach can be helpful for debugging and gives you more control over which tests are run and how they are executed. Examples:
+
+```shell
+HERMETO_TEST_IMAGE=localhost/hermeto:latest pytest [path/to/integration/test]
+
+pytest --hermeto-image=localhost/hermeto:latest [path/to/integration/test]
+```
+
+All hermeto integration test CLI options as well as the corresponding environment variables can be listed with `pytest --help`.
+
+To run integration tests in parallel, use the `-n` option + the number of workers. To utilize all CPU cores, use `auto` as the number of workers. Examples:
+
+```shell
+nox -s integration-tests -- -n 4
+nox -s integration-tests -- -n auto
+
+pytest [path/to/test] -n 4
+pytest [path/to/test] -n auto
+```

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -44,3 +44,19 @@ nox -s integration-tests -- -n auto
 pytest [path/to/test] -n 4
 pytest [path/to/test] -n auto
 ```
+
+## Generating test data
+
+Any time an existing test scenario is updated the test data needs to be updated
+because the existing output SBOMs would not match anymore.
+To generate new data and run integration tests with them:
+
+```shell
+nox -s generate-test-data
+```
+
+Generate data for test cases matching a pytest pattern:
+
+```shell
+nox -s generate-test-data -- -k test_e2e_gomod
+```

--- a/tests/integration/test_data/cargo_e2e/container/Containerfile
+++ b/tests/integration/test_data/cargo_e2e/container/Containerfile
@@ -4,6 +4,8 @@ FROM mirror.gcr.io/rust:1.93-alpine
 RUN if getent hosts www.google.com; then echo "Has network access!"; exit 1; fi
 
 WORKDIR /src
+
+ARG CARGO_BUILD_JOBS
 RUN cargo install --frozen --path .
 
 ENTRYPOINT ["rustic"]

--- a/tests/integration/test_data/cargo_mixed_git_crate_dependency/container/Containerfile
+++ b/tests/integration/test_data/cargo_mixed_git_crate_dependency/container/Containerfile
@@ -4,4 +4,6 @@ FROM mirror.gcr.io/rust:1-alpine
 RUN if getent hosts www.google.com; then echo "Has network access!"; exit 1; fi
 
 WORKDIR /src
+
+ARG CARGO_BUILD_JOBS
 RUN . /tmp/hermeto.env && cargo build --offline

--- a/tests/integration/test_data/legacy_entrypoint_e2e_test/container/Containerfile
+++ b/tests/integration/test_data/legacy_entrypoint_e2e_test/container/Containerfile
@@ -4,4 +4,6 @@ FROM mirror.gcr.io/rust:1-alpine
 RUN if getent hosts www.google.com; then echo "Has network access!"; exit 1; fi
 
 WORKDIR /src
+
+ARG CARGO_BUILD_JOBS
 RUN . /tmp/cachi2.env && cargo build --offline

--- a/tests/integration/test_data/pip_e2e_rust_extensions/container/Containerfile
+++ b/tests/integration/test_data/pip_e2e_rust_extensions/container/Containerfile
@@ -22,6 +22,7 @@ RUN dnf -y install \
 
 WORKDIR /src
 
+ARG CARGO_BUILD_JOBS
 RUN . /tmp/hermeto.env \
     && python3 -m pip install -r requirements.txt
 

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -201,6 +201,11 @@ def build_image_for_test_case(
         "none",
     ]
 
+    # extra build args
+    for build_arg in ("CARGO_BUILD_JOBS",):
+        if val := os.environ.get(build_arg):
+            flags.extend(["--build-arg", f"{build_arg}={val}"])
+
     # this should be extended to support more archs when we have the means of testing it in our CI
     rpm_repos_path = f"{output_dir}/hermeto-output/deps/rpm/x86_64/repos.d"
     if Path(rpm_repos_path).exists():


### PR DESCRIPTION
I've run our IT suite a lot lately and despite having `PYTEST_XDIST_AUTO_NUM_WORKERS` defined locally anytime the test suite hits the cargo tests (the python rust extension one is the worst) it hogs my CPU to a point the whole desktop barely responds.
This adjusts the harness such that `CARGO_BUILD_JOBS` can be passed from the local environment to alleviate the problem a bit. Additionally, adjust the docs on integration tests to mention these tuning variables to potentially host more options in there in the future.