### PR TITLE
Add experimental x-oci backend for OCI image prefetching

### DIFF
--- a/docs/design/oci.md
+++ b/docs/design/oci.md
@@ -1,0 +1,244 @@
+# OCI artifacts design document
+
+## Overview
+
+The [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md)
+defines an HTTP API for pushing and pulling container images and other content from registries.
+Container images are the primary content type, but the same API is used to store
+[arbitrary artifacts](https://github.com/opencontainers/image-spec/blob/main/manifest.md)
+(signatures, SBOMs, Helm charts, Wasm modules, etc.).
+
+This backend allows Hermeto to prefetch OCI container images from registries during the dependency
+prefetch step, so that hermetic builds can consume them without network access. Support for arbitrary
+OCI artifacts (ORAS-style custom media types) may be added in future work.
+
+**Motivating use case**: build pipelines that consume base images or pre-built container images from
+registries (e.g. Red Hat UBI images, NVIDIA CUDA images).
+In a hermetic build environment, these images must be fetched in advance and made available on disk.
+
+### Developer workflow
+
+1. The developer identifies the OCI images or artifacts their build needs.
+2. The developer resolves each reference to a digest using standard tooling:
+   ```sh
+   skopeo inspect --raw docker://registry.example.com/my-image:1.0 | sha256sum
+   # or
+   crane digest registry.example.com/my-image:1.0
+   ```
+3. The developer declares each dependency in `oci-images.lock.yaml` with its digest,
+   repository, and media type.
+4. Hermeto prefetches the declared images, producing an [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/main/image-layout.md)
+   directory for each.
+5. The build environment consumes the layouts via `podman load`, `skopeo copy oci:...`, or
+   `buildah from oci:...`.
+
+### How OCI registries work
+
+The OCI Distribution API exposes two key endpoints:
+
+- `GET /v2/<name>/manifests/<reference>`: fetches a manifest (image configuration, list of layers,
+   or multi-arch index).
+- `GET /v2/<name>/blobs/<digest>`: fetches a content-addressable blob (layer tarball, config JSON).
+
+All content is addressed by cryptographic digest (`sha256:<hex>`). A manifest lists the digests of
+its blobs, so verifying the manifest digest implicitly verifies the integrity of the entire image.
+
+Registries typically require authentication via the [Docker Token Authentication](https://distribution.github.io/distribution/spec/auth/token/)
+flow: the client receives a `401` with a `WWW-Authenticate` challenge, exchanges credentials at a
+token endpoint, and uses the resulting bearer token for subsequent requests.
+
+## Design
+
+### Scope
+
+**In scope:**
+
+- Fetching OCI images (single-arch and multi-arch) from any OCI-compliant registry
+- OCI Image Manifests (`application/vnd.oci.image.manifest.v1+json`)
+- Docker V2 Manifests (`application/vnd.docker.distribution.manifest.v2+json`)
+- OCI Image Indexes / Docker Manifest Lists (selecting a single platform)
+- Docker Token Authentication (anonymous and authenticated)
+- Output as OCI Image Layout directories
+
+**Out of scope (may be addressed in future work):**
+
+- Basic auth for registries that do not use token auth
+- OCI artifacts with arbitrary/custom media types (ORAS-style)
+- Signature verification (cosign, Notary)
+- Image attestation fetching
+- Pushing images or artifacts to registries
+- Building or modifying images
+
+### Dependency list generation
+
+#### Dependency list toolchain
+
+Hermeto does not resolve image references to digests. The developer must provide a lockfile with
+fully resolved digests. Standard tools to obtain digests:
+
+- `skopeo inspect --raw docker://<image>:<tag>` (pipe through `sha256sum`)
+- `crane digest <image>:<tag>`
+- `podman inspect --format '{{.Digest}}' <image>:<tag>`
+
+#### Dependency list format
+
+The lockfile is YAML, named `oci-images.lock.yaml`.
+
+```yaml
+metadata:
+  version: "1.0"
+images:
+  - repository: registry.redhat.io/rhel9/rhel-bootc
+    digest: sha256:7c4e86de0c80e1c773e1a4e2dae5a6c2c42049e5e2f3d8fc7eeb38adcb0c711a
+    media_type: application/vnd.oci.image.manifest.v1+json
+    tag: "9.4"
+    auth:
+      basic:
+        username: "$REGISTRY_USER"
+        password: "$REGISTRY_PASS"
+
+  - repository: ghcr.io/org/my-artifact
+    digest: sha256:deadbeef...
+    media_type: application/vnd.oci.image.index.v1+json
+    platform:
+      os: linux
+      architecture: amd64
+```
+
+**Field reference:**
+
+| Field | Required | Description |
+|---|---|---|
+| `repository` | yes | Full registry/repository path (e.g. `docker.io/library/alpine`) |
+| `digest` | yes | Content-addressable digest (e.g. `sha256:abc...`). Immutable identifier used for fetching. |
+| `media_type` | no | Media type of the manifest at the given digest. Defaults to `application/vnd.oci.image.manifest.v1+json`. |
+| `platform` | no | Platform selector for multi-arch image indexes. Required when `digest` points to an image index. |
+| `platform.os` | no | Operating system (default: `linux`) |
+| `platform.architecture` | yes | CPU architecture (e.g. `amd64`, `arm64`) |
+| `tag` | no | Human-readable tag. Informational only, used in SBOM output. Never used for fetching. |
+| `auth` | no | Authentication credentials. Mutually exclusive `basic` or `bearer` blocks. Supports environment variable expansion (e.g. `$REGISTRY_PASS`). Same model as the generic fetcher's `LockfileArtifactAuth`. |
+
+#### Checksum generation
+
+OCI images are content-addressable by design. The `digest` field in the lockfile serves as both
+the identifier and the checksum. Hermeto verifies:
+
+1. The manifest bytes hash to the lockfile `digest`.
+2. Each blob (config + layers) hashes to the digest declared in the manifest.
+
+This provides a complete chain of trust: the lockfile pins the manifest, and the manifest pins every
+blob. No separate checksum generation step is needed.
+
+### Fetching content
+
+#### Native vs. Hermeto fetch
+
+Hermeto handles all fetching directly via the OCI Distribution HTTP API. No external tools
+(skopeo, crane, podman) are invoked, consistent with the principle of avoiding arbitrary code
+execution.
+
+The OCI Distribution API is HTTP-based, so the existing `aiohttp` infrastructure in
+`hermeto/core/package_managers/general.py` (`async_download_files`) can be reused for blob
+downloads.
+
+#### Fetch procedure
+
+For each image entry in the lockfile:
+
+1. **Authenticate**: Send `GET /v2/` to the registry. If a `401` response includes a
+   `WWW-Authenticate: Bearer realm="...",service="...",scope="..."` header, exchange credentials
+   at the realm URL. If the lockfile provides `basic` auth, include it on the token request. If no
+   auth is configured, request an anonymous token (works for public registries).
+
+2. **Fetch manifest**: `GET /v2/<name>/manifests/<digest>` with `Accept: <media_type>` and the
+   bearer token. Compute `sha256` of the response body and verify it matches `digest` from the
+   lockfile. Parse the manifest JSON.
+
+3. **Handle image indexes**: If the manifest is an Image Index or Docker Manifest List, find the
+   entry matching the specified `platform`. If no `platform` was specified, raise an error asking
+   the user to set it. Fetch the platform-specific manifest by its digest (repeating step 2).
+
+4. **Download blobs**: Extract the config descriptor and layer descriptors from the manifest. For
+   each descriptor, build the download URL (`/v2/<name>/blobs/<digest>`) and the target path
+   (`blobs/sha256/<hex>`). Download concurrently. After download, verify each file's sha256
+   against its descriptor digest.
+
+5. **Write OCI Image Layout**: Create the output directory with the standard structure.
+
+#### Project structure (output)
+
+For each image, Hermeto produces an [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/main/image-layout.md)
+directory:
+
+```
+deps/x-oci/<sanitized-repository>/
+  oci-layout                    # {"imageLayoutVersion": "1.0.0"}
+  index.json                    # references the fetched manifest
+  blobs/
+    sha256/
+      <manifest-digest-hex>     # image manifest JSON
+      <config-digest-hex>       # image config JSON
+      <layer1-digest-hex>       # layer tarball
+      <layer2-digest-hex>       # layer tarball
+      ...
+```
+
+The directory name is derived from the repository (replacing `/` and `:` with `_`) plus a 12-char
+digest prefix to avoid collisions when the same repository appears at different digests
+(e.g. `registry.redhat.io/rhel9/rhel-bootc@sha256:7c4e86...` becomes
+`registry.redhat.io_rhel9_rhel-bootc_7c4e86de0c80`).
+
+#### Network requirements
+
+- **Registry endpoints**: Any OCI-compliant registry (Docker Hub, Quay, GHCR, registry.redhat.io, etc.)
+- **Authentication**: Docker Token Authentication (automatic challenge-response). Credentials come
+  from the lockfile's `auth` block with environment variable expansion.
+- **Redirects**: Some registries (notably Docker Hub) redirect blob downloads to CDN URLs. The
+  `aiohttp` client handles redirects with `requote_redirect_url=False` to preserve signed URLs.
+- **Rate limiting**: Docker Hub imposes pull rate limits. The retry infrastructure handles 429
+  responses.
+
+### Build environment config
+
+#### Environment variables
+
+| Variable Name | Purpose | Example Value | Required |
+|---|---|---|---|
+| `HERMETO_OCI_LAYOUT_DIR` | Root directory containing all OCI Image Layout directories | `deps/x-oci` | Yes |
+
+#### Configuration files
+
+No additional configuration files are injected. The OCI Image Layout is self-contained and can be
+consumed directly by container tools:
+
+```sh
+# Load into podman's local storage
+podman load --oci-dir deps/x-oci/registry.redhat.io_rhel9_rhel-bootc
+
+# Copy to a local registry or Docker daemon
+skopeo copy oci:deps/x-oci/registry.redhat.io_rhel9_rhel-bootc docker-daemon:my-image:latest
+
+# Use as a buildah source
+buildah from oci:deps/x-oci/registry.redhat.io_rhel9_rhel-bootc
+```
+
+## Implementation notes
+
+### Current limitations
+
+- **No signature verification**: cosign and Notary signatures are not fetched or verified.
+- **No attestation support**: SLSA provenance and other attestation artifacts are not fetched.
+- **No custom media types**: Only standard OCI and Docker V2 image manifests are supported.
+  ORAS-style artifacts with arbitrary media types are not yet handled.
+- **Single lockfile per package input**: Each `x-oci` package input processes one lockfile. Multiple
+  lockfiles require multiple package input entries.
+
+## References
+
+- [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec/blob/main/spec.md)
+- [OCI Image Specification](https://github.com/opencontainers/image-spec/blob/main/spec.md)
+- [OCI Image Layout](https://github.com/opencontainers/image-spec/blob/main/image-layout.md)
+- [Docker Token Authentication](https://distribution.github.io/distribution/spec/auth/token/)
+- [Package URL `pkg:oci` type](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#oci)
+- [Hermeto issue #1641](https://github.com/hermetoproject/hermeto/issues/1641)
+- [Hermeto issue #1080 (related, OCI URLs for RPMs)](https://github.com/hermetoproject/hermeto/issues/1080)

--- a/hermeto/core/models/input.py
+++ b/hermeto/core/models/input.py
@@ -114,6 +114,7 @@ PackageManagerType = Literal[
     # Add experimental package managers (or package managers whose implementation is in progress)
     # here with an x- prefix (e.g. "x-foo"):
     "x-maven",
+    "x-oci",
 ]
 
 
@@ -301,6 +302,12 @@ class MavenPackageInput(_PackageInputBase):
     type: Literal["x-maven"]
 
 
+class OciPackageInput(_PackageInputBase):
+    """Accepted input for an OCI image package."""
+
+    type: Literal["x-oci"]
+
+
 class NpmPackageInput(_PackageInputBase):
     """Accepted input for a npm package."""
 
@@ -428,6 +435,7 @@ PackageInput = Annotated[
     | GomodPackageInput
     | MavenPackageInput
     | NpmPackageInput
+    | OciPackageInput
     | PipPackageInput
     | PnpmPackageInput
     | RpmPackageInput
@@ -527,6 +535,11 @@ class Request(pydantic.BaseModel):
     def maven_packages(self) -> list[MavenPackageInput]:
         """Get the maven packages specified for this request."""
         return self._packages_by_type(MavenPackageInput)
+
+    @property
+    def oci_packages(self) -> list[OciPackageInput]:
+        """Get the OCI image packages specified for this request."""
+        return self._packages_by_type(OciPackageInput)
 
     @property
     def npm_packages(self) -> list[NpmPackageInput]:

--- a/hermeto/core/package_managers/oci/__init__.py
+++ b/hermeto/core/package_managers/oci/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-only
+from hermeto.core.package_managers.oci.main import fetch_oci_source
+
+__all__ = ["fetch_oci_source"]

--- a/hermeto/core/package_managers/oci/main.py
+++ b/hermeto/core/package_managers/oci/main.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: GPL-3.0-only
+import asyncio
+import json
+import logging
+from pathlib import Path
+
+from packageurl import PackageURL
+
+from hermeto.core.config import get_config
+from hermeto.core.models.input import Request
+from hermeto.core.models.output import Component, EnvironmentVariable, RequestOutput
+from hermeto.core.models.sbom import Annotation, create_backend_annotation
+from hermeto.core.package_managers.oci.models import DEFAULT_LOCKFILE, OciImage, OciLockfile
+from hermeto.core.package_managers.oci.oci_client import OciRegistryClient, create_retry_client
+
+log = logging.getLogger(__name__)
+
+OCI_IMAGE_LAYOUT = json.dumps({"imageLayoutVersion": "1.0.0"})
+
+
+def fetch_oci_source(request: Request) -> RequestOutput:
+    """Resolve and fetch OCI image dependencies for the given request."""
+    annotations: list[Annotation] = []
+    components: list[Component] = []
+
+    deps_dir = request.output_dir.join_within_root("deps", "x-oci")
+    deps_dir.path.mkdir(parents=True, exist_ok=True)
+
+    for package in request.oci_packages:
+        project_dir = request.source_dir.join_within_root(package.path)
+        lockfile_path = project_dir.path / DEFAULT_LOCKFILE
+        lockfile = OciLockfile.from_file(lockfile_path)
+
+        components.extend(_fetch_oci_images(lockfile, deps_dir.path))
+
+    if backend_annotation := create_backend_annotation(components, "x-oci"):
+        annotations.append(backend_annotation)
+
+    return RequestOutput.from_obj_list(
+        annotations=annotations,
+        components=components,
+        environment_variables=[
+            EnvironmentVariable(
+                name="HERMETO_OCI_LAYOUT_DIR",
+                value="${output_dir}/deps/x-oci",
+            ),
+        ],
+    )
+
+
+def _fetch_oci_images(lockfile: OciLockfile, deps_dir: Path) -> list[Component]:
+    """Fetch all images declared in a lockfile and return SBOM components."""
+
+    async def _fetch_all() -> list[Component]:
+        concurrency = get_config().runtime.concurrency_limit
+        sem = asyncio.Semaphore(concurrency)
+        client_session = create_retry_client()
+        async with client_session as session:
+            client = OciRegistryClient(session)
+            tasks = [_fetch_single_image(client, image, deps_dir, sem) for image in lockfile.images]
+            return list(await asyncio.gather(*tasks))
+
+    return asyncio.run(_fetch_all())
+
+
+async def _fetch_single_image(
+    client: OciRegistryClient,
+    image: OciImage,
+    deps_dir: Path,
+    sem: asyncio.Semaphore,
+) -> Component:
+    """Fetch a single OCI image and write it as an OCI Image Layout."""
+    log.info("Fetching OCI image %s@%s", image.repository, image.digest)
+
+    manifest_bytes, manifest, resolved_digest, resolved_media_type = await client.resolve_manifest(
+        image
+    )
+    image_dir = deps_dir / image.sanitized_name
+    image_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_oci_layout(image_dir)
+    _write_manifest_blob(image_dir, manifest_bytes, resolved_digest)
+    _write_index_json(image_dir, resolved_digest, manifest_bytes, resolved_media_type)
+
+    await client.download_blobs(image, manifest, image_dir, sem)
+
+    log.info("Fetched OCI image %s@%s", image.repository, image.digest)
+    return _create_sbom_component(image)
+
+
+def _write_oci_layout(image_dir: Path) -> None:
+    """Write the oci-layout marker file."""
+    layout_file = image_dir / "oci-layout"
+    layout_file.write_text(OCI_IMAGE_LAYOUT + "\n")
+
+
+def _write_manifest_blob(image_dir: Path, manifest_bytes: bytes, digest: str) -> None:
+    """Write the manifest as a blob."""
+    algorithm, hex_digest = digest.split(":", 1)
+    blobs_dir = image_dir / "blobs" / algorithm
+    blobs_dir.mkdir(parents=True, exist_ok=True)
+    (blobs_dir / hex_digest).write_bytes(manifest_bytes)
+
+
+def _write_index_json(
+    image_dir: Path, manifest_digest: str, manifest_bytes: bytes, media_type: str
+) -> None:
+    """Write the top-level index.json referencing the fetched manifest."""
+    index = {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {
+                "mediaType": media_type,
+                "digest": manifest_digest,
+                "size": len(manifest_bytes),
+            }
+        ],
+    }
+    (image_dir / "index.json").write_text(json.dumps(index, indent=2) + "\n")
+
+
+def _create_sbom_component(image: OciImage) -> Component:
+    """Create an SBOM component for a fetched OCI image."""
+    name = image.repo_path.rsplit("/", 1)[-1]
+
+    qualifiers: dict[str, str] = {
+        "repository_url": f"{image.registry}/{image.repo_path}",
+    }
+    if image.tag:
+        qualifiers["tag"] = image.tag
+
+    purl = PackageURL(
+        type="oci",
+        name=name,
+        version=image.digest,
+        qualifiers=qualifiers,
+    )
+
+    return Component(
+        name=name,
+        purl=purl.to_string(),
+        version=image.digest,
+    )

--- a/hermeto/core/package_managers/oci/models.py
+++ b/hermeto/core/package_managers/oci/models.py
@@ -1,0 +1,181 @@
+# SPDX-License-Identifier: GPL-3.0-only
+import re
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+
+from hermeto.core.errors import InvalidLockfileFormat, LockfileNotFound
+from hermeto.core.package_managers.generic.models import LockfileArtifactAuth
+
+DIGEST_PATTERN = re.compile(r"^sha256:[a-f0-9]{64}$")
+
+OCI_MEDIA_TYPES = frozenset(
+    {
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+    }
+)
+
+DEFAULT_LOCKFILE = "oci-images.lock.yaml"
+
+
+class OciPlatform(BaseModel):
+    """Platform selector for multi-arch image indexes."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    os: str = "linux"
+    architecture: str
+
+    def matches(self, manifest_platform: dict[str, str]) -> bool:
+        """Check whether this selector matches a platform entry from an image index."""
+        return (
+            manifest_platform.get("os") == self.os
+            and manifest_platform.get("architecture") == self.architecture
+        )
+
+
+class OciImage(BaseModel):
+    """A single OCI image entry in the lockfile."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    digest: str
+    media_type: str = "application/vnd.oci.image.manifest.v1+json"
+    platform: OciPlatform | None = None
+    tag: str | None = None
+    auth: LockfileArtifactAuth | None = None
+
+    @field_validator("digest")
+    @classmethod
+    def _validate_digest(cls, value: str) -> str:
+        if not DIGEST_PATTERN.match(value):
+            raise ValueError(
+                f"Digest must be in the format 'sha256:<64 hex chars>' (got '{value}')"
+            )
+        return value
+
+    @field_validator("media_type")
+    @classmethod
+    def _validate_media_type(cls, value: str) -> str:
+        if value not in OCI_MEDIA_TYPES:
+            raise ValueError(
+                f"Unsupported media type '{value}'. "
+                f"Supported types: {', '.join(sorted(OCI_MEDIA_TYPES))}"
+            )
+        return value
+
+    @property
+    def registry(self) -> str:
+        """Extract the canonical registry host from the repository."""
+        parts = self.repository.split("/", 1)
+        if len(parts) == 1:
+            return "docker.io"
+        first = parts[0]
+        if "." in first or ":" in first or first == "localhost":
+            return first
+        return "docker.io"
+
+    @property
+    def api_host(self) -> str:
+        """Return the actual API hostname for HTTP requests."""
+        registry = self.registry
+        if registry == "docker.io":
+            return "registry-1.docker.io"
+        return registry
+
+    @property
+    def repo_path(self) -> str:
+        """Extract the repository path (without registry) from the repository."""
+        parts = self.repository.split("/", 1)
+        if len(parts) == 1:
+            return f"library/{parts[0]}"
+        first = parts[0]
+        if "." in first or ":" in first or first == "localhost":
+            return parts[1]
+        return self.repository
+
+    @property
+    def digest_hex(self) -> str:
+        """Return just the hex portion of the digest."""
+        return self.digest.split(":", 1)[1]
+
+    @property
+    def sanitized_name(self) -> str:
+        """Return a filesystem-safe name derived from the repository and digest."""
+        repo_part = self.repository.replace("/", "_").replace(":", "_")
+        return f"{repo_part}_{self.digest_hex[:12]}"
+
+
+class OciLockfileMetadata(BaseModel):
+    """Metadata section of the OCI lockfile."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    version: Literal["1.0"]
+
+
+class OciLockfile(BaseModel):
+    """The top-level OCI images lockfile."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    metadata: OciLockfileMetadata
+    images: list[OciImage]
+
+    @field_validator("images")
+    @classmethod
+    def _validate_images_non_empty(cls, value: list[OciImage]) -> list[OciImage]:
+        if not value:
+            raise ValueError("At least one image must be declared in the lockfile")
+        return value
+
+    @model_validator(mode="after")
+    def _validate_no_duplicate_digests(self) -> "OciLockfile":
+        seen: set[str] = set()
+        for image in self.images:
+            key = f"{image.repository}@{image.digest}"
+            if key in seen:
+                raise ValueError(f"Duplicate image entry: {key}")
+            seen.add(key)
+        return self
+
+    @classmethod
+    def from_file(cls, path: Path) -> "OciLockfile":
+        """Parse an OCI lockfile from the given path."""
+        if not path.is_file():
+            if path.exists():
+                raise InvalidLockfileFormat(
+                    path,
+                    f"expected a file but found a {path.stat().st_mode & 0o170000:#o} entry. "
+                    "Please provide a readable YAML lockfile.",
+                )
+            raise LockfileNotFound(
+                path,
+                solution=(
+                    "Please provide an OCI images lockfile. "
+                    "See the documentation for the expected format."
+                ),
+            )
+
+        try:
+            with path.open() as f:
+                data = yaml.safe_load(f)
+        except (yaml.YAMLError, OSError) as e:
+            raise InvalidLockfileFormat(path, str(e)) from e
+
+        if not isinstance(data, dict):
+            raise InvalidLockfileFormat(
+                path,
+                "expected a YAML mapping at the top level",
+            )
+
+        try:
+            return cls.model_validate(data)
+        except Exception as e:
+            raise InvalidLockfileFormat(path, str(e)) from e

--- a/hermeto/core/package_managers/oci/oci_client.py
+++ b/hermeto/core/package_managers/oci/oci_client.py
@@ -1,0 +1,391 @@
+# SPDX-License-Identifier: GPL-3.0-only
+import asyncio
+import hashlib
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+import aiohttp_retry
+
+from hermeto.core.config import get_config
+from hermeto.core.errors import FetchError
+from hermeto.core.package_managers.oci.models import OciImage, OciPlatform
+
+log = logging.getLogger(__name__)
+
+BACKOFF_FACTOR = 1.3
+STATUS_FORCELIST = (429, 500, 502, 503, 504)
+
+INDEX_MEDIA_TYPES = frozenset(
+    {
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+    }
+)
+
+MANIFEST_MEDIA_TYPES = frozenset(
+    {
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    }
+)
+
+ACCEPT_HEADER = ", ".join(sorted(INDEX_MEDIA_TYPES | MANIFEST_MEDIA_TYPES))
+
+
+def _scheme_for(registry: str) -> str:
+    """Return 'http' for localhost registries, 'https' otherwise."""
+    if registry == "localhost" or registry.startswith("localhost:"):
+        return "http"
+    return "https"
+
+
+class _TokenExpiredError(FetchError):
+    """A registry returned 401, indicating the cached token may have expired."""
+
+
+class OciRegistryClient:
+    """HTTP client for the OCI Distribution API."""
+
+    def __init__(self, session: aiohttp_retry.RetryClient) -> None:
+        """Initialize the client with an aiohttp retry session."""
+        self._session = session
+        self._tokens: dict[str, str] = {}
+        self._auth_locks: dict[str, asyncio.Lock] = {}
+
+    async def _authenticate(
+        self,
+        registry: str,
+        repo_path: str,
+        auth_headers: dict[str, str] | None,
+        *,
+        force: bool = False,
+    ) -> str | None:
+        """Obtain a bearer token via the Docker token auth flow.
+
+        Returns the token string, or None if the registry does not require auth.
+        """
+        cache_key = f"{registry}/{repo_path}"
+        if not force and cache_key in self._tokens:
+            return self._tokens[cache_key]
+
+        if cache_key not in self._auth_locks:
+            self._auth_locks[cache_key] = asyncio.Lock()
+
+        async with self._auth_locks[cache_key]:
+            if not force and cache_key in self._tokens:
+                return self._tokens[cache_key]
+
+            scheme = _scheme_for(registry)
+
+            ping_url = f"{scheme}://{registry}/v2/"
+            async with self._session.get(ping_url) as resp:
+                if resp.status == 200:
+                    return None
+                if resp.status != 401:
+                    raise FetchError(
+                        f"Unexpected status {resp.status} from {ping_url}. "
+                        "Verify the registry URL is correct."
+                    )
+                www_auth = resp.headers.get("WWW-Authenticate", "")
+
+            realm, service, scope = parse_www_authenticate(www_auth, repo_path)
+
+            params: dict[str, str] = {}
+            if service:
+                params["service"] = service
+            params["scope"] = scope
+
+            headers: dict[str, str] = {}
+            if auth_headers:
+                headers.update(auth_headers)
+
+            async with self._session.get(realm, params=params, headers=headers) as resp:
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise FetchError(
+                        f"Failed to authenticate with {registry} for {repo_path}: "
+                        f"HTTP {resp.status}: {body}. "
+                        "Verify your registry credentials are correct."
+                    )
+                data = await resp.json()
+
+            token = data.get("token") or data.get("access_token")
+            if not token:
+                raise FetchError(
+                    f"Token endpoint at {realm} did not return a token. "
+                    "This may indicate an unsupported registry authentication flow."
+                )
+
+            self._tokens[cache_key] = token
+            return token
+
+    async def fetch_manifest(
+        self,
+        image: OciImage,
+    ) -> tuple[bytes, dict[str, Any]]:
+        """Fetch and verify a manifest from a registry.
+
+        Returns (raw_bytes, parsed_json).
+        """
+        auth_headers = image.auth.get_headers() if image.auth else None
+
+        scheme = _scheme_for(image.api_host)
+
+        url = f"{scheme}://{image.api_host}/v2/{image.repo_path}/manifests/{image.digest}"
+
+        for attempt in range(2):
+            token = await self._authenticate(
+                image.api_host, image.repo_path, auth_headers, force=(attempt > 0)
+            )
+            headers: dict[str, str] = {"Accept": ACCEPT_HEADER}
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+
+            async with self._session.get(url, headers=headers) as resp:
+                if resp.status == 401 and attempt == 0 and token is not None:
+                    continue
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise FetchError(
+                        f"Failed to fetch manifest for {image.repository}@{image.digest}: "
+                        f"HTTP {resp.status}: {body}. "
+                        "Verify the digest exists in the registry and that you have pull access."
+                    )
+                manifest_bytes = await resp.read()
+            break
+
+        actual_digest = f"sha256:{hashlib.sha256(manifest_bytes).hexdigest()}"
+        if actual_digest != image.digest:
+            raise FetchError(
+                f"Manifest digest mismatch for {image.repository}: "
+                f"expected {image.digest}, got {actual_digest}. "
+                "The registry may have returned unexpected content."
+            )
+
+        manifest = json.loads(manifest_bytes)
+        return manifest_bytes, manifest
+
+    async def resolve_manifest(
+        self,
+        image: OciImage,
+    ) -> tuple[bytes, dict[str, Any], str, str]:
+        """Fetch a manifest and resolve image indexes to a platform-specific manifest.
+
+        Returns (manifest_bytes, manifest_json, resolved_digest, resolved_media_type).
+        For direct manifests, resolved values equal the image's own digest and media_type.
+        """
+        manifest_bytes, manifest = await self.fetch_manifest(image)
+
+        if image.media_type not in INDEX_MEDIA_TYPES:
+            return manifest_bytes, manifest, image.digest, image.media_type
+
+        if not image.platform:
+            raise FetchError(
+                f"Image {image.repository}@{image.digest} is a multi-arch image index, "
+                "but no 'platform' was specified in the lockfile. "
+                "Please add a platform selector (e.g. platform: {os: linux, architecture: amd64})."
+            )
+
+        platform_digest, platform_media_type = select_platform(
+            manifest, image.platform, image.repository
+        )
+
+        platform_image = OciImage(
+            repository=image.repository,
+            digest=platform_digest,
+            media_type=platform_media_type,
+            auth=image.auth,
+        )
+        platform_bytes, platform_manifest = await self.fetch_manifest(platform_image)
+        return platform_bytes, platform_manifest, platform_digest, platform_media_type
+
+    async def download_blobs(
+        self,
+        image: OciImage,
+        manifest: dict[str, Any],
+        output_dir: Path,
+        sem: asyncio.Semaphore,
+    ) -> None:
+        """Download all blobs (config + layers) for a manifest to the output directory."""
+        descriptors = extract_blob_descriptors(manifest)
+        auth_headers = image.auth.get_headers() if image.auth else None
+
+        scheme = _scheme_for(image.api_host)
+
+        for attempt in range(2):
+            token = await self._authenticate(
+                image.api_host, image.repo_path, auth_headers, force=(attempt > 0)
+            )
+
+            downloads: dict[str, tuple[Path, str]] = {}
+            headers_map: dict[str, dict[str, str]] = {}
+
+            for desc in descriptors:
+                digest = desc["digest"]
+                algorithm, hex_digest = digest.split(":", 1)
+                blobs_dir = output_dir / "blobs" / algorithm
+                blobs_dir.mkdir(parents=True, exist_ok=True)
+                blob_path = blobs_dir / hex_digest
+
+                if blob_path.exists():
+                    continue
+
+                url = f"{scheme}://{image.api_host}/v2/{image.repo_path}/blobs/{digest}"
+                downloads[url] = (blob_path, digest)
+
+                if token:
+                    headers_map[url] = {"Authorization": f"Bearer {token}"}
+
+            if not downloads:
+                return
+
+            try:
+                await _download_and_verify_blobs(self._session, downloads, headers_map, sem)
+                break
+            except _TokenExpiredError:
+                if attempt > 0:
+                    raise
+
+
+async def _download_and_verify_blobs(
+    session: aiohttp_retry.RetryClient,
+    downloads: dict[str, tuple[Path, str]],
+    headers_map: dict[str, dict[str, str]],
+    sem: asyncio.Semaphore,
+) -> None:
+    """Download blobs concurrently and verify their checksums."""
+
+    async def _download_one(url: str, path: Path, expected_digest: str) -> None:
+        async with sem:
+            headers = headers_map.get(url, {})
+            async with session.get(url, headers=headers) as resp:
+                if resp.status == 401:
+                    raise _TokenExpiredError(f"Token expired while downloading blob {url}")
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise FetchError(
+                        f"Failed to download blob {url}: HTTP {resp.status}: {body}. "
+                        "Check registry connectivity and rate limits."
+                    )
+
+                algorithm = expected_digest.split(":", 1)[0]
+                hasher = hashlib.new(algorithm)
+                tmp_path = path.with_suffix(".tmp")
+                with tmp_path.open("wb") as f:
+                    async for chunk in resp.content.iter_chunked(65536):
+                        f.write(chunk)
+                        hasher.update(chunk)
+
+            actual = f"{algorithm}:{hasher.hexdigest()}"
+            if actual != expected_digest:
+                tmp_path.unlink(missing_ok=True)
+                raise FetchError(
+                    f"Blob checksum mismatch: expected {expected_digest}, got {actual}"
+                )
+
+            tmp_path.rename(path)
+
+    async_tasks = [
+        asyncio.create_task(_download_one(url, path, digest))
+        for url, (path, digest) in downloads.items()
+    ]
+    try:
+        await asyncio.gather(*async_tasks)
+    except BaseException:
+        for task in async_tasks:
+            task.cancel()
+        await asyncio.gather(*async_tasks, return_exceptions=True)
+        for path, _ in downloads.values():
+            path.with_suffix(".tmp").unlink(missing_ok=True)
+        raise
+
+
+def parse_www_authenticate(header: str, repo_path: str) -> tuple[str, str, str]:
+    """Parse a WWW-Authenticate Bearer challenge header.
+
+    Returns (realm, service, scope).
+    """
+    if not header.lower().startswith("bearer "):
+        raise FetchError(
+            f"Unsupported WWW-Authenticate scheme: '{header}'. "
+            "Only Bearer authentication is supported."
+        )
+
+    params_str = header[len("bearer ") :]
+    params: dict[str, str] = {}
+    for match in re.finditer(r'(\w+)="([^"]*)"', params_str):
+        params[match.group(1)] = match.group(2)
+
+    realm = params.get("realm", "")
+    if not realm:
+        raise FetchError("Registry WWW-Authenticate header is missing the 'realm' parameter.")
+
+    service = params.get("service", "")
+    scope = params.get("scope", f"repository:{repo_path}:pull")
+
+    return realm, service, scope
+
+
+def select_platform(
+    index: dict[str, Any],
+    platform: OciPlatform,
+    repository: str,
+) -> tuple[str, str]:
+    """Select a platform-specific manifest from an image index.
+
+    Returns (digest, mediaType).
+    """
+    manifests = index.get("manifests", [])
+
+    for entry in manifests:
+        entry_platform = entry.get("platform", {})
+        if platform.matches(entry_platform):
+            return entry["digest"], entry["mediaType"]
+
+    available = [
+        f"{m.get('platform', {}).get('os', '?')}/{m.get('platform', {}).get('architecture', '?')}"
+        for m in manifests
+    ]
+    raise FetchError(
+        f"No manifest found for platform {platform.os}/{platform.architecture} "
+        f"in image index {repository}. "
+        f"Available platforms: {', '.join(available)}"
+    )
+
+
+def extract_blob_descriptors(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract all blob descriptors (config + layers) from a manifest."""
+    descriptors: list[dict[str, Any]] = []
+
+    config = manifest.get("config")
+    if config:
+        descriptors.append(config)
+
+    for layer in manifest.get("layers", []):
+        descriptors.append(layer)
+
+    return descriptors
+
+
+def create_retry_client() -> aiohttp_retry.RetryClient:
+    """Create an aiohttp retry client with standard hermeto settings."""
+    max_retries = get_config().http.max_retries + 1
+    retry_options = aiohttp_retry.JitterRetry(
+        start_timeout=BACKOFF_FACTOR,
+        attempts=max_retries,
+        statuses=set(STATUS_FORCELIST),
+        exceptions={
+            aiohttp.ClientConnectionError,
+            aiohttp.ClientPayloadError,
+        },
+    )
+
+    return aiohttp_retry.RetryClient(
+        retry_options=retry_options,
+        trust_env=True,
+        requote_redirect_url=False,
+    )

--- a/hermeto/core/resolver.py
+++ b/hermeto/core/resolver.py
@@ -13,6 +13,7 @@ from hermeto.core.package_managers import (
     generic,
     gomod,
     maven,
+    oci,
     rpm,
 )
 from hermeto.core.package_managers.javascript import metayarn, npm, pnpm
@@ -27,6 +28,7 @@ _package_managers: dict[PackageManagerType, Handler] = {
     "cargo": cargo.fetch_cargo_source,
     "gomod": gomod.fetch_gomod_source,
     "x-maven": maven.fetch_maven_source,
+    "x-oci": oci.fetch_oci_source,
     "npm": npm.fetch_npm_source,
     "pip": pip.fetch_pip_source,
     "pnpm": pnpm.fetch_pnpm_source,

--- a/tests/unit/package_managers/oci/__init__.py
+++ b/tests/unit/package_managers/oci/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: GPL-3.0-only

--- a/tests/unit/package_managers/oci/test_models.py
+++ b/tests/unit/package_managers/oci/test_models.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: GPL-3.0-only
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermeto.core.errors import InvalidLockfileFormat, LockfileNotFound
+from hermeto.core.package_managers.oci.models import OciImage, OciLockfile, OciPlatform
+
+VALID_DIGEST = "sha256:" + "a" * 64
+
+
+def _write_lockfile(tmp_path: Path, data: dict) -> Path:
+    lockfile_path = tmp_path / "oci-images.lock.yaml"
+    lockfile_path.write_text(yaml.dump(data))
+    return lockfile_path
+
+
+def _minimal_lockfile_data(**overrides: object) -> dict:
+    image = {
+        "repository": "docker.io/library/alpine",
+        "digest": VALID_DIGEST,
+        "media_type": "application/vnd.oci.image.manifest.v1+json",
+    }
+    image.update(overrides)
+    return {
+        "metadata": {"version": "1.0"},
+        "images": [image],
+    }
+
+
+class TestOciLockfileParsing:
+    def test_minimal_valid_lockfile(self, tmp_path: Path) -> None:
+        path = _write_lockfile(tmp_path, _minimal_lockfile_data())
+        lockfile = OciLockfile.from_file(path)
+
+        assert len(lockfile.images) == 1
+        assert lockfile.images[0].repository == "docker.io/library/alpine"
+        assert lockfile.images[0].digest == VALID_DIGEST
+
+    def test_lockfile_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(LockfileNotFound):
+            OciLockfile.from_file(tmp_path / "nonexistent.yaml")
+
+    def test_invalid_yaml(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.yaml"
+        path.write_text(": : : invalid yaml [[[")
+        with pytest.raises(InvalidLockfileFormat):
+            OciLockfile.from_file(path)
+
+    def test_not_a_mapping(self, tmp_path: Path) -> None:
+        path = tmp_path / "list.yaml"
+        path.write_text("- item1\n- item2\n")
+        with pytest.raises(InvalidLockfileFormat, match="expected a YAML mapping"):
+            OciLockfile.from_file(path)
+
+    def test_missing_metadata(self, tmp_path: Path) -> None:
+        data = {"images": []}
+        path = _write_lockfile(tmp_path, data)
+        with pytest.raises(InvalidLockfileFormat):
+            OciLockfile.from_file(path)
+
+    def test_wrong_metadata_version(self, tmp_path: Path) -> None:
+        data = _minimal_lockfile_data()
+        data["metadata"]["version"] = "2.0"
+        path = _write_lockfile(tmp_path, data)
+        with pytest.raises(InvalidLockfileFormat):
+            OciLockfile.from_file(path)
+
+    def test_empty_images_rejected(self, tmp_path: Path) -> None:
+        data = {"metadata": {"version": "1.0"}, "images": []}
+        path = _write_lockfile(tmp_path, data)
+        with pytest.raises(InvalidLockfileFormat, match="At least one image"):
+            OciLockfile.from_file(path)
+
+    def test_full_lockfile_with_all_fields(self, tmp_path: Path) -> None:
+        data = _minimal_lockfile_data(
+            tag="3.19",
+            platform={"os": "linux", "architecture": "arm64"},
+        )
+        path = _write_lockfile(tmp_path, data)
+        lockfile = OciLockfile.from_file(path)
+
+        image = lockfile.images[0]
+        assert image.tag == "3.19"
+        assert image.platform is not None
+        assert image.platform.os == "linux"
+        assert image.platform.architecture == "arm64"
+
+    def test_multiple_images(self, tmp_path: Path) -> None:
+        digest2 = "sha256:" + "b" * 64
+        data = {
+            "metadata": {"version": "1.0"},
+            "images": [
+                {
+                    "repository": "docker.io/library/alpine",
+                    "digest": VALID_DIGEST,
+                    "media_type": "application/vnd.oci.image.manifest.v1+json",
+                },
+                {
+                    "repository": "ghcr.io/org/tool",
+                    "digest": digest2,
+                    "media_type": "application/vnd.docker.distribution.manifest.v2+json",
+                },
+            ],
+        }
+        path = _write_lockfile(tmp_path, data)
+        lockfile = OciLockfile.from_file(path)
+        assert len(lockfile.images) == 2
+
+    def test_duplicate_images_rejected(self, tmp_path: Path) -> None:
+        data = {
+            "metadata": {"version": "1.0"},
+            "images": [
+                {
+                    "repository": "docker.io/library/alpine",
+                    "digest": VALID_DIGEST,
+                    "media_type": "application/vnd.oci.image.manifest.v1+json",
+                },
+                {
+                    "repository": "docker.io/library/alpine",
+                    "digest": VALID_DIGEST,
+                    "media_type": "application/vnd.oci.image.manifest.v1+json",
+                },
+            ],
+        }
+        path = _write_lockfile(tmp_path, data)
+        with pytest.raises(InvalidLockfileFormat, match="Duplicate image entry"):
+            OciLockfile.from_file(path)
+
+    def test_extra_fields_rejected(self, tmp_path: Path) -> None:
+        data = _minimal_lockfile_data()
+        data["images"][0]["unexpected_field"] = "value"
+        path = _write_lockfile(tmp_path, data)
+        with pytest.raises(InvalidLockfileFormat):
+            OciLockfile.from_file(path)
+
+
+class TestOciImageDigestValidation:
+    def test_valid_sha256_digest(self) -> None:
+        image = OciImage(
+            repository="docker.io/library/alpine",
+            digest=VALID_DIGEST,
+        )
+        assert image.digest == VALID_DIGEST
+
+    def test_invalid_digest_format(self) -> None:
+        with pytest.raises(ValueError, match="sha256:<64 hex chars>"):
+            OciImage(repository="r", digest="sha256:tooshort")
+
+    def test_invalid_digest_algorithm(self) -> None:
+        with pytest.raises(ValueError, match="sha256:<64 hex chars>"):
+            OciImage(repository="r", digest="md5:" + "a" * 32)
+
+    def test_invalid_digest_no_colon(self) -> None:
+        with pytest.raises(ValueError, match="sha256:<64 hex chars>"):
+            OciImage(repository="r", digest="a" * 64)
+
+
+class TestOciImageMediaTypeValidation:
+    def test_oci_manifest(self) -> None:
+        image = OciImage(
+            repository="r",
+            digest=VALID_DIGEST,
+            media_type="application/vnd.oci.image.manifest.v1+json",
+        )
+        assert image.media_type == "application/vnd.oci.image.manifest.v1+json"
+
+    def test_docker_v2_manifest(self) -> None:
+        image = OciImage(
+            repository="r",
+            digest=VALID_DIGEST,
+            media_type="application/vnd.docker.distribution.manifest.v2+json",
+        )
+        assert image.media_type == "application/vnd.docker.distribution.manifest.v2+json"
+
+    def test_oci_index(self) -> None:
+        image = OciImage(
+            repository="r",
+            digest=VALID_DIGEST,
+            media_type="application/vnd.oci.image.index.v1+json",
+        )
+        assert image.media_type == "application/vnd.oci.image.index.v1+json"
+
+    def test_unsupported_media_type(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported media type"):
+            OciImage(
+                repository="r",
+                digest=VALID_DIGEST,
+                media_type="application/octet-stream",
+            )
+
+
+class TestOciImageRegistryParsing:
+    @pytest.mark.parametrize(
+        ("repository", "expected_registry", "expected_repo_path"),
+        [
+            ("docker.io/library/alpine", "docker.io", "library/alpine"),
+            ("registry.redhat.io/rhel9/rhel-bootc", "registry.redhat.io", "rhel9/rhel-bootc"),
+            ("ghcr.io/org/repo", "ghcr.io", "org/repo"),
+            ("localhost:5000/myimage", "localhost:5000", "myimage"),
+            ("localhost/myimage", "localhost", "myimage"),
+            ("alpine", "docker.io", "library/alpine"),
+            ("myorg/myimage", "docker.io", "myorg/myimage"),
+            ("my.registry.com:8080/ns/image", "my.registry.com:8080", "ns/image"),
+        ],
+    )
+    def test_registry_and_repo_path(
+        self, repository: str, expected_registry: str, expected_repo_path: str
+    ) -> None:
+        image = OciImage(repository=repository, digest=VALID_DIGEST)
+        assert image.registry == expected_registry
+        assert image.repo_path == expected_repo_path
+
+
+class TestOciImageProperties:
+    def test_digest_hex(self) -> None:
+        image = OciImage(repository="r", digest=VALID_DIGEST)
+        assert image.digest_hex == "a" * 64
+
+    def test_sanitized_name(self) -> None:
+        image = OciImage(
+            repository="registry.redhat.io/rhel9/rhel-bootc",
+            digest=VALID_DIGEST,
+        )
+        assert image.sanitized_name == f"registry.redhat.io_rhel9_rhel-bootc_{'a' * 12}"
+
+    def test_api_host_docker_io(self) -> None:
+        image = OciImage(repository="docker.io/library/alpine", digest=VALID_DIGEST)
+        assert image.registry == "docker.io"
+        assert image.api_host == "registry-1.docker.io"
+
+    def test_api_host_other_registry(self) -> None:
+        image = OciImage(repository="ghcr.io/org/repo", digest=VALID_DIGEST)
+        assert image.registry == "ghcr.io"
+        assert image.api_host == "ghcr.io"
+
+
+class TestOciPlatform:
+    def test_matches_exact(self) -> None:
+        platform = OciPlatform(os="linux", architecture="amd64")
+        assert platform.matches({"os": "linux", "architecture": "amd64"})
+
+    def test_no_match_different_arch(self) -> None:
+        platform = OciPlatform(os="linux", architecture="amd64")
+        assert not platform.matches({"os": "linux", "architecture": "arm64"})
+
+    def test_no_match_different_os(self) -> None:
+        platform = OciPlatform(os="linux", architecture="amd64")
+        assert not platform.matches({"os": "windows", "architecture": "amd64"})
+
+    def test_default_os_is_linux(self) -> None:
+        platform = OciPlatform(architecture="amd64")
+        assert platform.os == "linux"

--- a/tests/unit/package_managers/oci/test_oci_client.py
+++ b/tests/unit/package_managers/oci/test_oci_client.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: GPL-3.0-only
+import pytest
+
+from hermeto.core.errors import FetchError
+from hermeto.core.package_managers.oci.models import OciPlatform
+from hermeto.core.package_managers.oci.oci_client import (
+    extract_blob_descriptors,
+    parse_www_authenticate,
+    select_platform,
+)
+
+VALID_DIGEST = "sha256:" + "a" * 64
+
+
+class TestParseWwwAuthenticate:
+    def test_standard_bearer_challenge(self) -> None:
+        header = (
+            'Bearer realm="https://auth.docker.io/token",'
+            'service="registry.docker.io",'
+            'scope="repository:library/alpine:pull"'
+        )
+        realm, service, scope = parse_www_authenticate(header, "library/alpine")
+        assert realm == "https://auth.docker.io/token"
+        assert service == "registry.docker.io"
+        assert scope == "repository:library/alpine:pull"
+
+    def test_missing_scope_uses_default(self) -> None:
+        header = 'Bearer realm="https://auth.example.com/token",service="example.com"'
+        realm, _, scope = parse_www_authenticate(header, "org/repo")
+        assert realm == "https://auth.example.com/token"
+        assert scope == "repository:org/repo:pull"
+
+    def test_missing_service(self) -> None:
+        header = 'Bearer realm="https://auth.example.com/token"'
+        _, service, _ = parse_www_authenticate(header, "org/repo")
+        assert service == ""
+
+    def test_case_insensitive_bearer(self) -> None:
+        header = 'bearer realm="https://auth.example.com/token"'
+        realm, _, _ = parse_www_authenticate(header, "org/repo")
+        assert realm == "https://auth.example.com/token"
+
+    def test_unsupported_scheme_raises(self) -> None:
+        with pytest.raises(FetchError, match="Unsupported WWW-Authenticate"):
+            parse_www_authenticate('Basic realm="example"', "org/repo")
+
+    def test_missing_realm_raises(self) -> None:
+        with pytest.raises(FetchError, match="missing the 'realm'"):
+            parse_www_authenticate('Bearer service="foo"', "org/repo")
+
+
+class TestSelectPlatform:
+    def _make_index(self, platforms: list[dict[str, str]]) -> dict:
+        return {
+            "manifests": [
+                {
+                    "digest": f"sha256:{'0' * 63}{i}",
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "platform": p,
+                }
+                for i, p in enumerate(platforms)
+            ]
+        }
+
+    def test_selects_matching_platform(self) -> None:
+        index = self._make_index(
+            [
+                {"os": "linux", "architecture": "amd64"},
+                {"os": "linux", "architecture": "arm64"},
+            ]
+        )
+        platform = OciPlatform(os="linux", architecture="arm64")
+        digest, media_type = select_platform(index, platform, "test/repo")
+
+        assert digest == f"sha256:{'0' * 63}1"
+        assert media_type == "application/vnd.oci.image.manifest.v1+json"
+
+    def test_no_matching_platform_raises(self) -> None:
+        index = self._make_index(
+            [
+                {"os": "linux", "architecture": "amd64"},
+            ]
+        )
+        platform = OciPlatform(os="linux", architecture="s390x")
+
+        with pytest.raises(FetchError, match="No manifest found for platform"):
+            select_platform(index, platform, "test/repo")
+
+    def test_error_lists_available_platforms(self) -> None:
+        index = self._make_index(
+            [
+                {"os": "linux", "architecture": "amd64"},
+                {"os": "linux", "architecture": "arm64"},
+            ]
+        )
+        platform = OciPlatform(os="windows", architecture="amd64")
+
+        with pytest.raises(FetchError, match=r"linux/amd64.*linux/arm64"):
+            select_platform(index, platform, "test/repo")
+
+    def test_empty_manifests_raises(self) -> None:
+        index = {"manifests": []}
+        platform = OciPlatform(os="linux", architecture="amd64")
+
+        with pytest.raises(FetchError, match="No manifest found"):
+            select_platform(index, platform, "test/repo")
+
+
+class TestExtractBlobDescriptors:
+    def test_extracts_config_and_layers(self) -> None:
+        manifest = {
+            "config": {
+                "digest": "sha256:config",
+                "size": 100,
+                "mediaType": "application/vnd.oci.image.config.v1+json",
+            },
+            "layers": [
+                {
+                    "digest": "sha256:layer1",
+                    "size": 1000,
+                    "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                },
+                {
+                    "digest": "sha256:layer2",
+                    "size": 2000,
+                    "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+                },
+            ],
+        }
+        descriptors = extract_blob_descriptors(manifest)
+        assert len(descriptors) == 3
+        assert descriptors[0]["digest"] == "sha256:config"
+        assert descriptors[1]["digest"] == "sha256:layer1"
+        assert descriptors[2]["digest"] == "sha256:layer2"
+
+    def test_no_config(self) -> None:
+        manifest = {
+            "layers": [
+                {"digest": "sha256:layer1", "size": 1000},
+            ],
+        }
+        descriptors = extract_blob_descriptors(manifest)
+        assert len(descriptors) == 1
+
+    def test_no_layers(self) -> None:
+        manifest = {
+            "config": {"digest": "sha256:config", "size": 100},
+        }
+        descriptors = extract_blob_descriptors(manifest)
+        assert len(descriptors) == 1
+
+    def test_empty_manifest(self) -> None:
+        descriptors = extract_blob_descriptors({})
+        assert len(descriptors) == 0

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -475,7 +475,7 @@ class TestFetchDeps:
                 [
                     "Error: InvalidInput: 1 validation error for user input",
                     "packages -> 0",
-                    "Requested backend type 'idk' doesn't match expected ones: 'bundler', 'cargo', 'generic', 'gomod', 'npm', 'pip', 'pnpm', 'rpm', 'x-maven', 'yarn'",
+                    "Requested backend type 'idk' doesn't match expected ones: 'bundler', 'cargo', 'generic', 'gomod', 'npm', 'pip', 'pnpm', 'rpm', 'x-maven', 'x-oci', 'yarn'",
                 ],
                 ExitError.ERR_INVALID_INPUT,
             ),
@@ -484,7 +484,7 @@ class TestFetchDeps:
                 [
                     "Error: InvalidInput: 1 validation error for user input",
                     "packages -> 0",
-                    "Requested backend type 'idk' doesn't match expected ones: 'bundler', 'cargo', 'generic', 'gomod', 'npm', 'pip', 'pnpm', 'rpm', 'x-maven', 'yarn'",
+                    "Requested backend type 'idk' doesn't match expected ones: 'bundler', 'cargo', 'generic', 'gomod', 'npm', 'pip', 'pnpm', 'rpm', 'x-maven', 'x-oci', 'yarn'",
                 ],
                 ExitError.ERR_INVALID_INPUT,
             ),
@@ -493,7 +493,7 @@ class TestFetchDeps:
                 [
                     "Error: InvalidInput: 1 validation error for user input",
                     "packages -> 0",
-                    "Requested backend type 'idk' doesn't match expected ones: 'bundler', 'cargo', 'generic', 'gomod', 'npm', 'pip', 'pnpm', 'rpm', 'x-maven', 'yarn'",
+                    "Requested backend type 'idk' doesn't match expected ones: 'bundler', 'cargo', 'generic', 'gomod', 'npm', 'pip', 'pnpm', 'rpm', 'x-maven', 'x-oci', 'yarn'",
                 ],
                 ExitError.ERR_INVALID_INPUT,
             ),


### PR DESCRIPTION
## Summary

Add an experimental `x-oci` backend that prefetches OCI images from container registries, producing OCI Image Layout directories for hermetic builds. This lets build pipelines declare image dependencies in a lockfile (`oci-images.lock.yaml`) and have hermeto pull them before network access is blocked.

Tested end-to-end against Docker Hub (single-arch OCI manifest) and Quay.io (multi-arch Docker V2 manifest list), verified with `skopeo inspect`.

Resolves #1641

## Motivation

Some Konflux build pipelines need to consume pre-built container images as build inputs, not just as FROM stages. For example, bootc's CUDA build pulls a vLLM image and a model-optimizer image, bind-mounts their rootfs, and reconstructs them via `podman import --change`. This works, but loses the original image metadata (ENV, LABELS, CMD, ENTRYPOINT) because Konflux's `prePullBaseImages()` only makes the filesystem layers available through FROM stages, not the full OCI config.

With this backend, builds can declare those image dependencies in a lockfile and have hermeto prefetch them as complete OCI Image Layouts, preserving all metadata. The build can then consume them with `skopeo copy oci:...` or `podman load` instead of reconstructing images from raw rootfs directories.

## What's included

- **Design document** (`docs/design/oci.md`): covers OCI Distribution Spec, lockfile format, fetch procedure, OCI Image Layout output, SBOM representation
- **Lockfile models** (`oci/models.py`): `OciLockfile`, `OciImage`, `OciPlatform` with digest/media-type validation, Docker Hub shorthand expansion, duplicate detection, non-empty images check
- **OCI Distribution HTTP client** (`oci/oci_client.py`): Docker token auth with per-key locking and cache, manifest fetch with digest verification, image index resolution, concurrent blob downloads with atomic writes and cleanup on failure, token refresh on 401
- **Backend wiring** (`oci/main.py`): `fetch_oci_source()` entry point, concurrent image fetching via `asyncio.gather`, OCI Image Layout output, `pkg:oci` PURL generation
- **49 unit tests** across models and client helpers

## Lockfile format

```yaml
metadata:
  version: "1.0"
images:
  - repository: registry.redhat.io/rhel9/rhel-bootc
    digest: sha256:7c4e86de0c80e1c773e1a4e2dae5a6c2c42049e5e2f3d8fc7eeb38adcb0c711a
    media_type: application/vnd.oci.image.manifest.v1+json
    tag: "9.4"
  - repository: ghcr.io/org/my-artifact
    digest: sha256:deadbeef...
    media_type: application/vnd.oci.image.index.v1+json
    platform:
      os: linux
      architecture: amd64
```

## Output

```
deps/x-oci/<sanitized-repo>/
  oci-layout
  index.json
  blobs/sha256/...
```

Consumable via `skopeo copy oci:...`, `podman load`, or `buildah from oci:...`.

## Test plan

- [x] `ruff check` and `ruff format` pass on all changed files
- [x] 49 unit tests pass (models, client helpers)
- [x] E2E: fetch `docker.io/library/alpine:3.21` (single-arch OCI manifest)
- [x] E2E: fetch `quay.io/prometheus/node-exporter:v1.9.1` (multi-arch Docker V2 manifest list)
- [x] E2E: multi-image lockfile with both registries fetched concurrently
- [x] `skopeo inspect oci:...` validates all produced layouts
- [x] SBOM contains correct `pkg:oci` PURLs with canonical `repository_url`
- [ ] CI passes
