### PR TITLE
enhancement(workflow): add a github workflow that removes a stale pr/issue

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,23 @@
+name: Mark stale issues and PRs and close them
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v10
+        with:
+          days-before-issue-stale: 30
+          days-before-issue-close: 7
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-issue-label: 'no-issue-activity'
+          stale-pr-label: 'no-pr-activity'
+          stale-issue-message: 'This issue is stale because it has been inactive for 30 days. Please reply or it will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been inactive for 30 days. Please reply or it will be closed in 7 days.'


### PR DESCRIPTION
### Summery
This workflow will mark a PR or issue stale if it has been inactive for 30 days (no comments or pushes), then closes it after 7 days. This will help keep the PR and issue backlog up-to-date.

### Discussion
It may be worth adding exemptions to the workflow to not close a PR or issue if it's assigned to a specific person or it has a specific tag/milestone.

### Source
[Here](https://github.com/actions/stale) is the source of the github action.