### PR TITLE
[tests] Move git env var stripping to global test level & strip another git variable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,13 @@ import pytest
 from tests.integration.utils import DEFAULT_INTEGRATION_TESTS_REPO
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _clean_git_env() -> None:
+    """Strip selected GIT_ env vars that leak from outer git operations."""
+    for var in ("GIT_DIR",):
+        os.environ.pop(var, None)
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register custom CLI options for Hermeto integration tests."""
     group = parser.getgroup("hermeto integration", "hermeto integration test options")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from tests.integration.utils import DEFAULT_INTEGRATION_TESTS_REPO
 @pytest.fixture(autouse=True, scope="session")
 def _clean_git_env() -> None:
     """Strip selected GIT_ env vars that leak from outer git operations."""
-    for var in ("GIT_DIR",):
+    for var in ("GIT_DIR", "GIT_WORK_TREE"):
         os.environ.pop(var, None)
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,5 +1,4 @@
 # SPDX-License-Identifier: GPL-3.0-only
-import os
 import sys
 import tarfile
 from pathlib import Path
@@ -12,13 +11,6 @@ from hermeto.core.rooted_path import RootedPath
 from hermeto.core.type_aliases import StrPath
 
 FileContents = str
-
-
-@pytest.fixture(autouse=True, scope="session")
-def _clean_git_env() -> None:
-    """Strip selected GIT_ env vars that leak from outer git operations."""
-    for var in ("GIT_DIR",):
-        os.environ.pop(var, None)
 
 
 def _create_git_repo(path: Path, files: dict[StrPath, FileContents] | None = None) -> git.Repo:


### PR DESCRIPTION
Follow-up work to https://github.com/hermetoproject/hermeto/pull/1665.
This should take care of (many identical failures):
```bash
...
FAILED tests/integration/test_yarn_classic.py::test_yarn_classic_packages[yarn_classic_offline_mirror_collision] - hermeto.core.errors.GitError: Git command failed: Cmd('git') failed due to: exit code(128)
  cmdline: git reset --hard --recurse-submodules
  stderr: 'fatal: Unable to create '<path_to_git_worktree>/<git_worktree>/index.lock': File exists.

Another git process seems to be running in this repository, or the lock file may be stale'
...
```
when running integration tests inside a git rebase from within a git worktree.