### PR TITLE
.github: dependabot: Exclude test directory from Dependabot scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,50 @@ updates:
     schedule:
       interval: "weekly"
 
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    exclude-paths:
+      - "tests/**"
+    ignore:
+      - dependency-name: "*"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    exclude-paths:
+      - "tests/**"
+    ignore:
+      - dependency-name: "*"
+
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    exclude-paths:
+      - "tests/**"
+    ignore:
+      - dependency-name: "*"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    exclude-paths:
+      - "tests/**"
+    ignore:
+      - dependency-name: "*"
+
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "monthly"
     commit-message:
       prefix: "Dockerfile"
+    exclude-paths:
+      - "tests/**"
     ignore:
       # We must handle major.minor Go releases manually due to direct feature support
       - dependency-name: "library/golang"
@@ -34,6 +72,8 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    exclude-paths:
+      - "tests/**"
     ignore:
       - dependency-name: "pydantic-core"
       - dependency-name: "createrepo-c"


### PR DESCRIPTION
Integration test data contains manifests for npm, cargo, bundler, gomod, docker, and pip ecosystems. Dependabot auto-detects these apparently and opens unwanted version/security update PRs for test fixtures [1].

Add exclude-paths for tests/** to all ecosystem entries. For ecosystems missing from our current dependabot config - add entries.

Unfortunately for us, dependabot can neither suppress security updates [2], nor does it seem to support the `exclude-paths` on the global level to be inherited by all ecosystems [3].

[1] https://github.com/hermetoproject/hermeto/pull/1683
[2] https://github.com/dependabot/dependabot-core/issues/14408
[3] https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#exclude-paths-